### PR TITLE
Enhancement: Add International Fixed chronology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,17 +3,15 @@
 /lib/
 /dist/
 /test-output/
+/temp*
 /.settings/
 /nbproject/private/
 /target/
 .classpath
 .project
 .checkstyle
-# IDEA meta files
-/.idea/
-/*.iml
-/*.ipr
-/*.iws
-# diff by-products
-*.rej
-*.orig
+*.class
+*.jar
+*.war
+*.ear
+**TempTest.java

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /lib/
 /dist/
 /test-output/
-/temp*
 /.settings/
 /nbproject/private/
 /target/
@@ -14,4 +13,12 @@
 *.jar
 *.war
 *.ear
-**TempTest.java
+[tT]emp*
+# IIDEA meta files
+/.idea/
+/*.iml
+/*.ipr
+/*.iws
+# diff by-products
+*.rej
+*.orig

--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,7 @@
 .classpath
 .project
 .checkstyle
-*.class
-*.jar
-*.war
-*.ear
-[tT]emp*
-# IIDEA meta files
+# IDEA meta files
 /.idea/
 /*.iml
 /*.ipr

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
@@ -83,7 +83,7 @@ public class InternationalFixedChronology extends AbstractChronology implements 
     /**
      * Range of year.
      */
-    private static final ValueRange YEAR_RANGE = ValueRange.of (0, 999_999);
+    private static final ValueRange YEAR_RANGE = ValueRange.of (1, 999_999);
 
     /**
      * Range of proleptic month.
@@ -233,7 +233,7 @@ public class InternationalFixedChronology extends AbstractChronology implements 
             throw new ClassCastException ("Era must be InternationalFixedEra");
         }
 
-        if (0 > yearOfEra) {
+        if (1 > yearOfEra) {
             throw new DateTimeException ("Year of era MUST not be negative!");
         }
 

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
@@ -46,9 +46,9 @@ public class InternationalFixedChronology extends AbstractChronology implements 
     public static final InternationalFixedChronology INSTANCE = new InternationalFixedChronology ();
 
     /**
-     * Serialization version.
+     * Serialization version UID.
      */
-    //private static final long serialVersionUID = -7021464635577802085L;
+    private static final long serialVersionUID = -199871091397669007L;
 
     /**
      * Standard 7-day week.

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
@@ -1,0 +1,431 @@
+package org.threeten.extra.chrono;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.chrono.*;
+import java.time.temporal.*;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The International Fixed calendar system.
+ * <p>
+ * This chronology defines the rules of the International Fixed calendar system.
+ * It shares the leap year rule with the Gregorian calendar.
+ * Dates are aligned such that {@code 0-13-28 (International Fixed)} is {@code 0000-12-30 (ISO)}.
+ * <p>
+ * This class is not proleptic. It implements only year starting from year 0 onwards.
+ * <p>
+ * This class implements a calendar where January 1st is the start of the year.
+ * <p>
+ * The fields are defined as follows:
+ * <ul>
+ * <li>era - There is only one era, the current 'Common Era' (CE).
+ * <li>year-of-era - The year-of-era for the current era increases uniformly from the epoch at year zero.
+ * <li>proleptic-year - The proleptic year is the same as the year-of-era for the current era.
+ * <li>month-of-year - There are 13 months in an International Fixed year, numbered from 1 to 13.
+ * <li>day-of-month - There are 28 or 29 days in an International Fixed month, numbered from 1 to 28 / 29.
+ *  Month 6 may have 29 days - for leap day.
+ *  Month 13 has 29 days - for year day.
+ *  All other months have 28 days.
+ * <li>day-of-year - There are 365 days in a standard International Fixed year and 366 days in a leap year.
+ *  The days are numbered from 1 to 365 / 366 accordingly.
+ * <li>leap-year - Leap years occur every 4 years, but skips 3 out of four centuries, i.e. when the century is not divisible by 400.
+ *  This is the same rule in use for the Gregorian calendar.
+ * </ul>
+ *
+ * <h3>Implementation Requirements</h3>
+ * This class is immutable and thread-safe.
+ */
+public class InternationalFixedChronology extends AbstractChronology implements Serializable {
+    /**
+     * Singleton instance for the International fixed chronology.
+     */
+    public static final InternationalFixedChronology INSTANCE = new InternationalFixedChronology ();
+
+    /**
+     * Serialization version.
+     */
+    //private static final long serialVersionUID = -7021464635577802085L;
+
+    /**
+     * Standard 7-day week.
+     */
+    private static final int DAYS_IN_WEEK = 7;
+
+    /**
+     * In all months, there are 4 complete weeks.
+     */
+    static final int WEEKS_IN_MONTH = 4;
+
+    /**
+     * There are 13 months in a (non-leap) year.
+     */
+    static final int MONTHS_IN_YEAR = 13;
+
+    /**
+     * There are 4 weeks of 7 days, or 28 total days in a month.
+     */
+    static final int DAYS_IN_MONTH = WEEKS_IN_MONTH * DAYS_IN_WEEK;
+
+    /**
+     * There are 13 months of 28 days, or 364 days in a (non-leap) year.
+     */
+    static final int DAYS_IN_YEAR = MONTHS_IN_YEAR * DAYS_IN_MONTH;
+
+    /**
+     * There are 52 weeks in a (non-leap) year.
+     */
+    static final int WEEKS_IN_YEAR = DAYS_IN_YEAR / DAYS_IN_WEEK;
+
+    /**
+     * Range of year.
+     */
+    private static final ValueRange YEAR_RANGE = ValueRange.of (0, 999_999);
+
+    /**
+     * Range of proleptic month.
+     */
+    private static final ValueRange PROLEPTIC_MONTH_RANGE = ValueRange.of (0, 1_000_000 * 13L - 1);
+
+    /**
+     * Range of day of month.
+     */
+    static final ValueRange DAY_OF_MONTH_RANGE = ValueRange.of (1, DAYS_IN_MONTH, DAYS_IN_MONTH + 1);
+
+    /**
+     * Range of day of year.
+     */
+    static final ValueRange DAY_OF_YEAR_RANGE = ValueRange.of (1, DAYS_IN_YEAR, DAYS_IN_YEAR + 1);
+
+    /**
+     * Range of month of year.
+     */
+    static final ValueRange MONTH_OF_YEAR_RANGE = ValueRange.of (1, MONTHS_IN_YEAR);
+
+    /**
+     * The number of days in a 400 year cycle.
+     */
+    private static final int DAYS_PER_CYCLE = 146097;
+
+    /**
+     * The number of days from year zero to year 1970.
+     * There are five 400 year cycles from year zero to 2000.
+     * There are 7 leap years from 1970 to 2000.
+     */
+    static final long DAYS_0000_TO_1970 = (DAYS_PER_CYCLE * 5L) - (30L * 365L + 7L);
+
+    /**
+     * Private constructor, that is public to satisfy the {@code ServiceLoader}.
+     * Use the singleton {@link #INSTANCE} instead.
+     */
+    public InternationalFixedChronology () {
+    }
+
+    /**
+     * Creates the chronology era object from the numeric value.
+     * <p>
+     * The era is, conceptually, the largest division of the time-line.
+     * Most calendar systems have a single epoch dividing the time-line into two eras.
+     * However, some have multiple eras, such as one for the reign of each leader.
+     * The exact meaning is determined by the chronology according to the following constraints.
+     * <p>
+     * The era in use at 1970-01-01 must have the value 1.
+     * Later eras must have sequentially higher values.
+     * Earlier eras must have sequentially lower values.
+     * Each chronology must refer to an enum or similar singleton to provide the era values.
+     * <p>
+     * This method returns the singleton era of the correct type for the specified era value.
+     *
+     * @param eraValue the era value
+     * @return the calendar system era, not null
+     * @throws DateTimeException if unable to create the era
+     */
+    @Override
+    public Era eraOf (final int eraValue) {
+        return InternationalFixedEra.of (eraValue);
+    }
+
+    /**
+     * Gets the list of eras for the chronology.
+     * <p>
+     * Most calendar systems have an era, within which the year has meaning.
+     * If the calendar system does not support the concept of eras, an empty
+     * list must be returned.
+     *
+     * @return the list of eras for the chronology, may be immutable, not null
+     */
+    @Override
+    public List<Era> eras () {
+        return Arrays.<Era> asList (InternationalFixedEra.values ());
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Gets the ID of the chronology - 'Ifc'.
+     * <p>
+     * The ID uniquely identifies the {@code Chronology}.
+     * It can be used to lookup the {@code Chronology} using {@link #of(String)}.
+     *
+     * @return the chronology ID - 'Ifc'
+     * @see #getCalendarType()
+     */
+    @Override
+    public String getId () {
+        return "Ifc";
+    }
+
+    /**
+     * Gets the calendar type of the underlying calendar system - 'ifc'.
+     * <p>
+     * The <em>Unicode Locale Data Markup Language (LDML)</em> specification
+     * does not define an identifier for the Pax calendar, but were it to
+     * do so, 'pax' is highly likely to be chosen.
+     *
+     * @return the calendar system type - 'ifc'
+     * @see #getId()
+     */
+    @Override
+    public String getCalendarType () {
+        return "ifc";
+    }
+
+    /**
+     * Checks if the specified year is a leap year.
+     * <p>
+     * A leap-year is a year of a longer length than normal.
+     * The exact meaning is determined by the chronology according to the following constraints.
+     * <ul>
+     * <li>a leap-year must imply a year-length longer than a non leap-year.
+     * <li>a chronology that does not support the concept of a year must return false.
+     * </ul>
+     *
+     * @param year the proleptic-year to check, not validated for range
+     * @return true if the year is a leap year
+     */
+    @Override
+    public boolean isLeapYear (final long year) {
+        return ((year & 3) == 0) && ((year % 100) != 0 || (year % 400) == 0);
+    }
+
+    /**
+     * Calculates the proleptic-year given the era and year-of-era.
+     * <p>
+     * The International Fixed calendar only knows common era years, thus negative years are invalid.
+     * <p>
+     * If the chronology makes active use of eras, such as {@code JapaneseChronology}
+     * then the year-of-era will be validated against the era.
+     * For other chronologies, validation is optional.
+     *
+     * @param era       the era of the correct type for the chronology, not null
+     * @param yearOfEra the chronology year-of-era
+     * @return the proleptic-year
+     * @throws DateTimeException  if unable to convert to a proleptic-year,
+     *                            such as if the year is invalid for the era
+     * @throws ClassCastException if the {@code era} is not of the correct type for the chronology
+     */
+    @Override
+    public int prolepticYear (final Era era, final int yearOfEra) {
+        if (!(era instanceof InternationalFixedEra)) {
+            throw new ClassCastException ("Era must be InternationalFixedEra");
+        }
+
+        if (0 > yearOfEra) {
+            throw new DateTimeException ("Year of era MUST not be negative!");
+        }
+
+        return yearOfEra;
+    }
+
+    /**
+     * Gets the range of valid values for the specified field.
+     * <p>
+     * All fields can be expressed as a {@code long} integer.
+     * This method returns an object that describes the valid range for that value.
+     * <p>
+     * Note that the result only describes the minimum and maximum valid values
+     * and it is important not to read too much into them. For example, there
+     * could be values within the range that are invalid for the field.
+     * <p>
+     * This method will return a result whether or not the chronology supports the field.
+     *
+     * @param field the field to get the range for, not null
+     * @return the range of valid values for the field, not null
+     * @throws DateTimeException if the range for the field cannot be obtained
+     */
+    @Override
+    public ValueRange range (final ChronoField field) {
+        switch (field) {
+            case PROLEPTIC_MONTH:
+                return PROLEPTIC_MONTH_RANGE;
+            case YEAR_OF_ERA:
+                return YEAR_RANGE;
+            case YEAR:
+                return YEAR_RANGE;
+            case DAY_OF_MONTH:
+                return DAY_OF_MONTH_RANGE;
+            case DAY_OF_YEAR:
+                return DAY_OF_YEAR_RANGE;
+            case MONTH_OF_YEAR:
+                return MONTH_OF_YEAR_RANGE;
+            default:
+                return field.range ();
+        }
+    }
+
+    /**
+     * Resolve singleton.
+     *
+     * @return the singleton instance, not null
+     */
+    @SuppressWarnings ("static-method")
+    private Object readResolve () {
+        return INSTANCE;
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Obtains a local date in Julian calendar system from the
+     * era, year-of-era, month-of-year and day-of-month fields.
+     *
+     * @param era        the Julian era, not null
+     * @param yearOfEra  the year-of-era
+     * @param month      the month-of-year
+     * @param dayOfMonth the day-of-month
+     * @return the Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     * @throws ClassCastException if the {@code era} is not a {@code JulianEra}
+     */
+    @Override
+    public InternationalFixedDate date (final Era era, final int yearOfEra, final int month, final int dayOfMonth) {
+        return date (prolepticYear (era, yearOfEra), month, dayOfMonth);
+    }
+
+    /**
+     * Obtains a local date in Julian calendar system from the
+     * proleptic-year, month-of-year and day-of-month fields.
+     *
+     * @param prolepticYear the proleptic-year
+     * @param month         the month-of-year
+     * @param dayOfMonth    the day-of-month
+     * @return the Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override
+    public InternationalFixedDate date (final int prolepticYear, final int month, final int dayOfMonth) {
+        return InternationalFixedDate.of (prolepticYear, month, dayOfMonth);
+    }
+
+    /**
+     * Obtains a local date in Julian calendar system from the
+     * era, year-of-era and day-of-year fields.
+     *
+     * @param era       the Julian era, not null
+     * @param yearOfEra the year-of-era
+     * @param dayOfYear the day-of-year
+     * @return the Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     * @throws ClassCastException if the {@code era} is not a {@code JulianEra}
+     */
+    @Override
+    public InternationalFixedDate dateYearDay (final Era era, final int yearOfEra, final int dayOfYear) {
+        return dateYearDay (prolepticYear (era, yearOfEra), dayOfYear);
+    }
+
+    /**
+     * Obtains a local date in Julian calendar system from the
+     * proleptic-year and day-of-year fields.
+     *
+     * @param prolepticYear the proleptic-year
+     * @param dayOfYear     the day-of-year
+     * @return the Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override
+    public InternationalFixedDate dateYearDay (final int prolepticYear, final int dayOfYear) {
+        return InternationalFixedDate.ofYearDay (prolepticYear, dayOfYear);
+    }
+
+    /**
+     * Obtains a local date in the Julian calendar system from the epoch-day.
+     *
+     * @param epochDay the epoch day
+     * @return the Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public InternationalFixedDate dateEpochDay (final long epochDay) {
+        return InternationalFixedDate.ofEpochDay (epochDay);
+    }
+
+    //-------------------------------------------------------------------------
+
+    /**
+     * Obtains the current Julian local date from the system clock in the default time-zone.
+     * <p>
+     * This will query the {@link Clock#systemDefaultZone() system clock} in the default
+     * time-zone to obtain the current date.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @return the current Julian local date using the system clock and default time-zone, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public InternationalFixedDate dateNow () {
+        return InternationalFixedDate.now ();
+    }
+
+    /**
+     * Obtains the current Julian local date from the system clock in the specified time-zone.
+     * <p>
+     * This will query the {@link Clock#system(ZoneId) system clock} to obtain the current date.
+     * Specifying the time-zone avoids dependence on the default time-zone.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @param zone the zone ID to use, not null
+     * @return the current Julian local date using the system clock, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public InternationalFixedDate dateNow (final ZoneId zone) {
+        return InternationalFixedDate.now (zone);
+    }
+
+    /**
+     * Obtains the current Julian local date from the specified clock.
+     * <p>
+     * This will query the specified clock to obtain the current date - today.
+     * Using this method allows the use of an alternate clock for testing.
+     * The alternate clock may be introduced using {@link Clock dependency injection}.
+     *
+     * @param clock the clock to use, not null
+     * @return the current Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override  // override with covariant return type
+    public InternationalFixedDate dateNow (final Clock clock) {
+        return InternationalFixedDate.now (clock);
+    }
+
+    //-------------------------------------------------------------------------
+
+    /**
+     * Obtains a Julian local date from another date-time object.
+     *
+     * @param temporal the date-time object to convert, not null
+     * @return the Julian local date, not null
+     * @throws DateTimeException if unable to create the date
+     */
+    @Override
+    public InternationalFixedDate date (final TemporalAccessor temporal) {
+        return InternationalFixedDate.from (temporal);
+    }
+}

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -1,0 +1,640 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra.chrono;
+
+import java.io.Serializable;
+import java.time.*;
+import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.ChronoLocalDateTime;
+import java.time.chrono.ChronoPeriod;
+import java.time.temporal.*;
+
+import static java.time.temporal.ChronoField.*;
+//import static org.threeten.extra.chrono.InternationalFixedChronology.*;
+
+/**
+ * A date in the International fixed calendar system.
+ * <p>
+ * Implements a pure International Fixed calendar (also known as the Cotsworth plan, the Eastman plan,
+ * the 13 Month calendar or the Equal Month calendar) a solar calendar proposal for calendar reform designed by
+ * Moses B. Cotsworth, who presented it in 1902.</p>
+ * <p>
+ * It provides for a year of 13 months of 28 days each, with one or two days a year belonging to no month or week.
+ * It is therefore a perennial calendar, with every date fixed always on the same weekday.
+ * Though it was never officially adopted in any country, it was the official calendar of the Eastman Kodak Company
+ * from 1928 to 1989.</p>
+ * <p>
+ * This date operates using the {@linkplain InternationalFixedChronology International fixed calendar}.
+ * This calendar system is a proposed reform calendar system, and is not in common use.
+ * The International fixed differs from the Gregorian in terms of month count and length, and the leap year rule.
+ * Dates are aligned such that {@code 0001-01-01 (International fixed)} is {@code 0000-12-31 (ISO)}.</p>
+ * <p>
+ * More information is available in the <a href='https://en.wikipedia.org/wiki/International_Fixed_Calendar'>International fixed Calendar</a> Wikipedia article.</p>
+ * <p>
+ * <h3>Implementation Requirements</h3>
+ * This class is immutable and thread-safe.
+ * <p>
+ * This class must be treated as a value type. Do not synchronize, rely on the
+ * identity hash code or use the distinction between equals() and ==.</p>
+ */
+public final class InternationalFixedDate
+        extends AbstractDate
+        implements ChronoLocalDate, Serializable {
+
+    /**
+     * Serialization version.
+     */
+    private static final long serialVersionUID = -2229133057743750072L;
+
+    /**
+     * The days per 400 year cycle.
+     */
+    private static final int DAYS_PER_CYCLE = 146097;
+
+    /**
+     * Number of years in a decade.
+     */
+    private static final int YEARS_IN_DECADE = 10;
+
+    /**
+     * Number of years in a century.
+     */
+    private static final int YEARS_IN_CENTURY = 100;
+
+    /**
+     * Number of years in a millennium.
+     */
+    private static final int YEARS_IN_MILLENNIUM = 1000;
+
+    /**
+     * The proleptic year.
+     */
+    private final int prolepticYear;
+
+    /**
+     * The month.
+     */
+    private final short month;
+
+    /**
+     * The day.
+     */
+    private final short day;
+
+    /**
+     * In a leap year, is it the day between June 28th and Sol 1st ?
+     */
+    private final boolean isLeapDay;
+
+    /**
+     * Is is the last day of the year ?
+     */
+    private final boolean isYearDay;
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Creates an instance from validated data.
+     *
+     * @param prolepticYear the International fixed proleptic-year
+     * @param month         the International fixed month, from 1 to 13
+     * @param dayOfMonth    the International fixed day-of-month, from 1 to 28, the 29th is only legal for leap day and year day
+     */
+    private InternationalFixedDate (final int prolepticYear, final int month, final int dayOfMonth) {
+        YEAR.checkValidValue (prolepticYear);
+        InternationalFixedChronology.MONTH_OF_YEAR_RANGE.checkValidValue (month, MONTH_OF_YEAR);
+        InternationalFixedChronology.DAY_OF_MONTH_RANGE.checkValidValue (dayOfMonth, DAY_OF_MONTH);
+
+        if (0 > prolepticYear) {
+            throw new DateTimeException ("Invalid date, year must be positive: " + prolepticYear + '-' + month + '-' + dayOfMonth);
+        }
+
+        if (dayOfMonth > 28 && month != 6 && month != 13) {
+            throw new DateTimeException ("Invalid date: " + prolepticYear + '-' + month + '-' + dayOfMonth);
+        }
+
+        this.prolepticYear = prolepticYear;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
+        this.isLeapDay = dayOfMonth == 29 && month == 6;
+        this.isYearDay = dayOfMonth == 29 && month == 13;
+
+        if (this.isLeapDay && !isLeapYear ()) {
+            throw new DateTimeException ("Invalid leap date: " + prolepticYear + '-' + month + '-' + dayOfMonth);
+        }
+    }
+
+    /**
+     * Obtains the current {@code InternationalFixedDate} from the system clock in the default time-zone.
+     * <p>
+     * This will query the {@link Clock#systemDefaultZone() system clock} in the default
+     * time-zone to obtain the current date.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @return the current date using the system clock and default time-zone, not null
+     */
+    public static InternationalFixedDate now () {
+        return now (Clock.systemDefaultZone ());
+    }
+
+    /**
+     * Obtains the current {@code InternationalFixedDate} from the system clock in the specified time-zone.
+     * <p>
+     * This will query the {@link Clock#system(ZoneId) system clock} to obtain the current date.
+     * Specifying the time-zone avoids dependence on the default time-zone.
+     * <p>
+     * Using this method will prevent the ability to use an alternate clock for testing
+     * because the clock is hard-coded.
+     *
+     * @param zone the zone ID to use, not null
+     * @return the current date using the system clock, not null
+     */
+    public static InternationalFixedDate now (final ZoneId zone) {
+        return now (Clock.system (zone));
+    }
+
+    /**
+     * Obtains the current {@code InternationalFixedDate} from the specified clock.
+     * <p>
+     * This will query the specified clock to obtain the current date - today.
+     * Using this method allows the use of an alternate clock for testing.
+     * The alternate clock may be introduced using {@linkplain Clock dependency injection}.
+     *
+     * @param clock the clock to use, not null
+     * @return the current date, not null
+     * @throws DateTimeException if the current date cannot be obtained
+     */
+    public static InternationalFixedDate now (final Clock clock) {
+        LocalDate now = LocalDate.now (clock);
+
+        return InternationalFixedDate.ofEpochDay (now.toEpochDay ());
+    }
+
+    /**
+     * Obtains a {@code InternationalFixedDate} representing a date in the International fixed calendar
+     * system from the proleptic-year, month-of-year and day-of-month fields.
+     * <p>
+     * This returns a {@code InternationalFixedDate} with the specified fields.
+     * The day must be valid for the year and month, otherwise an exception will be thrown.
+     *
+     * @param prolepticYear the International fixed proleptic-year
+     * @param month         the International fixed month-of-year, from 1 to 13
+     * @param dayOfMonth    the International fixed day-of-month, from 1 to 28
+     * @return the date in International fixed calendar system, not null
+     * @throws DateTimeException if the value of any field is out of range,
+     *                           or if the day-of-month is invalid for the month-year
+     */
+    public static InternationalFixedDate of (final int prolepticYear, final int month, final int dayOfMonth) {
+        return new InternationalFixedDate (prolepticYear, month, dayOfMonth);
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Obtains a {@code InternationalFixedDate} from a temporal object.
+     * <p>
+     * This obtains a date in the International fixed calendar system based on the specified temporal.
+     * A {@code TemporalAccessor} represents an arbitrary set of date and time information,
+     * which this factory converts to an instance of {@code InternationalFixedDate}.
+     * <p>
+     * The conversion typically uses the {@link ChronoField#EPOCH_DAY EPOCH_DAY}
+     * field, which is standardized across calendar systems.
+     * <p>
+     * This method matches the signature of the functional interface {@link TemporalQuery}
+     * allowing it to be used as a query via method reference, {@code InternationalFixedDate::from}.
+     *
+     * @param temporal the temporal object to convert, not null
+     * @return the date in the International fixed calendar system, not null
+     * @throws DateTimeException if unable to convert to a {@code InternationalFixedDate}
+     */
+    public static InternationalFixedDate from (final TemporalAccessor temporal) {
+        if (temporal instanceof InternationalFixedDate) {
+            return (InternationalFixedDate) temporal;
+        }
+
+        return InternationalFixedDate.ofEpochDay (temporal.getLong (EPOCH_DAY));
+    }
+
+    /**
+     * Obtains a {@code InternationalFixedDate} representing a date in the International fixed calendar
+     * system from the proleptic-year and day-of-year fields.
+     * <p>
+     * This returns a {@code InternationalFixedDate} with the specified fields.
+     * The day must be valid for the year, otherwise an exception will be thrown.
+     *
+     * @param prolepticYear the International fixed proleptic-year
+     * @param dayOfYear     the International fixed day-of-year, from 1 to 371
+     * @return the date in International fixed calendar system, not null
+     * @throws DateTimeException if the value of any field is out of range,
+     *                           or if the day-of-year is invalid for the year
+     */
+    static InternationalFixedDate ofYearDay (final int prolepticYear, final int dayOfYear) {
+        YEAR.checkValidValue (prolepticYear);
+        InternationalFixedChronology.DAY_OF_YEAR_RANGE.checkValidValue (dayOfYear, DAY_OF_YEAR);
+        boolean leap = InternationalFixedChronology.INSTANCE.isLeapYear (prolepticYear);
+
+        if (dayOfYear > (InternationalFixedChronology.DAYS_IN_YEAR + 1) && !leap) {
+            throw new DateTimeException ("Invalid date 'DayOfYear " + dayOfYear + "' as '" + prolepticYear + "' is not a leap year");
+        }
+
+        int month = ((dayOfYear - 1) / InternationalFixedChronology.DAYS_IN_MONTH) + 1;
+
+        // In leap years, the leap-month is shorter than the following month, so needs to be adjusted.
+        if (leap && month == InternationalFixedChronology.MONTHS_IN_YEAR && dayOfYear >= InternationalFixedChronology.DAYS_IN_YEAR - InternationalFixedChronology.DAYS_IN_MONTH + 1) {
+            month++;
+        }
+
+        // Subtract days-at-start-of-month from days in year
+        int dayOfMonth = dayOfYear - (month - 1) * InternationalFixedChronology.DAYS_IN_MONTH;
+
+        // Adjust for shorter inserted leap-month.
+        if (month == InternationalFixedChronology.MONTHS_IN_YEAR + 1) {
+            dayOfMonth += InternationalFixedChronology.DAYS_IN_MONTH;
+        }
+
+        return of (prolepticYear, month, dayOfMonth);
+    }
+
+    /**
+     * Obtains a {@code InternationalFixedDate} representing a date in the International fixed calendar
+     * system from the epoch-day.
+     *
+     * @param epochDay the epoch day to convert based on 1970-01-01 (ISO)
+     * @return the date in International fixed calendar system, not null
+     * @throws DateTimeException if the epoch-day is out of range
+     */
+    public static InternationalFixedDate ofEpochDay (final long epochDay) {
+        EPOCH_DAY.range ().checkValidValue (epochDay, EPOCH_DAY);
+        long zeroDay = epochDay + InternationalFixedChronology.DAYS_0000_TO_1970;
+
+        if (zeroDay < 0) {
+            throw new DateTimeException ("Negative epoch invalid: " + epochDay);
+        }
+
+        long yearEst = (400 * zeroDay) / DAYS_PER_CYCLE;
+        long doyEst = zeroDay - (365 * yearEst + yearEst / 4 - yearEst / 100 + yearEst / 400);
+        int month = 1 + (int) ((doyEst - 1 ) / 28);
+        int dom = 1 + (int) ((doyEst - 1) % 28);
+
+        if (month == 14) {
+            month = 13;
+            dom += 28;
+        }
+
+        // check year now we are certain it is correct
+        int year = YEAR.checkValidIntValue (yearEst);
+
+        return new InternationalFixedDate (year, month, dom);
+    }
+
+    private static InternationalFixedDate resolvePreviousValid (final int prolepticYear, final int month, final int day) {
+        int monthR = Math.min (month, InternationalFixedChronology.MONTHS_IN_YEAR);
+        int dayR = Math.min (day, InternationalFixedChronology.DAYS_IN_MONTH + (month == 6 || month == 13 ? 1 : 0));
+
+        return InternationalFixedDate.of (prolepticYear, monthR, dayR);
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Get the count of leap years since International fixed year 0.
+     * <p>
+     * This number is negative if the year is prior to International fixed year 0.
+     *
+     * @param prolepticYear The year.
+     * @return The number of leap years since International fixed year 0.
+     */
+    private static long getLeapYearsBefore (final long prolepticYear) {
+        return (prolepticYear / 4) - (prolepticYear / 100) + (prolepticYear / 400);
+    }
+
+    /**
+     * Validates the object.
+     *
+     * @return the resolved date, not null
+     */
+    private Object readResolve () {
+        return InternationalFixedDate.of (prolepticYear, month, day);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    int getProlepticYear () {
+        return prolepticYear;
+    }
+
+    @Override
+    int getMonth () {
+        return month;
+    }
+
+    @Override
+    int getDayOfMonth () {
+        return day;
+    }
+
+    @Override
+    int getDayOfYear () {
+        return (month - 1) * InternationalFixedChronology.DAYS_IN_MONTH + getDayOfMonth ();
+    }
+
+    @Override
+    AbstractDate withDayOfYear (final int value) {
+        return plusDays (value - getDayOfYear ());
+    }
+
+    @Override
+    int lengthOfYearInMonths () {
+        return InternationalFixedChronology.MONTHS_IN_YEAR;
+    }
+
+    @Override
+    ValueRange rangeAlignedWeekOfMonth () {
+        return ValueRange.of (1, InternationalFixedChronology.WEEKS_IN_MONTH);
+    }
+
+    @Override
+    InternationalFixedDate resolvePrevious (final int newYear, final int newMonth, final int dayOfMonth) {
+        return resolvePreviousValid (newYear, newMonth, dayOfMonth);
+    }
+
+    @Override
+    public ValueRange range (final TemporalField field) {
+        if (field == ChronoField.ALIGNED_WEEK_OF_YEAR) {
+            return ValueRange.of (1, InternationalFixedChronology.WEEKS_IN_YEAR);
+        } else if (field == ChronoField.MONTH_OF_YEAR) {
+            return ValueRange.of (1, InternationalFixedChronology.MONTHS_IN_YEAR);
+        }
+
+        return super.range (field);
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Gets the chronology of this date, which is the International fixed calendar system.
+     * <p>
+     * The {@code Chronology} represents the calendar system in use.
+     * The era and other fields in {@link ChronoField} are defined by the chronology.
+     *
+     * @return the International fixed chronology, not null
+     */
+    @Override
+    public InternationalFixedChronology getChronology () {
+        return InternationalFixedChronology.INSTANCE;
+    }
+
+    /**
+     * Gets the era applicable at this date.
+     * <p>
+     * The International fixed calendar system only has one era, 'CE',
+     * defined by {@link InternationalFixedEra}.
+     *
+     * @return the era applicable at this date, not null
+     */
+    @Override
+    public InternationalFixedEra getEra () {
+        return InternationalFixedEra.CE;
+    }
+
+    /**
+     * Returns the length of the month represented by this date.
+     * <p>
+     * This returns the length of the month in days.
+     * Month lengths do not match those of the ISO calendar system.
+     *
+     * @return the length of the month in days, 28 or 29
+     */
+    @Override
+    public int lengthOfMonth () {
+        return InternationalFixedChronology.DAYS_IN_MONTH + ((this.month == 6 && this.isLeapYear ()) || this.month == 13 || this.isLeapDay || this.isYearDay ? 1 : 0);
+    }
+
+    @Override
+    public int lengthOfYear () {
+        return InternationalFixedChronology.DAYS_IN_YEAR + (isLeapYear () ? 1 : 0);
+    }
+
+    //-------------------------------------------------------------------------
+    @Override
+    public InternationalFixedDate with (final TemporalAdjuster adjuster) {
+        return (InternationalFixedDate) adjuster.adjustInto (this);
+    }
+
+    @Override
+    public InternationalFixedDate with (final TemporalField field, final long newValue) {
+        // Evaluate years as a special case, to deal with inserted leap months.
+        if (field == ChronoField.YEAR) {
+            return plusYears (Math.subtractExact (newValue, getProlepticYear ()));
+        }
+
+        return (InternationalFixedDate) super.with (field, newValue);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public InternationalFixedDate plus (final TemporalAmount amount) {
+        return (InternationalFixedDate) amount.addTo (this);
+    }
+
+    @Override
+    public InternationalFixedDate plus (final long amountToAdd, final TemporalUnit unit) {
+        return (InternationalFixedDate) super.plus (amountToAdd, unit);
+    }
+
+    /**
+     * Returns a copy of this {@code InternationalFixedDate} with the specified period in years added.
+     * <p>
+     * This method adds the specified amount to the years field in two steps:
+     * <ol>
+     * <li>Add the input years to the year field</li>
+     * <li>If necessary, shift the index to account for the inserted/deleted leap-month.</li>
+     * </ol>
+     * <p>
+     * In the International fixed Calendar, the month of December is 13 in non-leap-years, and 14 in leap years.
+     * Shifting the index of the month thus means the month would still be the same.
+     * <p>
+     * In the case of moving from the inserted leap-month (destination year is non-leap), the month index is retained.
+     * This has the effect of retaining the same day-of-year.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param yearsToAdd the years to add, may be negative
+     * @return a {@code InternationalFixedDate} based on this date with the years added, not null
+     * @throws DateTimeException if the result exceeds the supported date range
+     */
+    @Override
+    InternationalFixedDate plusYears (final long yearsToAdd) {
+        if (yearsToAdd == 0) {
+            return this;
+        }
+
+        int newYear = YEAR.checkValidIntValue (getProlepticYear () + yearsToAdd);
+
+        // Otherwise, one of the following is true:
+        // 1 - Before the leap month, nothing to do (most common)
+        // 2 - Both source and destination in leap-month, nothing to do
+        // 3 - Both source and destination after leap month in leap year, nothing to do
+        // 4 - Source in leap month, but destination year not leap. Retain month index, preserving day-of-year.
+        // 5 - Source after leap month, but destination year not leap. Move month index back.
+        return resolvePreviousValid (newYear, month, day);
+    }
+
+    /**
+     * Returns a copy of this {@code InternationalFixedDate} with the specified period in months added.
+     * <p>
+     * This method adds the specified amount to the months field in three steps:
+     * <ol>
+     * <li>Add the input months to the month-of-year field</li>
+     * <li>Check if the resulting date would be invalid</li>
+     * <li>Adjust the day-of-month to the last valid day if necessary</li>
+     * </ol>
+     * <p>
+     * For example, 2006-12-13 plus one month would result in the invalid date 2006-13-13.
+     * Instead of returning an invalid result, the last valid day of the month, 2006-13-07, is selected instead.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param monthsToAdd the months to add, may be negative
+     * @return a {@code InternationalFixedDate} based on this date with the months added, not null
+     * @throws DateTimeException if the result exceeds the supported date range
+     */
+    @Override
+    InternationalFixedDate plusMonths (final long monthsToAdd) {
+        if (monthsToAdd == 0) {
+            return this;
+        }
+
+        long calcMonths = Math.addExact (getProlepticMonth (), monthsToAdd);
+        int newYear = YEAR.checkValidIntValue (Math.floorDiv (calcMonths, InternationalFixedChronology.MONTHS_IN_YEAR));
+        int newMonth = Math.toIntExact (calcMonths % InternationalFixedChronology.MONTHS_IN_YEAR) + 1;
+
+        return resolvePreviousValid (newYear, newMonth, getDayOfMonth ());
+    }
+
+    @Override
+    public InternationalFixedDate minus (final TemporalAmount amount) {
+        return (InternationalFixedDate) amount.subtractFrom (this);
+    }
+
+    @Override
+    public InternationalFixedDate minus (final long amountToSubtract, final TemporalUnit unit) {
+        return (amountToSubtract == Long.MIN_VALUE ? plus (Long.MAX_VALUE, unit).plus (1, unit) : plus (-amountToSubtract, unit));
+    }
+
+    //-------------------------------------------------------------------------
+    @Override  // for covariant return type
+    @SuppressWarnings ("unchecked")
+    public ChronoLocalDateTime<InternationalFixedDate> atTime (final LocalTime localTime) {
+        return (ChronoLocalDateTime<InternationalFixedDate>) ChronoLocalDate.super.atTime (localTime);
+    }
+
+    @Override
+    public long until (final Temporal endExclusive, final TemporalUnit unit) {
+        return until (InternationalFixedDate.from (endExclusive), unit);
+    }
+
+    @Override
+    long until (final AbstractDate end, final TemporalUnit unit) {
+        if (unit instanceof ChronoUnit) {
+            InternationalFixedDate ifxEnd = InternationalFixedDate.from (end);
+            switch ((ChronoUnit) unit) {
+                case YEARS:
+                    return yearsUntil (ifxEnd);
+                case DECADES:
+                    return yearsUntil (ifxEnd) / YEARS_IN_DECADE;
+                case CENTURIES:
+                    return yearsUntil (ifxEnd) / YEARS_IN_CENTURY;
+                case MILLENNIA:
+                    return yearsUntil (ifxEnd) / YEARS_IN_MILLENNIUM;
+                default:
+                    break;
+            }
+        }
+
+        return super.until (end, unit);
+    }
+
+    /**
+     * Get the number of years from this date to the given day.
+     *
+     * @param end The end date.
+     * @return The number of years from this date to the given day.
+     */
+    long yearsUntil (final InternationalFixedDate end) {
+        // If either date is after the inserted leap month, and the other year isn't leap, simulate the effect of the inserted month.
+        long startYear = getProlepticYear () * 512L + getDayOfYear ();
+        long endYear = end.getProlepticYear () * 512L + end.getDayOfYear ();
+
+        return (endYear - startYear) / 512L;
+    }
+
+    @Override
+    public ChronoPeriod until (final ChronoLocalDate endDateExclusive) {
+        InternationalFixedDate end = InternationalFixedDate.from (endDateExclusive);
+        int years = Math.toIntExact (yearsUntil (end));
+        // Get to the same "whole" year.
+        InternationalFixedDate sameYearEnd = end.plusYears (years);
+        int months = (int) monthsUntil (sameYearEnd);
+        int days = (int) daysUntil (sameYearEnd.plusMonths (months));
+
+        return getChronology ().period (years, months, days);
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public long toEpochDay () {
+        long epochDay = ((long) getProlepticYear ()) * (InternationalFixedChronology.DAYS_IN_YEAR + 1) + getLeapYearsBefore (getProlepticYear ()) + getDayOfYear ();
+
+        return epochDay - InternationalFixedChronology.DAYS_0000_TO_1970;
+    }
+
+    @Override
+    int getYearOfEra () {
+        return getProlepticYear ();
+    }
+
+    @Override
+    public String toString () {
+        StringBuilder buf = new StringBuilder (getChronology ().toString ());
+        buf.append (' ')
+           .append (getEra ())
+           .append (' ')
+           .append (getYearOfEra ())
+           .append (getMonth () < 10 ? "-0" : '-').append (getMonth ())
+           .append (getDayOfMonth () < 10 ? "-0" : '-').append (getDayOfMonth ());
+
+        return buf.toString ();
+    }
+}

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -71,9 +71,9 @@ public final class InternationalFixedDate
         implements ChronoLocalDate, Serializable {
 
     /**
-     * Serialization version.
+     * Serialization version UID.
      */
-    private static final long serialVersionUID = -2229133057743750072L;
+    private static final long serialVersionUID = -7473722012599657263L;
 
     /**
      * The days per 400 year cycle.

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -624,17 +624,4 @@ public final class InternationalFixedDate
     int getYearOfEra () {
         return getProlepticYear ();
     }
-
-    @Override
-    public String toString () {
-        StringBuilder buf = new StringBuilder (getChronology ().toString ());
-        buf.append (' ')
-           .append (getEra ())
-           .append (' ')
-           .append (getYearOfEra ())
-           .append (getMonth () < 10 ? "-0" : '-').append (getMonth ())
-           .append (getDayOfMonth () < 10 ? "-0" : '-').append (getDayOfMonth ());
-
-        return buf.toString ();
-    }
 }

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -38,9 +38,6 @@ import java.time.chrono.ChronoLocalDateTime;
 import java.time.chrono.ChronoPeriod;
 import java.time.temporal.*;
 
-import static java.time.temporal.ChronoField.*;
-//import static org.threeten.extra.chrono.InternationalFixedChronology.*;
-
 /**
  * A date in the International fixed calendar system.
  * <p>
@@ -130,12 +127,12 @@ public final class InternationalFixedDate
      * @param dayOfMonth    the International fixed day-of-month, from 1 to 28, the 29th is only legal for leap day and year day
      */
     private InternationalFixedDate (final int prolepticYear, final int month, final int dayOfMonth) {
-        YEAR.checkValidValue (prolepticYear);
-        InternationalFixedChronology.MONTH_OF_YEAR_RANGE.checkValidValue (month, MONTH_OF_YEAR);
-        InternationalFixedChronology.DAY_OF_MONTH_RANGE.checkValidValue (dayOfMonth, DAY_OF_MONTH);
+        ChronoField.YEAR.checkValidValue (prolepticYear);
+        InternationalFixedChronology.MONTH_OF_YEAR_RANGE.checkValidValue (month, ChronoField.MONTH_OF_YEAR);
+        InternationalFixedChronology.DAY_OF_MONTH_RANGE.checkValidValue (dayOfMonth, ChronoField.DAY_OF_MONTH);
 
-        if (0 > prolepticYear) {
-            throw new DateTimeException ("Invalid date, year must be positive: " + prolepticYear + '-' + month + '-' + dayOfMonth);
+        if (1 > prolepticYear) {
+            throw new DateTimeException ("Invalid date, year must be at least 1: " + prolepticYear + '-' + month + '-' + dayOfMonth);
         }
 
         if (dayOfMonth > 28 && month != 6 && month != 13) {
@@ -243,7 +240,7 @@ public final class InternationalFixedDate
             return (InternationalFixedDate) temporal;
         }
 
-        return InternationalFixedDate.ofEpochDay (temporal.getLong (EPOCH_DAY));
+        return InternationalFixedDate.ofEpochDay (temporal.getLong (ChronoField.EPOCH_DAY));
     }
 
     /**
@@ -260,8 +257,8 @@ public final class InternationalFixedDate
      *                           or if the day-of-year is invalid for the year
      */
     static InternationalFixedDate ofYearDay (final int prolepticYear, final int dayOfYear) {
-        YEAR.checkValidValue (prolepticYear);
-        InternationalFixedChronology.DAY_OF_YEAR_RANGE.checkValidValue (dayOfYear, DAY_OF_YEAR);
+        ChronoField.YEAR.checkValidValue (prolepticYear);
+        InternationalFixedChronology.DAY_OF_YEAR_RANGE.checkValidValue (dayOfYear, ChronoField.DAY_OF_YEAR);
         boolean leap = InternationalFixedChronology.INSTANCE.isLeapYear (prolepticYear);
 
         if (dayOfYear > (InternationalFixedChronology.DAYS_IN_YEAR + 1) && !leap) {
@@ -295,7 +292,7 @@ public final class InternationalFixedDate
      * @throws DateTimeException if the epoch-day is out of range
      */
     public static InternationalFixedDate ofEpochDay (final long epochDay) {
-        EPOCH_DAY.range ().checkValidValue (epochDay, EPOCH_DAY);
+        ChronoField.EPOCH_DAY.range ().checkValidValue (epochDay, ChronoField.EPOCH_DAY);
         long zeroDay = epochDay + InternationalFixedChronology.DAYS_0000_TO_1970;
 
         if (zeroDay < 0) {
@@ -313,7 +310,7 @@ public final class InternationalFixedDate
         }
 
         // check year now we are certain it is correct
-        int year = YEAR.checkValidIntValue (yearEst);
+        int year = ChronoField.YEAR.checkValidIntValue (yearEst);
 
         return new InternationalFixedDate (year, month, dom);
     }
@@ -500,7 +497,7 @@ public final class InternationalFixedDate
             return this;
         }
 
-        int newYear = YEAR.checkValidIntValue (getProlepticYear () + yearsToAdd);
+        int newYear = ChronoField.YEAR.checkValidIntValue (getProlepticYear () + yearsToAdd);
 
         // Otherwise, one of the following is true:
         // 1 - Before the leap month, nothing to do (most common)
@@ -537,7 +534,7 @@ public final class InternationalFixedDate
         }
 
         long calcMonths = Math.addExact (getProlepticMonth (), monthsToAdd);
-        int newYear = YEAR.checkValidIntValue (Math.floorDiv (calcMonths, InternationalFixedChronology.MONTHS_IN_YEAR));
+        int newYear = ChronoField.YEAR.checkValidIntValue (Math.floorDiv (calcMonths, InternationalFixedChronology.MONTHS_IN_YEAR));
         int newMonth = Math.toIntExact (calcMonths % InternationalFixedChronology.MONTHS_IN_YEAR) + 1;
 
         return resolvePreviousValid (newYear, newMonth, getDayOfMonth ());

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedEra.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedEra.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.threeten.extra.chrono;
+
+import java.time.DateTimeException;
+import java.time.chrono.Era;
+
+/**
+ * An era in the International Fixed calendar system.
+ * <p>
+ * The International Fixed calendar system only has one era.
+ * The current era, for years from 1 onwards, is known as 'Current Era'.
+ * All previous years are invalid.
+ * <p>
+ * The start of the International Fixed epoch {@code 0001-01-01 (Pax)} is {@code 0000-12-31 (ISO)}.
+ * <p>
+ * <b>Do not use {@code ordinal()} to obtain the numeric representation of {@code InternationalFixedEra}.
+ * Use {@code getValue()} instead.</b>
+ * <p>
+ * <h3>Implementation Requirements:</h3>
+ * This is an immutable and thread-safe enum.
+ */
+public enum InternationalFixedEra implements Era {
+    /**
+     * The singleton instance for the current era, 'Current Era',
+     * which has the numeric value 0.
+     */
+    CE;
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Obtains an instance of {@code PaxEra} from an {@code int} value.
+     * <p>
+     * {@code PaxEra} is an enum representing the International Fixed era of CE.
+     * This factory allows the enum to be obtained from the {@code int} value.
+     *
+     * @param era the CE value to represent, only 0 (CE)
+     * @return the era singleton, not null
+     * @throws DateTimeException if the value is invalid
+     */
+    public static InternationalFixedEra of (final int era) {
+        if (0 == era) {
+            return CE;
+        }
+
+        throw new DateTimeException ("Invalid era: " + era);
+    }
+
+    //-----------------------------------------------------------------------
+
+    /**
+     * Gets the numeric era {@code int} value.
+     * <p>
+     * The era CE has the value 0.
+     *
+     * @return the era value, only 0 (CE)
+     */
+    @Override
+    public int getValue () {
+        return ordinal ();
+    }
+}

--- a/src/main/resources/META-INF/services/java.time.chrono.Chronology
+++ b/src/main/resources/META-INF/services/java.time.chrono.Chronology
@@ -4,3 +4,4 @@ org.threeten.extra.chrono.EthiopicChronology
 org.threeten.extra.chrono.JulianChronology
 org.threeten.extra.chrono.PaxChronology
 org.threeten.extra.chrono.DiscordianChronology
+org.threeten.extra.chrono.InternationalFixedChronology

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -80,7 +80,7 @@ public class TestInternationalFixedChronology {
     @DataProvider (name = "samples")
     Object[][] data_samples () {
         return new Object[][] {
-                { InternationalFixedDate.of (0, 13, 29), LocalDate.of (0, 12, 31) },
+                { InternationalFixedDate.of (1, 13, 29), LocalDate.of (1, 12, 31) },
                 { InternationalFixedDate.of (1, 1, 1), LocalDate.of (1, 1, 1) },
                 { InternationalFixedDate.of (1, 1, 2), LocalDate.of (1, 1, 2) },
 
@@ -110,8 +110,8 @@ public class TestInternationalFixedChronology {
                 { InternationalFixedDate.of (401, 1, 1), LocalDate.of (401, 1, 1) },
                 { InternationalFixedDate.of (401, 1, 2), LocalDate.of (401, 1, 2) },
 
-                { InternationalFixedDate.of (0, 13, 28), LocalDate.of (0, 12, 30) },
-                { InternationalFixedDate.of (0, 13, 27), LocalDate.of (0, 12, 29) },
+                { InternationalFixedDate.of (1, 13, 28), LocalDate.of (1, 12, 30) },
+                { InternationalFixedDate.of (1, 13, 27), LocalDate.of (1, 12, 29) },
 
                 { InternationalFixedDate.of (1582, 9, 28), LocalDate.of (1582, 9, 9) },
                 { InternationalFixedDate.of (1582, 10, 1), LocalDate.of (1582, 9, 10) },
@@ -167,15 +167,11 @@ public class TestInternationalFixedChronology {
         assertEquals (LocalDate.from (date.plus (0, ChronoUnit.DAYS)), iso);
         assertEquals (LocalDate.from (date.plus (1, ChronoUnit.DAYS)), iso.plusDays (1));
         assertEquals (LocalDate.from (date.plus (35, ChronoUnit.DAYS)), iso.plusDays (35));
-        assertEquals (LocalDate.from (date.plus (-1, ChronoUnit.DAYS)), iso.plusDays (-1));
-        assertEquals (LocalDate.from (date.plus (-60, ChronoUnit.DAYS)), iso.plusDays (-60));
     }
 
     @Test (dataProvider = "samples")
     public void test_minusDays (final InternationalFixedDate date, final LocalDate iso) {
         assertEquals (LocalDate.from (date.minus (0, ChronoUnit.DAYS)), iso);
-        assertEquals (LocalDate.from (date.minus (1, ChronoUnit.DAYS)), iso.minusDays (1));
-        assertEquals (LocalDate.from (date.minus (35, ChronoUnit.DAYS)), iso.minusDays (35));
         assertEquals (LocalDate.from (date.minus (-1, ChronoUnit.DAYS)), iso.minusDays (-1));
         assertEquals (LocalDate.from (date.minus (-60, ChronoUnit.DAYS)), iso.minusDays (-60));
     }
@@ -185,14 +181,13 @@ public class TestInternationalFixedChronology {
         assertEquals (date.until (iso.plusDays (0), ChronoUnit.DAYS), 0);
         assertEquals (date.until (iso.plusDays (1), ChronoUnit.DAYS), 1);
         assertEquals (date.until (iso.plusDays (35), ChronoUnit.DAYS), 35);
-        assertEquals (date.until (iso.minusDays (40), ChronoUnit.DAYS), -40);
     }
 
     @DataProvider (name = "badDates")
     Object[][] data_badDates () {
         return new Object[][] {
+                {    0, 1, 1 },
                 { 1900, 0, 0 },
-
                 { 1900, -1, 1 },
                 { 1900, 0, 1 },
                 { 1900, 15, 1 },
@@ -254,7 +249,7 @@ public class TestInternationalFixedChronology {
             return ((year & 3) == 0) && ((year % 100) != 0 || (year % 400) == 0);
         };
 
-        for (int year = 0; year < 1000; year++) {
+        for (int year = 1; year < 1001; year++) {
             InternationalFixedDate base = InternationalFixedDate.of (year, 1, 1);
             assertEquals (base.isLeapYear (), isLeapYear.test (year), "Year " + year + " is failing");
             assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (year), isLeapYear.test (year), "Year " + year + " is failing");
@@ -273,7 +268,6 @@ public class TestInternationalFixedChronology {
         assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (3), false);
         assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (2), false);
         assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (1), false);
-        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (0), true);
     }
 
     @DataProvider (name = "lengthOfMonth")
@@ -315,7 +309,7 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_era_loop () {
-        for (int year = 0; year < 400; year++) {
+        for (int year = 1; year < 401; year++) {
             InternationalFixedDate base = InternationalFixedChronology.INSTANCE.date (year, 1, 1);
             assertEquals (year, base.get (ChronoField.YEAR));
             InternationalFixedEra era = InternationalFixedEra.CE;
@@ -328,7 +322,7 @@ public class TestInternationalFixedChronology {
 
     @Test
     public void test_era_yearDay_loop () {
-        for (int year = 0; year < 400; year++) {
+        for (int year = 1; year < 401; year++) {
             InternationalFixedDate base = InternationalFixedChronology.INSTANCE.dateYearDay (year, 1);
             assertEquals (year, base.get (ChronoField.YEAR));
             InternationalFixedEra era = InternationalFixedEra.CE;
@@ -442,9 +436,7 @@ public class TestInternationalFixedChronology {
                 { 2014, 5, 26, ChronoField.PROLEPTIC_MONTH, 2014 * 13 + 5 - 1 },
                 { 2014, 5, 26, ChronoField.YEAR, 2014 },
                 { 2014, 5, 26, ChronoField.ERA, 1 },
-                { 1, 6, 8, ChronoField.ERA, 1 },
-                { 0, 6, 8, ChronoField.ERA, 0 },
-
+                {    1, 6,  8, ChronoField.ERA, 1 },
                 { 2014, 5, 26, WeekFields.ISO.dayOfWeek (), 7 },
         };
     }

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -1,0 +1,802 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra.chrono;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.*;
+import java.time.chrono.ChronoPeriod;
+import java.time.chrono.Chronology;
+import java.time.chrono.Era;
+import java.time.chrono.IsoEra;
+import java.time.temporal.*;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test.
+ */
+@Test
+@SuppressWarnings ({ "static-method", "javadoc" })
+public class TestInternationalFixedChronology {
+
+    //-----------------------------------------------------------------------
+    // Chronology.of(String)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_chronology_of_name () {
+        Chronology chronology = Chronology.of ("Ifc");
+        Assert.assertNotNull (chronology);
+        Assert.assertEquals (chronology, InternationalFixedChronology.INSTANCE);
+        Assert.assertEquals (chronology.getId (), "Ifc");
+        Assert.assertEquals (chronology.getCalendarType (), "ifc");
+    }
+
+    @Test
+    public void test_chronology_of_name_id () {
+        Chronology chronology = Chronology.of ("Ifc");
+        Assert.assertNotNull (chronology);
+        Assert.assertEquals (chronology, InternationalFixedChronology.INSTANCE);
+        Assert.assertEquals (chronology.getId (), "Ifc");
+        Assert.assertEquals (chronology.getCalendarType (), "ifc");
+    }
+
+    //-----------------------------------------------------------------------
+    // creation, toLocalDate()
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "samples")
+    Object[][] data_samples () {
+        return new Object[][] {
+                { InternationalFixedDate.of (0, 13, 29), LocalDate.of (0, 12, 31) },
+                { InternationalFixedDate.of (1, 1, 1), LocalDate.of (1, 1, 1) },
+                { InternationalFixedDate.of (1, 1, 2), LocalDate.of (1, 1, 2) },
+
+                { InternationalFixedDate.of (1, 1, 27), LocalDate.of (1, 1, 27) },
+                { InternationalFixedDate.of (1, 1, 28), LocalDate.of (1, 1, 28) },
+                { InternationalFixedDate.of (1, 2, 1), LocalDate.of (1, 1, 29) },
+                { InternationalFixedDate.of (1, 2, 2), LocalDate.of (1, 1, 30) },
+
+                { InternationalFixedDate.of (6, 12, 27), LocalDate.of (6, 12, 1) },
+                { InternationalFixedDate.of (6, 12, 28), LocalDate.of (6, 12, 2) },
+                { InternationalFixedDate.of (6, 13, 1), LocalDate.of (6, 12, 3) },
+                { InternationalFixedDate.of (6, 13, 2), LocalDate.of (6, 12, 4) },
+                { InternationalFixedDate.of (6, 13, 3), LocalDate.of (6, 12, 5) },
+                { InternationalFixedDate.of (6, 13, 27), LocalDate.of (6, 12, 29) },
+                { InternationalFixedDate.of (6, 13, 28), LocalDate.of (6, 12, 30) },
+                { InternationalFixedDate.of (6, 13, 29), LocalDate.of (6, 12, 31) },
+                { InternationalFixedDate.of (7, 1, 1), LocalDate.of (7, 1, 1) },
+
+                { InternationalFixedDate.of (399, 13, 1), LocalDate.of (399, 12, 3) },
+                { InternationalFixedDate.of (399, 13, 2), LocalDate.of (399, 12, 4) },
+                { InternationalFixedDate.of (399, 13, 3), LocalDate.of (399, 12, 5) },
+                { InternationalFixedDate.of (399, 13, 4), LocalDate.of (399, 12, 6) },
+                { InternationalFixedDate.of (399, 13, 5), LocalDate.of (399, 12, 7) },
+                { InternationalFixedDate.of (400, 13, 27), LocalDate.of (400, 12, 29) },
+                { InternationalFixedDate.of (400, 13, 28), LocalDate.of (400, 12, 30) },
+                { InternationalFixedDate.of (400, 13, 29), LocalDate.of (400, 12, 31) },
+                { InternationalFixedDate.of (401, 1, 1), LocalDate.of (401, 1, 1) },
+                { InternationalFixedDate.of (401, 1, 2), LocalDate.of (401, 1, 2) },
+
+                { InternationalFixedDate.of (0, 13, 28), LocalDate.of (0, 12, 30) },
+                { InternationalFixedDate.of (0, 13, 27), LocalDate.of (0, 12, 29) },
+
+                { InternationalFixedDate.of (1582, 9, 28), LocalDate.of (1582, 9, 9) },
+                { InternationalFixedDate.of (1582, 10, 1), LocalDate.of (1582, 9, 10) },
+                { InternationalFixedDate.of (1945, 10, 27), LocalDate.of (1945, 10, 6) },
+
+                { InternationalFixedDate.of (2012, 6, 15), LocalDate.of (2012, 6, 4) },
+                { InternationalFixedDate.of (2012, 6, 16), LocalDate.of (2012, 6, 5) },
+        };
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_LocalDate_from_InternationalFixedDate (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (LocalDate.from (date), iso);
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_InternationalFixedDate_from_LocalDate (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (InternationalFixedDate.from (iso), date);
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_InternationalFixedDate_chronology_dateEpochDay (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (InternationalFixedChronology.INSTANCE.dateEpochDay (iso.toEpochDay ()), date);
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_InternationalFixedDate_toEpochDay (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (date.toEpochDay (), iso.toEpochDay ());
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_InternationalFixedDate_until_InternationalFixedDate (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (date.until (date), InternationalFixedChronology.INSTANCE.period (0, 0, 0));
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_InternationalFixedDate_until_LocalDate (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (date.until (iso), InternationalFixedChronology.INSTANCE.period (0, 0, 0));
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_LocalDate_until_InternationalFixedDate (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (iso.until (date), Period.ZERO);
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_Chronology_date_Temporal (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (InternationalFixedChronology.INSTANCE.date (iso), date);
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_plusDays (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (LocalDate.from (date.plus (0, ChronoUnit.DAYS)), iso);
+        assertEquals (LocalDate.from (date.plus (1, ChronoUnit.DAYS)), iso.plusDays (1));
+        assertEquals (LocalDate.from (date.plus (35, ChronoUnit.DAYS)), iso.plusDays (35));
+        assertEquals (LocalDate.from (date.plus (-1, ChronoUnit.DAYS)), iso.plusDays (-1));
+        assertEquals (LocalDate.from (date.plus (-60, ChronoUnit.DAYS)), iso.plusDays (-60));
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_minusDays (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (LocalDate.from (date.minus (0, ChronoUnit.DAYS)), iso);
+        assertEquals (LocalDate.from (date.minus (1, ChronoUnit.DAYS)), iso.minusDays (1));
+        assertEquals (LocalDate.from (date.minus (35, ChronoUnit.DAYS)), iso.minusDays (35));
+        assertEquals (LocalDate.from (date.minus (-1, ChronoUnit.DAYS)), iso.minusDays (-1));
+        assertEquals (LocalDate.from (date.minus (-60, ChronoUnit.DAYS)), iso.minusDays (-60));
+    }
+
+    @Test (dataProvider = "samples")
+    public void test_until_DAYS (final InternationalFixedDate date, final LocalDate iso) {
+        assertEquals (date.until (iso.plusDays (0), ChronoUnit.DAYS), 0);
+        assertEquals (date.until (iso.plusDays (1), ChronoUnit.DAYS), 1);
+        assertEquals (date.until (iso.plusDays (35), ChronoUnit.DAYS), 35);
+        assertEquals (date.until (iso.minusDays (40), ChronoUnit.DAYS), -40);
+    }
+
+    @DataProvider (name = "badDates")
+    Object[][] data_badDates () {
+        return new Object[][] {
+                { 1900, 0, 0 },
+
+                { 1900, -1, 1 },
+                { 1900, 0, 1 },
+                { 1900, 15, 1 },
+                { 1900, 16, 1 },
+
+                { 1900, 1, -1 },
+                { 1900, 1, 0 },
+                { 1900, 1, 29 },
+
+                { 1900, 13, -1 },
+                { 1900, 13, 0 },
+                { 1900, 13, 88 },
+                { 1900, 14, -1 },
+                { 1900, 14, 0 },
+                { 1900, 14, 29 },
+                { 1900, 14, 30 },
+
+                { 1898, 13, -1 },
+                { 1898, 13, 0 },
+                { 1898, 14, 29 },
+                { 1898, 14, 30 },
+                { 1898, 14, 1 },
+                { 1898, 14, 2 },
+
+                { 1900, 14, -1 },
+                { 1900, 14, 0 },
+                { 1900, 14, 29 },
+
+                { 1900, 2, 29 },
+                { 1900, 3, 29 },
+                { 1900, 4, 29 },
+                { 1900, 5, 29 },
+                { 1900, 6, 29 },
+                { 1900, 7, 29 },
+                { 1900, 8, 29 },
+                { 1900, 9, 29 },
+                { 1900, 10, 29 },
+                { 1900, 11, 29 },
+                { 1900, 12, 29 },
+        };
+    }
+
+    @Test (dataProvider = "badDates", expectedExceptions = DateTimeException.class)
+    public void test_badDates (final int year, final int month, final int dom) {
+        InternationalFixedDate.of (year, month, dom);
+    }
+
+    @Test (expectedExceptions = DateTimeException.class)
+    public void test_chronology_dateYearDay_badDate () {
+        InternationalFixedChronology.INSTANCE.dateYearDay (2001, 365);
+    }
+
+    //-----------------------------------------------------------------------
+    // isLeapYear()
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_isLeapYear_loop () {
+        Predicate<Integer> isLeapYear = year -> {
+            return ((year & 3) == 0) && ((year % 100) != 0 || (year % 400) == 0);
+        };
+
+        for (int year = 0; year < 1000; year++) {
+            InternationalFixedDate base = InternationalFixedDate.of (year, 1, 1);
+            assertEquals (base.isLeapYear (), isLeapYear.test (year), "Year " + year + " is failing");
+            assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (year), isLeapYear.test (year), "Year " + year + " is failing");
+        }
+    }
+
+    @Test
+    public void test_isLeapYear_specific () {
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (400), true);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (100), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (99), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (7), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (6), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (5), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (4), true);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (3), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (2), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (1), false);
+        assertEquals (InternationalFixedChronology.INSTANCE.isLeapYear (0), true);
+    }
+
+    @DataProvider (name = "lengthOfMonth")
+    Object[][] data_lengthOfMonth () {
+        return new Object[][] {
+                { 1900, 1, 28 },
+                { 1900, 2, 28 },
+                { 1900, 3, 28 },
+                { 1900, 4, 28 },
+                { 1900, 5, 28 },
+                { 1900, 6, 28 },
+                { 1900, 7, 28 },
+                { 1900, 8, 28 },
+                { 1900, 9, 28 },
+                { 1900, 10, 28 },
+                { 1900, 11, 28 },
+                { 1900, 12, 28 },
+                { 1900, 13, 29 },
+
+                { 1901, 13, 29 },
+                { 1902, 13, 29 },
+                { 1903, 13, 29 },
+                { 1904, 13, 29 },
+                { 1905, 13, 29 },
+                { 1906, 13, 29 },
+                { 2000, 13, 29 },
+                { 2100, 13, 29 },
+        };
+    }
+
+    @Test (dataProvider = "lengthOfMonth")
+    public void test_lengthOfMonth (final int year, final int month, final int length) {
+        InternationalFixedDate date = InternationalFixedDate.of (year, month, 1);
+        assertEquals (date.lengthOfMonth (), length);
+    }
+
+    //-----------------------------------------------------------------------
+    // era, prolepticYear and dateYearDay
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_era_loop () {
+        for (int year = 0; year < 400; year++) {
+            InternationalFixedDate base = InternationalFixedChronology.INSTANCE.date (year, 1, 1);
+            assertEquals (year, base.get (ChronoField.YEAR));
+            InternationalFixedEra era = InternationalFixedEra.CE;
+            assertEquals (era, base.getEra ());
+            assertEquals (year, base.get (ChronoField.YEAR_OF_ERA));
+            InternationalFixedDate eraBased = InternationalFixedChronology.INSTANCE.date (era, year, 1, 1);
+            assertEquals (eraBased, base);
+        }
+    }
+
+    @Test
+    public void test_era_yearDay_loop () {
+        for (int year = 0; year < 400; year++) {
+            InternationalFixedDate base = InternationalFixedChronology.INSTANCE.dateYearDay (year, 1);
+            assertEquals (year, base.get (ChronoField.YEAR));
+            InternationalFixedEra era = InternationalFixedEra.CE;
+            assertEquals (era, base.getEra ());
+            assertEquals (year, base.get (ChronoField.YEAR_OF_ERA));
+            InternationalFixedDate eraBased = InternationalFixedChronology.INSTANCE.dateYearDay (era, year, 1);
+            assertEquals (eraBased, base);
+        }
+    }
+
+    @Test
+    public void test_prolepticYear_specific () {
+        assertEquals (InternationalFixedChronology.INSTANCE.prolepticYear (InternationalFixedEra.CE, 4), 4);
+        assertEquals (InternationalFixedChronology.INSTANCE.prolepticYear (InternationalFixedEra.CE, 3), 3);
+        assertEquals (InternationalFixedChronology.INSTANCE.prolepticYear (InternationalFixedEra.CE, 2), 2);
+        assertEquals (InternationalFixedChronology.INSTANCE.prolepticYear (InternationalFixedEra.CE, 1), 1);
+    }
+
+    @Test (expectedExceptions = ClassCastException.class)
+    public void test_prolepticYear_badEra () {
+        InternationalFixedChronology.INSTANCE.prolepticYear (IsoEra.CE, 4);
+    }
+
+    @Test
+    public void test_Chronology_eraOf () {
+        assertEquals (InternationalFixedChronology.INSTANCE.eraOf (0), InternationalFixedEra.CE);
+    }
+
+    @Test (expectedExceptions = DateTimeException.class)
+    public void test_Chronology_eraOf_invalid () {
+        InternationalFixedChronology.INSTANCE.eraOf (2);
+    }
+
+    @Test
+    public void test_Chronology_eras () {
+        List<Era> eras = InternationalFixedChronology.INSTANCE.eras ();
+        assertEquals (eras.size (), 1);
+        assertEquals (eras.contains (InternationalFixedEra.CE), true);
+    }
+
+    //-----------------------------------------------------------------------
+    // Chronology.range
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_Chronology_range () {
+        assertEquals (InternationalFixedChronology.INSTANCE.range (ChronoField.DAY_OF_WEEK), ValueRange.of (1, 7));
+        assertEquals (InternationalFixedChronology.INSTANCE.range (ChronoField.DAY_OF_MONTH), ValueRange.of (1, 28, 29));
+        assertEquals (InternationalFixedChronology.INSTANCE.range (ChronoField.DAY_OF_YEAR), ValueRange.of (1, 364, 365));
+        assertEquals (InternationalFixedChronology.INSTANCE.range (ChronoField.MONTH_OF_YEAR), ValueRange.of (1, 13));
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.range
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "ranges")
+    Object[][] data_ranges () {
+        return new Object[][] {
+                { 2012, 1, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 2, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 3, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 4, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 5, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 6, 23, ChronoField.DAY_OF_MONTH, 1, 29 },
+                { 2012, 7, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 8, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 9, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 10, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 11, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 12, 23, ChronoField.DAY_OF_MONTH, 1, 28 },
+                { 2012, 13, 3, ChronoField.DAY_OF_MONTH, 1, 29 },
+                { 2012, 13, 23, ChronoField.DAY_OF_MONTH, 1, 29 },
+
+                { 2012, 1, 23, ChronoField.MONTH_OF_YEAR, 1, 13 },
+                { 2012, 1, 23, ChronoField.DAY_OF_YEAR, 1, 365 },
+
+                { 2012, 1, 23, ChronoField.ALIGNED_WEEK_OF_MONTH, 1, 4 },
+                { 2012, 13, 3, ChronoField.ALIGNED_WEEK_OF_MONTH, 1, 4 },
+                { 2012, 13, 23, ChronoField.ALIGNED_WEEK_OF_MONTH, 1, 4 },
+
+                { 2011, 13, 23, ChronoField.DAY_OF_MONTH, 1, 29 },
+                { 2011, 1, 23, ChronoField.MONTH_OF_YEAR, 1, 13 },
+                { 2011, 13, 23, ChronoField.DAY_OF_YEAR, 1, 364 },
+                { 2011, 13, 23, ChronoField.ALIGNED_WEEK_OF_MONTH, 1, 4 },
+        };
+    }
+
+    @Test (dataProvider = "ranges")
+    public void test_range (final int year, final int month, final int dom, final TemporalField field, final int expectedMin, final int expectedMax) {
+        assertEquals (InternationalFixedDate.of (year, month, dom).range (field), ValueRange.of (expectedMin, expectedMax));
+    }
+
+    @Test (expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_range_unsupported () {
+        InternationalFixedDate.of (2012, 6, 28).range (ChronoField.MINUTE_OF_DAY);
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.getLong
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "getLong")
+    Object[][] data_getLong () {
+        return new Object[][] {
+                { 2014, 5, 26, ChronoField.DAY_OF_WEEK, 7 },
+                { 2014, 5, 26, ChronoField.DAY_OF_MONTH, 26 },
+                { 2014, 5, 26, ChronoField.DAY_OF_YEAR, 28 + 28 + 28 + 28 + 26 },
+                { 2014, 5, 26, ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH, 5 },
+                { 2014, 5, 26, ChronoField.ALIGNED_WEEK_OF_MONTH, 4 },
+                { 2014, 5, 26, ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR, 5 },
+                { 2014, 5, 26, ChronoField.ALIGNED_WEEK_OF_YEAR, 20 },
+                { 2014, 5, 26, ChronoField.MONTH_OF_YEAR, 5 },
+                { 2014, 5, 26, ChronoField.PROLEPTIC_MONTH, 2014 * 13 + 5 - 1 },
+                { 2014, 5, 26, ChronoField.YEAR, 2014 },
+                { 2014, 5, 26, ChronoField.ERA, 1 },
+                { 1, 6, 8, ChronoField.ERA, 1 },
+                { 0, 6, 8, ChronoField.ERA, 0 },
+
+                { 2014, 5, 26, WeekFields.ISO.dayOfWeek (), 7 },
+        };
+    }
+
+    @Test (dataProvider = "getLong")
+    public void test_getLong (final int year, final int month, final int dom, final TemporalField field, final long expected) {
+        assertEquals (InternationalFixedDate.of (year, month, dom).getLong (field), expected);
+    }
+
+    @Test (expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_getLong_unsupported () {
+        InternationalFixedDate.of (2012, 6, 28).getLong (ChronoField.MINUTE_OF_DAY);
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.with
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "with")
+    Object[][] data_with () {
+        return new Object[][] {
+                { 2014, 5, 26, ChronoField.DAY_OF_WEEK, 3, 2014, 5, 22 },
+                { 2014, 5, 26, ChronoField.DAY_OF_WEEK, 4, 2014, 5, 23 },
+                { 2014, 5, 26, ChronoField.DAY_OF_MONTH, 28, 2014, 5, 28 },
+                { 2014, 5, 26, ChronoField.DAY_OF_MONTH, 26, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.DAY_OF_YEAR, 364, 2014, 13, 28 },
+                { 2014, 5, 26, ChronoField.DAY_OF_YEAR, 138, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH, 3, 2014, 5, 24 },
+                { 2014, 5, 26, ChronoField.ALIGNED_DAY_OF_WEEK_IN_MONTH, 5, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.ALIGNED_WEEK_OF_MONTH, 1, 2014, 5, 5 },
+                { 2014, 5, 26, ChronoField.ALIGNED_WEEK_OF_MONTH, 4, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR, 3, 2014, 5, 24 },
+                { 2014, 5, 26, ChronoField.ALIGNED_DAY_OF_WEEK_IN_YEAR, 5, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.ALIGNED_WEEK_OF_YEAR, 23, 2014, 6, 19 },
+                { 2014, 5, 26, ChronoField.ALIGNED_WEEK_OF_YEAR, 20, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.MONTH_OF_YEAR, 7, 2014, 7, 26 },
+                { 2014, 5, 26, ChronoField.MONTH_OF_YEAR, 5, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.PROLEPTIC_MONTH, 2013 * 13 + 4, 2013, 5, 26 },
+                { 2014, 5, 26, ChronoField.PROLEPTIC_MONTH, 2013 * 13 + 5, 2013, 6, 26 },
+                { 2014, 5, 26, ChronoField.YEAR, 2012, 2012, 5, 26 },
+                { 2014, 5, 26, ChronoField.YEAR, 2014, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.YEAR_OF_ERA, 2012, 2012, 5, 26 },
+                { 2014, 5, 26, ChronoField.YEAR_OF_ERA, 2014, 2014, 5, 26 },
+                { 2014, 5, 26, ChronoField.ERA, 1, 2014, 5, 26 },
+
+                { 2011, 3, 28, ChronoField.MONTH_OF_YEAR, 13, 2011, 13, 28 },
+                { 2012, 3, 28, ChronoField.MONTH_OF_YEAR, 13, 2012, 13, 28 },
+                { 2012, 3, 28, ChronoField.MONTH_OF_YEAR, 6, 2012, 6, 28 },
+                { 2012, 13, 7, ChronoField.YEAR, 2011, 2011, 13, 7 },
+                { 2014, 5, 26, WeekFields.ISO.dayOfWeek (), 3, 2014, 5, 22 },
+        };
+    }
+
+    @Test (dataProvider = "with")
+    public void test_with_TemporalField (
+            final int year,
+            final int month,
+            final int dom,
+            final TemporalField field,
+            final long value,
+            final int expectedYear,
+            final int expectedMonth,
+            final int expectedDom) {
+        assertEquals (InternationalFixedDate.of (year, month, dom).with (field, value), InternationalFixedDate.of (expectedYear, expectedMonth, expectedDom));
+    }
+
+    @Test (expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_with_TemporalField_unsupported () {
+        InternationalFixedDate.of (2012, 6, 28).with (ChronoField.MINUTE_OF_DAY, 0);
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.with(TemporalAdjuster)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_adjust_toLastDayOfMonth () {
+        InternationalFixedDate base = InternationalFixedDate.of (2012, 6, 23);
+        InternationalFixedDate test = base.with (TemporalAdjusters.lastDayOfMonth ());
+        assertEquals (test, InternationalFixedDate.of (2012, 6, 29));
+
+        base = InternationalFixedDate.of (2012, 13, 2);
+        test = base.with (TemporalAdjusters.lastDayOfMonth ());
+        assertEquals (test, InternationalFixedDate.of (2012, 13, 29));
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.with(Local*)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_adjust_toLocalDate () {
+        InternationalFixedDate date = InternationalFixedDate.of (2000, 1, 4);
+        InternationalFixedDate test = date.with (LocalDate.of (2012, 7, 14));
+        assertEquals (test, InternationalFixedDate.of (2012, 7, 27));
+    }
+
+    @Test (expectedExceptions = DateTimeException.class)
+    public void test_adjust_toMonth () {
+        InternationalFixedDate date = InternationalFixedDate.of (2000, 1, 4);
+        date.with (Month.APRIL);
+    }
+
+    //-----------------------------------------------------------------------
+    // LocalDate.with(InternationalFixedDate)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_LocalDate_adjustToInternationalFixedDate () {
+        InternationalFixedDate date = InternationalFixedDate.of (2012, 6, 15);
+        LocalDate test = LocalDate.MIN.with (date);
+        assertEquals (test, LocalDate.of (2012, 6, 4));
+    }
+
+    @Test
+    public void test_LocalDateTime_adjustToInternationalFixedDate () {
+        InternationalFixedDate date = InternationalFixedDate.of (2012, 6, 15);
+        LocalDateTime test = LocalDateTime.MIN.with (date);
+        assertEquals (test, LocalDateTime.of (2012, 6, 4, 0, 0));
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.plus
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "plus")
+    Object[][] data_plus () {
+        return new Object[][] {
+                { 2014, 5, 26, 0, ChronoUnit.DAYS, 2014, 5, 26 },
+                { 2014, 5, 26, 8, ChronoUnit.DAYS, 2014, 6, 6 },
+                { 2014, 5, 26, -3, ChronoUnit.DAYS, 2014, 5, 23 },
+                { 2014, 5, 26, 0, ChronoUnit.WEEKS, 2014, 5, 26 },
+                { 2014, 5, 26, 3, ChronoUnit.WEEKS, 2014, 6, 19 },
+                { 2014, 5, 26, -5, ChronoUnit.WEEKS, 2014, 4, 19 },
+                { 2014, 5, 26, 0, ChronoUnit.MONTHS, 2014, 5, 26 },
+                { 2014, 5, 26, 3, ChronoUnit.MONTHS, 2014, 8, 26 },
+                { 2014, 5, 26, -5, ChronoUnit.MONTHS, 2013, 13, 26 },
+                { 2014, 5, 26, 0, ChronoUnit.YEARS, 2014, 5, 26 },
+                { 2014, 5, 26, 3, ChronoUnit.YEARS, 2017, 5, 26 },
+                { 2014, 5, 26, -5, ChronoUnit.YEARS, 2009, 5, 26 },
+                { 2014, 5, 26, 0, ChronoUnit.DECADES, 2014, 5, 26 },
+                { 2014, 5, 26, 3, ChronoUnit.DECADES, 2044, 5, 26 },
+                { 2014, 5, 26, -5, ChronoUnit.DECADES, 1964, 5, 26 },
+                { 2014, 5, 26, 0, ChronoUnit.CENTURIES, 2014, 5, 26 },
+                { 2014, 5, 26, 3, ChronoUnit.CENTURIES, 2314, 5, 26 },
+                { 2014, 5, 26, -5, ChronoUnit.CENTURIES, 1514, 5, 26 },
+                { 2014, 5, 26, 0, ChronoUnit.MILLENNIA, 2014, 5, 26 },
+                { 2014, 5, 26, 3, ChronoUnit.MILLENNIA, 5014, 5, 26 },
+
+                { 2012, 13, 6, 3, ChronoUnit.MONTHS, 2013, 3, 6 },
+                { 2011, 13, 26, 1, ChronoUnit.YEARS, 2012, 13, 26 },
+                { 2014, 13, 26, -2, ChronoUnit.YEARS, 2012, 13, 26 },
+                { 2012, 13, 26, -6, ChronoUnit.YEARS, 2006, 13, 26 },
+                { 2012, 13, 6, -6, ChronoUnit.YEARS, 2006, 13, 6 },
+        };
+    }
+
+    @DataProvider (name = "plusLeap")
+    Object[][] data_plus_leap () {
+        return new Object[][] {
+                { 2012, 12, 26, 1, ChronoUnit.MONTHS, 2012, 13, 26 },
+                { 2012, 13, 26, -1, ChronoUnit.MONTHS, 2012, 12, 26 },
+                { 2012, 13, 6, 3, ChronoUnit.YEARS, 2015, 13, 6 },
+        };
+    }
+
+    @DataProvider (name = "minusLeap")
+    Object[][] data_minus_leap () {
+        return new Object[][] {
+                { 2012, 13, 7, -1, ChronoUnit.MONTHS, 2012, 12, 7 },
+                { 2012, 13, 7, 1, ChronoUnit.MONTHS, 2013, 1, 7 },
+                { 2012, 13, 6, 3, ChronoUnit.YEARS, 2015, 13, 6 },
+        };
+    }
+
+    @Test (dataProvider = "plus")
+    public void test_plus_TemporalUnit (
+            final int year,
+            final int month,
+            final int dom,
+            final long amount,
+            final TemporalUnit unit,
+            final int expectedYear,
+            final int expectedMonth,
+            final int expectedDom) {
+        assertEquals (InternationalFixedDate.of (year, month, dom).plus (amount, unit), InternationalFixedDate.of (expectedYear, expectedMonth, expectedDom));
+    }
+
+    @Test (dataProvider = "plusLeap")
+    public void test_plus_leap_TemporalUnit (
+            final int year,
+            final int month,
+            final int dom,
+            final long amount,
+            final TemporalUnit unit,
+            final int expectedYear,
+            final int expectedMonth,
+            final int expectedDom) {
+        test_plus_TemporalUnit (year, month, dom, amount, unit, expectedYear, expectedMonth, expectedDom);
+    }
+
+    @Test (dataProvider = "plus")
+    public void test_minus_TemporalUnit (
+            final int expectedYear,
+            final int expectedMonth,
+            final int expectedDom,
+            final long amount,
+            final TemporalUnit unit,
+            final int year,
+            final int month,
+            final int dom) {
+        assertEquals (InternationalFixedDate.of (year, month, dom).minus (amount, unit), InternationalFixedDate.of (expectedYear, expectedMonth, expectedDom));
+    }
+
+    @Test (dataProvider = "minusLeap")
+    public void test_minus_leap_TemporalUnit (
+            final int year,
+            final int month,
+            final int dom,
+            final long amount,
+            final TemporalUnit unit,
+            final int expectedYear,
+            final int expectedMonth,
+            final int expectedDom) {
+        test_minus_TemporalUnit (year, month, dom, amount, unit, expectedYear, expectedMonth, expectedDom);
+    }
+
+    @Test (expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_plus_TemporalUnit_unsupported () {
+        InternationalFixedDate.of (2012, 6, 10).plus (0, ChronoUnit.MINUTES);
+    }
+
+    //-----------------------------------------------------------------------
+    // InternationalFixedDate.until
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "until")
+    Object[][] data_until () {
+        return new Object[][] {
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.DAYS, 0 },
+                { 2014, 5, 26, 2014, 6, 4, ChronoUnit.DAYS, 6 },
+                { 2014, 5, 26, 2014, 5, 20, ChronoUnit.DAYS, -6 },
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.WEEKS, 0 },
+                { 2014, 5, 26, 2014, 6, 4, ChronoUnit.WEEKS, 0 },
+                { 2014, 5, 26, 2014, 6, 5, ChronoUnit.WEEKS, 1 },
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.MONTHS, 0 },
+                { 2014, 5, 26, 2014, 6, 25, ChronoUnit.MONTHS, 0 },
+                { 2014, 5, 26, 2014, 6, 26, ChronoUnit.MONTHS, 1 },
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.YEARS, 0 },
+                { 2014, 5, 26, 2015, 5, 25, ChronoUnit.YEARS, 0 },
+                { 2014, 5, 26, 2015, 5, 26, ChronoUnit.YEARS, 1 },
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.DECADES, 0 },
+                { 2014, 5, 26, 2024, 5, 25, ChronoUnit.DECADES, 0 },
+                { 2014, 5, 26, 2024, 5, 26, ChronoUnit.DECADES, 1 },
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.CENTURIES, 0 },
+                { 2014, 5, 26, 2114, 5, 25, ChronoUnit.CENTURIES, 0 },
+                { 2014, 5, 26, 2114, 5, 26, ChronoUnit.CENTURIES, 1 },
+                { 2014, 5, 26, 2014, 5, 26, ChronoUnit.MILLENNIA, 0 },
+                { 2014, 5, 26, 3014, 5, 25, ChronoUnit.MILLENNIA, 0 },
+                { 2014, 5, 26, 3014, 5, 26, ChronoUnit.MILLENNIA, 1 },
+
+                { 2011, 13, 26, 2013, 13, 26, ChronoUnit.YEARS, 2 },
+                { 2011, 13, 26, 2012, 13, 26, ChronoUnit.YEARS, 1 },
+                { 2012, 13, 26, 2011, 13, 26, ChronoUnit.YEARS, -1 },
+                { 2012, 13, 26, 2013, 13, 26, ChronoUnit.YEARS, 1 },
+                { 2011, 13, 6, 2011, 13, 6, ChronoUnit.YEARS, 0 },
+                { 2012, 13, 6, 2012, 13, 6, ChronoUnit.YEARS, 0 },
+                { 2011, 13, 1, 2011, 13, 1, ChronoUnit.YEARS, 0 },
+                { 2012, 13, 7, 2012, 13, 7, ChronoUnit.YEARS, 0 },
+                { 2011, 12, 28, 2012, 13, 1, ChronoUnit.YEARS, 1 },
+                { 2012, 13, 1, 2011, 13, 1, ChronoUnit.YEARS, -1 },
+                { 2013, 13, 6, 2012, 13, 6, ChronoUnit.YEARS, -1 },
+                { 2012, 13, 6, 2013, 13, 6, ChronoUnit.YEARS, 1 },
+        };
+    }
+
+    @Test (dataProvider = "until")
+    public void test_until_TemporalUnit (
+            final int year1,
+            final int month1,
+            final int dom1,
+            final int year2,
+            final int month2,
+            final int dom2,
+            final TemporalUnit unit,
+            final long expected) {
+        InternationalFixedDate start = InternationalFixedDate.of (year1, month1, dom1);
+        InternationalFixedDate end = InternationalFixedDate.of (year2, month2, dom2);
+
+        assertEquals (start.until (end, unit), expected);
+    }
+
+    @Test (expectedExceptions = UnsupportedTemporalTypeException.class)
+    public void test_until_TemporalUnit_unsupported () {
+        InternationalFixedDate start = InternationalFixedDate.of (2012, 6, 28);
+        InternationalFixedDate end = InternationalFixedDate.of (2012, 7, 1);
+        start.until (end, ChronoUnit.MINUTES);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_plus_Period () {
+        assertEquals (InternationalFixedDate.of (2014, 5, 26).plus (InternationalFixedChronology.INSTANCE.period (0, 2, 2)), InternationalFixedDate.of (2014, 7, 28));
+    }
+
+    @Test (expectedExceptions = DateTimeException.class)
+    public void test_plus_Period_ISO () {
+        assertEquals (InternationalFixedDate.of (2014, 5, 26).plus (Period.ofMonths (2)), InternationalFixedDate.of (2014, 7, 26));
+    }
+
+    @Test
+    public void test_minus_Period () {
+        ChronoPeriod period = InternationalFixedChronology.INSTANCE.period (0, 2, 3);
+        assertEquals (InternationalFixedDate.of (2014, 5, 26).minus (period), InternationalFixedDate.of (2014, 3, 23));
+    }
+
+    @Test (expectedExceptions = DateTimeException.class)
+    public void test_minus_Period_ISO () {
+        ChronoPeriod period = Period.ofMonths (2);
+        assertEquals (InternationalFixedDate.of (2014, 5, 26).minus (period), InternationalFixedDate.of (2014, 3, 26));
+    }
+
+    //-----------------------------------------------------------------------
+    // equals()
+    //-----------------------------------------------------------------------
+    @Test
+    void test_equals () {
+        InternationalFixedDate a1 = InternationalFixedDate.of (2000, 1, 3);
+        InternationalFixedDate a2 = InternationalFixedDate.of (2000, 1, 3);
+        InternationalFixedDate b = InternationalFixedDate.of (2000, 1, 4);
+        InternationalFixedDate c = InternationalFixedDate.of (2000, 2, 3);
+        InternationalFixedDate d = InternationalFixedDate.of (2001, 1, 3);
+
+        assertEquals (a1.equals (a1), true);
+        assertEquals (a1.equals (a2), true);
+        assertEquals (a1.equals (b), false);
+        assertEquals (a1.equals (c), false);
+        assertEquals (a1.equals (d), false);
+
+        assertEquals (a1.equals (null), false);
+        assertEquals ("".equals (a1), false);
+
+        assertEquals (a1.hashCode (), a2.hashCode ());
+    }
+
+    //-----------------------------------------------------------------------
+    // toString()
+    //-----------------------------------------------------------------------
+    @DataProvider (name = "toString")
+    Object[][] data_toString () {
+        return new Object[][] {
+                { InternationalFixedDate.of (1, 1, 1), "Ifc CE 1-01-01" },
+                { InternationalFixedDate.of (2012, 6, 23), "Ifc CE 2012-06-23" },
+        };
+    }
+
+    @Test (dataProvider = "toString")
+    public void test_toString (final InternationalFixedDate date, final String expected) {
+        assertEquals (date.toString (), expected);
+    }
+}


### PR DESCRIPTION
Implemented IFC - chronology for International Fixed calendar, described in http://en.wikipedia.org/wiki/International_Fixed_Calendar.
It is a bit similar to Pax, has the same leap year rule as the Gregorian calendar.
However, it consists of 13 months with each 28 days; leap day is inserted between end of month 6 and beginning of month 7.
