### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/AbstractDate.java
+++ b/src/main/java/org/threeten/extra/chrono/AbstractDate.java
@@ -87,8 +87,8 @@ abstract class AbstractDate
 
     abstract AbstractDate resolvePrevious(int newYear, int newMonth, int dayOfMonth);
 
-    AbstractDate resolveEpochDay(long epcohDay) {
-        return (AbstractDate) getChronology().dateEpochDay(epcohDay);
+    AbstractDate resolveEpochDay(long epochDay) {
+        return (AbstractDate) getChronology().dateEpochDay(epochDay);
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/threeten/extra/chrono/AccountingDate.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingDate.java
@@ -295,7 +295,6 @@ public final class AccountingDate extends AbstractDate implements ChronoLocalDat
      *
      * @param chronology  the Accounting chronology to base the date on, not null
      * @param prolepticYear  the Accounting proleptic-year
-     * @param dayOfYear  the Accounting day-of-year, from 1 to 371
      * @return the date in Accounting calendar system, not null
      * @throws DateTimeException if the value of any field is out of range,
      *  or if the day-of-year is invalid for the month-year,

--- a/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
+++ b/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
@@ -70,12 +70,10 @@ import java.util.Objects;
 public final class BritishCutoverDate
         extends AbstractDate
         implements ChronoLocalDate, Serializable {
-
     /**
      * Serialization version.
      */
     private static final long serialVersionUID = -9626278512674L;
-
     /**
      * The underlying date.
      */
@@ -83,7 +81,7 @@ public final class BritishCutoverDate
     /**
      * The underlying Julian date if before the cutover.
      */
-    private transient final JulianDate julianDate;
+    private final transient JulianDate julianDate;
 
     //-----------------------------------------------------------------------
     /**


### PR DESCRIPTION
Typo: epcohDay -> epochDay
Incorrect java-doc reference to non-existing @param
Transpose "transient final" to appease check-style
