### PR TITLE
Changes to wip/ifc in order to treat Year Day as 13/29, Leap Day as 6/29

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
@@ -141,7 +141,7 @@ public final class InternationalFixedChronology extends AbstractChronology imple
     /**
      * Range of day of month.
      */
-    static final ValueRange DAY_OF_MONTH_RANGE = ValueRange.of(-1, 0, -1, DAYS_IN_MONTH);
+    static final ValueRange DAY_OF_MONTH_RANGE = ValueRange.of(1, DAYS_IN_MONTH + 1);
     /**
      * Range of week of year.
      */
@@ -161,7 +161,7 @@ public final class InternationalFixedChronology extends AbstractChronology imple
     /**
      * Range of month of year.
      */
-    static final ValueRange MONTH_OF_YEAR_RANGE = ValueRange.of(-1, 0, MONTHS_IN_YEAR, MONTHS_IN_YEAR);
+    static final ValueRange MONTH_OF_YEAR_RANGE = ValueRange.of(1, MONTHS_IN_YEAR);
     /**
      * Range of eras.
      */

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -564,7 +564,7 @@ public final class InternationalFixedDate
                 case ALIGNED_DAY_OF_WEEK_IN_MONTH:
                 case ALIGNED_DAY_OF_WEEK_IN_YEAR:
                 case DAY_OF_WEEK:
-                    int dom = (isYearDay || isLeapDay) ? 21 : ((getDayOfMonth() - 1 ) / DAYS_IN_WEEK) * DAYS_IN_WEEK;
+                    int dom = (isYearDay || isLeapDay) ? 21 : ((getDayOfMonth() - 1) / DAYS_IN_WEEK) * DAYS_IN_WEEK;
                     return resolvePreviousValid(prolepticYear, month, dom + nval);
                 case ALIGNED_WEEK_OF_MONTH:
                     int d = day == DAYS_IN_MONTH + 1 ? 1 : day % DAYS_IN_WEEK;

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -212,36 +212,6 @@ public final class InternationalFixedDate
         return create(prolepticYear, month, dayOfMonth);
     }
 
-    /**
-     * Obtains a {@code InternationalFixedDate} representing a date in the International fixed calendar
-     * system from the proleptic-year, for the out-of-month day of Leap Day, which follows the last day in June and precedes Sol 1.
-     * <p>
-     * This returns a {@code InternationalFixedDate} with the specified fields.
-     *
-     * @param prolepticYear  the International fixed proleptic-year
-     * @return the date in International fixed calendar system, not null
-     * @throws DateTimeException if the value of any field is out of range,
-     *  or if the day-of-month is invalid for the month-year
-     */
-    public static InternationalFixedDate leapDay(int prolepticYear) {
-        return create(prolepticYear, 6, 29);
-    }
-
-    /**
-     * Obtains a {@code InternationalFixedDate} representing a date in the International fixed calendar
-     * system from the proleptic-year, for the out-of-month day of Year Day, which follows the last day in December.
-     * <p>
-     * This returns a {@code InternationalFixedDate} with the specified fields.
-     *
-     * @param prolepticYear  the International fixed proleptic-year
-     * @return the date in International fixed calendar system, not null
-     * @throws DateTimeException if the value of any field is out of range,
-     *  or if the day-of-month is invalid for the month-year
-     */
-    public static InternationalFixedDate yearDay(int prolepticYear) {
-        return create(prolepticYear, 13, 29);
-    }
-
     //-----------------------------------------------------------------------
     /**
      * Obtains a {@code InternationalFixedDate} from a temporal object.

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedDate.java
@@ -202,8 +202,8 @@ public final class InternationalFixedDate
      * The day must be valid for the year and month, otherwise an exception will be thrown.
      *
      * @param prolepticYear  the International fixed proleptic-year
-     * @param month  the International fixed month-of-year, from -1 to 13 (-1 for Leap Day, 0 for Year Day)
-     * @param dayOfMonth  the International fixed day-of-month, from -1 to 28 (-1 for Leap Day, 0 for Year Day)
+     * @param month  the International fixed month-of-year, from 1 to 13
+     * @param dayOfMonth  the International fixed day-of-month, from 1 to 28 (29 for Leap Day or Year Day)
      * @return the date in International fixed calendar system, not null
      * @throws DateTimeException if the value of any field is out of range,
      *  or if the day-of-month is invalid for the month-year
@@ -224,7 +224,7 @@ public final class InternationalFixedDate
      *  or if the day-of-month is invalid for the month-year
      */
     public static InternationalFixedDate leapDay(int prolepticYear) {
-        return create(prolepticYear, -1, -1);
+        return create(prolepticYear, 6, 29);
     }
 
     /**
@@ -239,7 +239,7 @@ public final class InternationalFixedDate
      *  or if the day-of-month is invalid for the month-year
      */
     public static InternationalFixedDate yearDay(int prolepticYear) {
-        return create(prolepticYear, 0, 0);
+        return create(prolepticYear, 13, 29);
     }
 
     //-----------------------------------------------------------------------
@@ -293,8 +293,8 @@ public final class InternationalFixedDate
         boolean isYearDay = dayOfYear == DAYS_IN_YEAR + (isLeapYear ? 1 : 0);
         boolean isLeapDay = isLeapYear && dayOfYear == LEAP_DAY_AS_DAY_OF_YEAR;
         int doy = isLeapYear && dayOfYear > LEAP_DAY_AS_DAY_OF_YEAR ? dayOfYear - 1 : dayOfYear;
-        int month = isYearDay ? 0 : isLeapDay ? -1 : 1 + ((doy - 1) / DAYS_IN_MONTH);
-        int day = isYearDay ? 0 : isLeapDay ? -1 : 1 + ((doy - 1) % DAYS_IN_MONTH);
+        int month = isYearDay ? MONTHS_IN_YEAR : isLeapDay ? 6 : 1 + ((doy - 1) / DAYS_IN_MONTH);
+        int day = (isYearDay || isLeapDay) ? DAYS_IN_MONTH + 1 : 1 + ((doy - 1) % DAYS_IN_MONTH);
 
         return new InternationalFixedDate(prolepticYear, month, day);
     }
@@ -340,18 +340,13 @@ public final class InternationalFixedDate
      *   {@link #with(TemporalField, long)}.
      *
      * @param prolepticYear  the International fixed proleptic-year
-     * @param month  the International fixed month, from -1 to 13 (-1 for Leap Day, 0 for Year Day)
-     * @param day  the International fixed day-of-month, from -1 to 28 (-1 for Leap Day, 0 for Year Day)
+     * @param month  the International fixed month, from 1 to 13
+     * @param day  the International fixed day-of-month, from 1 to 28 (29 for Leap Day or Year Day)
      * @return
      */
     private static InternationalFixedDate resolvePreviousValid(int prolepticYear, int month, int day) {
-        if ((month == 0 && day == 0) || (month == -1 && day == -1 && INSTANCE.isLeapYear(prolepticYear))) {
-            // create valid Year Day or Leap Day
-            return create(prolepticYear, month, day);
-        }
-
-        int monthR = month == -1 ? 7 : month == 0 ? MONTHS_IN_YEAR : Math.min(month, MONTHS_IN_YEAR);
-        int dayR = day == -1 ? 1 : day == 0 ? DAYS_IN_MONTH : Math.min(day, DAYS_IN_MONTH);
+        int monthR = Math.min(month, MONTHS_IN_YEAR);
+        int dayR = Math.min(day, (monthR == 13 || (monthR == 6 && INSTANCE.isLeapYear(prolepticYear)) ? DAYS_IN_MONTH + 1 : DAYS_IN_MONTH));
 
         return create(prolepticYear, monthR, dayR);
     }
@@ -359,11 +354,10 @@ public final class InternationalFixedDate
     //-----------------------------------------------------------------------
     /**
      * Factory method, validates the given triplet year, month and dayOfMonth.
-     * Special values are required for Year Day (N/0/0) and Leap Day (N/-1/-1).
      *
      * @param prolepticYear  the International fixed proleptic-year
-     * @param month  the International fixed month, from -1 to 13 (-1 for Leap Day, 0 for Year Day)
-     * @param dayOfMonth  the International fixed day-of-month, from -1 to 28 (-1 for Leap Day, 0 for Year Day)
+     * @param month  the International fixed month, from 1 to 13
+     * @param dayOfMonth  the International fixed day-of-month, from 1 to 28 (29 for Leap Day or Year Day)
      * @return the International fixed date
      * @throws DateTimeException if the date is invalid
      */
@@ -372,10 +366,10 @@ public final class InternationalFixedDate
         MONTH_OF_YEAR_RANGE.checkValidValue(month, ChronoField.MONTH_OF_YEAR);
         DAY_OF_MONTH_RANGE.checkValidValue(dayOfMonth, ChronoField.DAY_OF_MONTH);
 
-        if ((month < 1 || dayOfMonth < 1) && (dayOfMonth != month)) {
-            throw new DateTimeException("Ambiguous Year or Leap Day: " + prolepticYear + '/' + month + '/' + dayOfMonth);
+        if (dayOfMonth == DAYS_IN_MONTH + 1 && (month != 6 && month != MONTHS_IN_YEAR)) {
+            throw new DateTimeException("Invalid date: " + prolepticYear + '/' + month + '/' + dayOfMonth);
         }
-        if ((month == -1) && (dayOfMonth == -1) && !INSTANCE.isLeapYear(prolepticYear)) {
+        if ((month == 6) && (dayOfMonth == DAYS_IN_MONTH + 1) && !INSTANCE.isLeapYear(prolepticYear)) {
             throw new DateTimeException("Invalid Leap Day as '" + prolepticYear + "' is not a leap year");
         }
         return new InternationalFixedDate(prolepticYear, month, dayOfMonth);
@@ -386,16 +380,16 @@ public final class InternationalFixedDate
      * Creates an instance from validated data.
      *
      * @param prolepticYear  the International fixed proleptic-year
-     * @param month  the International fixed month, from -1 to 13 (-1 for Leap Day, 0 for Year Day)
-     * @param dayOfMonth  the International fixed day-of-month, from -1 to 28 (-1 for Leap Day, 0 for Year Day)
+     * @param month  the International fixed month, from 1 to 13
+     * @param dayOfMonth  the International fixed day-of-month, from 1 to 28 (29 for Leap Day or Year Day)
      */
     private InternationalFixedDate(int prolepticYear, int month, int dayOfMonth) {
         this.prolepticYear = prolepticYear;
         this.month = month;
         this.day = dayOfMonth;
         this.isLeapYear = isLeapYear();
-        this.isLeapDay = this.day == -1;
-        this.isYearDay = this.day == 0;
+        this.isLeapDay = this.month == 6 && this.day == 29;
+        this.isYearDay = this.month == 13 && this.day == 29;
         this.dayOfYear = this.isLeapDay ? LEAP_DAY_AS_DAY_OF_YEAR :
             this.isYearDay ? DAYS_IN_YEAR + (this.isLeapYear ? 1 : 0) :
                 (month - 1) * DAYS_IN_MONTH + this.day + (this.isLeapYear && this.month > 6 ? 1 : 0);
@@ -451,22 +445,12 @@ public final class InternationalFixedDate
      * @return int month for calculations
      */
     private int getInternalMonth() {
-        return this.isYearDay ? MONTHS_IN_YEAR : this.isLeapDay ? 7 : this.month;
+        return this.isLeapDay ? 6 : this.month;
     }
 
     @Override
     int getDayOfMonth() {
         return day;
-    }
-
-    /**
-     * For calculation purposes, consider Leap Day to be Sol 1st.
-     * In the same spirit, treat Year Day December 29th.
-     *
-     * @return int day of the month for calculations
-     */
-    private int getInternalDayOfMonth() {
-        return isYearDay ? DAYS_IN_MONTH + 1 : isLeapDay ? 0 : day;
     }
 
     @Override
@@ -481,7 +465,7 @@ public final class InternationalFixedDate
      * @return int day of the year for calculations
      */
     private int getInternalDayOfYear() {
-        return isLeapYear && (isYearDay || month > 6) ? dayOfYear - 1 : dayOfYear;
+        return isLeapYear && (month > 6) ? dayOfYear - 1 : dayOfYear;
     }
 
     @Override
@@ -496,7 +480,7 @@ public final class InternationalFixedDate
 
     @Override
     ValueRange rangeAlignedWeekOfMonth() {
-        return month > 0 ? WEEK_OF_MONTH_RANGE : EMPTY_RANGE;
+        return (isYearDay || isLeapDay) ? EMPTY_RANGE : WEEK_OF_MONTH_RANGE;
     }
 
     @Override
@@ -537,13 +521,13 @@ public final class InternationalFixedDate
      * This returns the length of the month in days.
      * Month lengths do not match those of the ISO calendar system.
      * <p>
-     * Since Leap Day / Year Day are not part of any month, their 'imaginary' month is of length 1.
+     * Leap Day is part of June, Year Day is part of December.
      *
-     * @return the length of the month in days, 28 or 1
+     * @return the length of the month in days, 28 (29 for Year Day or Leap Day)
      */
     @Override
     public int lengthOfMonth() {
-        return month > 0 ? DAYS_IN_MONTH : 1;
+        return DAYS_IN_MONTH + ((isYearDay || isLeapDay) ? 1 : 0);
     }
 
     /**
@@ -568,20 +552,11 @@ public final class InternationalFixedDate
     @Override
     public InternationalFixedDate with(TemporalField field, long newValue) {
         if (field instanceof ChronoField) {
-            if (newValue == 0 && day < 1) {
+            if (newValue == 0 && day == DAYS_IN_MONTH + 1) {
                 return this;
             }
 
             ChronoField f = (ChronoField) field;
-            if (f == ChronoField.DAY_OF_MONTH || f == ChronoField.MONTH_OF_YEAR) {
-                if (newValue == 0) {
-                    return create(prolepticYear, 0, 0);
-                }
-                if (newValue == -1) {
-                    return create(prolepticYear, -1, -1);
-                }
-            }
-
             getChronology().range(f).checkValidValue(newValue, f);
             int nval = (int) newValue;
 
@@ -589,15 +564,17 @@ public final class InternationalFixedDate
                 case ALIGNED_DAY_OF_WEEK_IN_MONTH:
                 case ALIGNED_DAY_OF_WEEK_IN_YEAR:
                 case DAY_OF_WEEK:
-                    int dom = isYearDay ? 21 : (getInternalDayOfMonth() / DAYS_IN_WEEK) * DAYS_IN_WEEK;
+                    int dom = (isYearDay || isLeapDay) ? 21 : ((getDayOfMonth() - 1 ) / DAYS_IN_WEEK) * DAYS_IN_WEEK;
                     return resolvePreviousValid(prolepticYear, month, dom + nval);
                 case ALIGNED_WEEK_OF_MONTH:
-                    int d = day < 1 ? 1 : day % DAYS_IN_WEEK;
+                    int d = day == DAYS_IN_MONTH + 1 ? 1 : day % DAYS_IN_WEEK;
                     return resolvePreviousValid(prolepticYear, month, (nval - 1) * DAYS_IN_WEEK + d);
                 case ALIGNED_WEEK_OF_YEAR:
                     int newMonth = 1 + ((nval - 1) / WEEKS_IN_MONTH);
-                    int newDay = ((nval - 1) % WEEKS_IN_MONTH) * DAYS_IN_WEEK + 1 + ((day < 1) ? 0 : (day - 1) % DAYS_IN_WEEK);
+                    int newDay = ((nval - 1) % WEEKS_IN_MONTH) * DAYS_IN_WEEK + 1 + ((day - 1) % DAYS_IN_WEEK);
                     return resolvePreviousValid(prolepticYear, newMonth, newDay);
+                case DAY_OF_MONTH:
+                    return create(prolepticYear, month, nval);
                 default:
                     break;
             }
@@ -642,6 +619,7 @@ public final class InternationalFixedDate
         int newYear = Math.toIntExact(Math.floorDiv(calcEm, WEEKS_IN_YEAR));
         int newWeek = Math.toIntExact(Math.floorMod(calcEm, WEEKS_IN_YEAR));
         int newMonth = 1 + Math.floorDiv(newWeek, WEEKS_IN_MONTH);
+        //int newDay = 1 + ((newWeek * DAYS_IN_WEEK + ((day - 1) % DAYS_IN_WEEK)) % DAYS_IN_MONTH);
         int newDay = 1 + ((newWeek * DAYS_IN_WEEK + 8 + (isLeapDay ? 0 : isYearDay ? -1 : (day - 1) % DAYS_IN_WEEK) - 1) % DAYS_IN_MONTH);
 
         return create(newYear, newMonth, newDay);
@@ -677,7 +655,7 @@ public final class InternationalFixedDate
 
     @Override
     public ValueRange range(TemporalField field) {
-        boolean special = this.day < 1;
+        boolean special = this.day == DAYS_IN_MONTH + 1;
 
         if (field instanceof ChronoField) {
             if (isSupported(field)) {
@@ -693,7 +671,7 @@ public final class InternationalFixedDate
                     case ALIGNED_WEEK_OF_YEAR:
                         return special ? EMPTY_RANGE : ValueRange.of(1, WEEKS_IN_YEAR);
                     case DAY_OF_MONTH:
-                        return this.isYearDay ? EMPTY_RANGE : isLeapDay ? ValueRange.of(-1, -1) : ValueRange.of(1, DAYS_IN_MONTH);
+                        return (month == MONTHS_IN_YEAR || (isLeapYear && month == 6)) ? ValueRange.of(1, DAYS_IN_MONTH + 1) : ValueRange.of(1, DAYS_IN_MONTH);
                     case DAY_OF_YEAR:
                         return this.isLeapYear ? DAY_OF_YEAR_LEAP_RANGE : DAY_OF_YEAR_NORMAL_RANGE;
                     case EPOCH_DAY:
@@ -714,7 +692,7 @@ public final class InternationalFixedDate
 
     @Override
     public int getAlignedDayOfWeekInMonth() {
-        if (day < 1) {
+        if (day == DAYS_IN_MONTH + 1) {
             return 0;
         }
         return ((day - 1) % lengthOfWeek()) + 1;
@@ -722,7 +700,7 @@ public final class InternationalFixedDate
 
     @Override
     int getAlignedDayOfWeekInYear() {
-        if (day < 1) {
+        if (day == DAYS_IN_MONTH + 1) {
             return 0;
         }
         return ((day - 1) % lengthOfWeek()) + 1;
@@ -730,7 +708,7 @@ public final class InternationalFixedDate
 
     @Override
     int getAlignedWeekOfMonth() {
-        if (day < 1) {
+        if (day == DAYS_IN_MONTH + 1) {
             return 0;
         }
         return ((day - 1) / lengthOfWeek()) + 1;
@@ -738,7 +716,7 @@ public final class InternationalFixedDate
 
     @Override
     int getAlignedWeekOfYear() {
-        if (day < 1) {
+        if (day == DAYS_IN_MONTH + 1) {
             return 0;
         }
 
@@ -754,7 +732,7 @@ public final class InternationalFixedDate
      */
     @Override
     public int getDayOfWeek() {
-        if (day < 1) {
+        if (day == DAYS_IN_MONTH + 1) {
             return 0;
         }
         return 1 + ((day - 1) % DAYS_IN_WEEK);
@@ -766,7 +744,7 @@ public final class InternationalFixedDate
     }
 
     long getProlepticWeek() {
-        return getProlepticMonth() * WEEKS_IN_MONTH + ((getInternalDayOfMonth() - 1) / DAYS_IN_WEEK) - 1;
+        return getProlepticMonth() * WEEKS_IN_MONTH + ((getDayOfMonth() - 1) / DAYS_IN_WEEK) - 1;
     }
 
     @Override
@@ -829,14 +807,16 @@ public final class InternationalFixedDate
         // When both Leap Day and Year Day start / end the period, the intra-month difference can be +- 28 days,
         // because internally day-of-month as 1 (Leap Day) or 29 (Year Day) for calculations.
         // Thus we have to compensate the difference accordingly.
-        if (days == DAYS_IN_MONTH) {
-            days = 0;
-            months += 1;
-        }
+        if ((!isYearDay && !isLeapDay) && !(end.isYearDay && !end.isLeapDay)) {
+            if (days == DAYS_IN_MONTH) {
+                days = 0;
+                months += 1;
+            }
 
-        if (days == -DAYS_IN_MONTH) {
-            days = 0;
-            months -= 1;
+            if (days == -DAYS_IN_MONTH) {
+                days = 0;
+                months -= 1;
+            }
         }
 
         return getChronology().period(years, months, days);
@@ -853,8 +833,8 @@ public final class InternationalFixedDate
     @Override
     long monthsUntil(AbstractDate end) {
         InternationalFixedDate date = InternationalFixedDate.from(end);
-        long monthStart = this.getProlepticMonth() * 32L + this.getInternalDayOfMonth();
-        long monthEnd = date.getProlepticMonth() * 32L + date.getInternalDayOfMonth();
+        long monthStart = this.getProlepticMonth() * 32L + this.getDayOfMonth();
+        long monthEnd = date.getProlepticMonth() * 32L + date.getDayOfMonth();
 
         return (monthEnd - monthStart) / 32L;
     }
@@ -883,7 +863,7 @@ public final class InternationalFixedDate
                 .append(getYearOfEra())
                 .append(this.month < 10 && this.month > 0 ? "/0" : '/')
                 .append(this.month)
-                .append(this.day < 10 && this.day > 0 ? "/0" : '/')
+                .append(this.day < 10 ? "/0" : '/')
                 .append(this.day)
                 .toString();
     }

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -127,20 +127,20 @@ public class TestInternationalFixedChronology {
 
             {InternationalFixedDate.of(1, 13, 28), LocalDate.of(1, 12, 30)},
             {InternationalFixedDate.of(1, 13, 27), LocalDate.of(1, 12, 29)},
-            {InternationalFixedDate.of(1, 0, 0), LocalDate.of(1, 12, 31)},
+            {InternationalFixedDate.of(1, 13, 29), LocalDate.of(1, 12, 31)},
             {InternationalFixedDate.yearDay(1), LocalDate.of(1, 12, 31)},
             {InternationalFixedDate.of(2, 1, 1), LocalDate.of(2, 1, 1)},
 
             {InternationalFixedDate.of(4, 6, 27), LocalDate.of(4, 6, 15)},
             {InternationalFixedDate.of(4, 6, 28), LocalDate.of(4, 6, 16)},
-            {InternationalFixedDate.of(4, -1, -1), LocalDate.of(4, 6, 17)},
+            {InternationalFixedDate.of(4, 6, 29), LocalDate.of(4, 6, 17)},
             {InternationalFixedDate.leapDay(4), LocalDate.of(4, 6, 17)},
             {InternationalFixedDate.of(4, 7, 1), LocalDate.of(4, 6, 18)},
             {InternationalFixedDate.of(4, 7, 2), LocalDate.of(4, 6, 19)},
 
             {InternationalFixedDate.of(4, 13, 28), LocalDate.of(4, 12, 30)},
             {InternationalFixedDate.of(4, 13, 27), LocalDate.of(4, 12, 29)},
-            {InternationalFixedDate.of(4, 0, 0), LocalDate.of(4, 12, 31)},
+            {InternationalFixedDate.of(4, 13, 29), LocalDate.of(4, 12, 31)},
             {InternationalFixedDate.yearDay(4), LocalDate.of(4, 12, 31)},
             {InternationalFixedDate.of(5, 1, 1), LocalDate.of(5, 1, 1)},
 
@@ -151,7 +151,7 @@ public class TestInternationalFixedChronology {
 
             {InternationalFixedDate.of(400, 6, 27), LocalDate.of(400, 6, 15)},
             {InternationalFixedDate.of(400, 6, 28), LocalDate.of(400, 6, 16)},
-            {InternationalFixedDate.of(400, -1, -1), LocalDate.of(400, 6, 17)},
+            {InternationalFixedDate.of(400, 6, 29), LocalDate.of(400, 6, 17)},
             {InternationalFixedDate.leapDay(400), LocalDate.of(400, 6, 17)},
             {InternationalFixedDate.of(400, 7, 1), LocalDate.of(400, 6, 18)},
             {InternationalFixedDate.of(400, 7, 2), LocalDate.of(400, 6, 19)},
@@ -242,7 +242,7 @@ public class TestInternationalFixedChronology {
     Object[][] data_badDates() {
         return new Object[][] {
             {-1, 13, 28},
-            {-1, 0, 0},
+            {-1, 13, 29},
             {0, 1, 1},
 
             {1900, -2, 1},
@@ -257,7 +257,6 @@ public class TestInternationalFixedChronology {
             {1904, -1, 0},
             {1904, -1, 1},
 
-            {1900, -1, -1},
             {1900, -1, 0},
             {1900, -1, -2},
 
@@ -276,7 +275,7 @@ public class TestInternationalFixedChronology {
             {1900, 10, 29},
             {1900, 11, 29},
             {1900, 12, 29},
-            {1900, 13, 29},
+            {1900, 13, 30},
         };
     }
 
@@ -338,35 +337,36 @@ public class TestInternationalFixedChronology {
     @DataProvider(name = "lengthOfMonth")
     Object[][] data_lengthOfMonth() {
         return new Object[][] {
-            {1900, 1, 28},
-            {1900, 2, 28},
-            {1900, 3, 28},
-            {1900, 4, 28},
-            {1900, 5, 28},
-            {1900, 6, 28},
-            {1900, 7, 28},
-            {1900, 8, 28},
-            {1900, 9, 28},
-            {1900, 10, 28},
-            {1900, 11, 28},
-            {1900, 12, 28},
-            {1900, 13, 28},
+            {1900, 1, 28, 28},
+            {1900, 2, 28, 28},
+            {1900, 3, 28, 28},
+            {1900, 4, 28, 28},
+            {1900, 5, 28, 28},
+            {1900, 6, 28, 28},
+            {1900, 7, 28, 28},
+            {1900, 8, 28, 28},
+            {1900, 9, 28, 28},
+            {1900, 10, 28, 28},
+            {1900, 11, 28, 28},
+            {1900, 12, 28, 28},
+            {1900, 13, 29, 29},
+            {1904, 6, 29, 29},
         };
     }
 
     @Test(dataProvider = "lengthOfMonth")
-    public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(InternationalFixedDate.of(year, month, 1).lengthOfMonth(), length);
+    public void test_lengthOfMonth(int year, int month, int day, int length) {
+        assertEquals(InternationalFixedDate.of(year, month, day).lengthOfMonth(), length);
     }
 
     @Test
     public void test_lengthOfMonth_specific() {
-        assertEquals(InternationalFixedDate.yearDay(1900).lengthOfMonth(), 1);
-        assertEquals(InternationalFixedDate.of(1900, 0, 0).lengthOfMonth(), 1);
-        assertEquals(InternationalFixedDate.yearDay(2000).lengthOfMonth(), 1);
-        assertEquals(InternationalFixedDate.of(2000, 0, 0).lengthOfMonth(), 1);
-        assertEquals(InternationalFixedDate.leapDay(2000).lengthOfMonth(), 1);
-        assertEquals(InternationalFixedDate.of(2000, -1, -1).lengthOfMonth(), 1);
+        assertEquals(InternationalFixedDate.yearDay(1900).lengthOfMonth(), 29);
+        assertEquals(InternationalFixedDate.of(1900, 13, 29).lengthOfMonth(), 29);
+        assertEquals(InternationalFixedDate.yearDay(2000).lengthOfMonth(), 29);
+        assertEquals(InternationalFixedDate.of(2000, 13, 29).lengthOfMonth(), 29);
+        assertEquals(InternationalFixedDate.leapDay(2000).lengthOfMonth(), 29);
+        assertEquals(InternationalFixedDate.of(2000, 6, 29).lengthOfMonth(), 29);
     }
 
     //-----------------------------------------------------------------------
@@ -454,11 +454,11 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH), ValueRange.of(1, 4));
         assertEquals(InternationalFixedChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(0, 52));
         assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(-1, 0, -1, 28));
+        assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 29));
         assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
         assertEquals(InternationalFixedChronology.INSTANCE.range(ERA), ValueRange.of(1, 1));
         assertEquals(InternationalFixedChronology.INSTANCE.range(EPOCH_DAY), ValueRange.of(-719_528, 1_000_000 * 365L + 242_499 - 719_528));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(-1, 0, 13, 13));
+        assertEquals(InternationalFixedChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
         assertEquals(InternationalFixedChronology.INSTANCE.range(PROLEPTIC_MONTH), ValueRange.of(13, 1_000_000 * 13L - 1));
         assertEquals(InternationalFixedChronology.INSTANCE.range(YEAR), ValueRange.of(1, 1_000_000));
         assertEquals(InternationalFixedChronology.INSTANCE.range(YEAR_OF_ERA), ValueRange.of(1, 1_000_000));
@@ -470,41 +470,41 @@ public class TestInternationalFixedChronology {
     @DataProvider(name = "ranges")
     Object[][] data_ranges() {
         return new Object[][] {
-            // Leap Day and Year Day are in their own 'months', so (0 to 0), (-1 to -1), or (1 to 28)
-            {2012, -1, -1, DAY_OF_MONTH, ValueRange.of(-1, -1)},
-            {2012, 0, 0, DAY_OF_MONTH, ValueRange.of(0, 0)},
+            // Leap Day and Year Day are members of months
+            {2012, 6, 29, DAY_OF_MONTH, ValueRange.of(1, 29)},
+            {2012, 13, 29, DAY_OF_MONTH, ValueRange.of(1, 29)},
             {2012, 1, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 2, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 3, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 4, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 5, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
-            {2012, 6, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
+            {2012, 6, 23, DAY_OF_MONTH, ValueRange.of(1, 29)},
             {2012, 7, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 8, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 9, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 10, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 11, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
             {2012, 12, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
-            {2012, 13, 23, DAY_OF_MONTH, ValueRange.of(1, 28)},
+            {2012, 13, 23, DAY_OF_MONTH, ValueRange.of(1, 29)},
 
             {2012, 1, 23, DAY_OF_YEAR, ValueRange.of(1, 366)},
-            // Leap Day is still in same year, so (-1 to 13) in leap year
-            {2012, 1, 23, MONTH_OF_YEAR, ValueRange.of(-1, 0, 13, 13)},
+            // Leap Day is still in same year, so (1 to 13) in leap year
+            {2012, 1, 23, MONTH_OF_YEAR, ValueRange.of(1, 13)},
             // Leap Day/Year Day in own months, so (0 to 0) or (1 to 7)
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, ValueRange.of(0, 0)},
-            {2012, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, ValueRange.of(0, 0)},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, ValueRange.of(0, 0)},
+            {2012, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, ValueRange.of(0, 0)},
             {2012, 1, 23, ALIGNED_DAY_OF_WEEK_IN_MONTH, ValueRange.of(1, 7)},
             // Leap Day/Year Day in own months, so (0 to 0) or (1 to 4)
-            {2012, -1, -1, ALIGNED_WEEK_OF_MONTH, ValueRange.of(0, 0)},
-            {2012, 0, 0, ALIGNED_WEEK_OF_MONTH, ValueRange.of(0, 0)},
+            {2012, 6, 29, ALIGNED_WEEK_OF_MONTH, ValueRange.of(0, 0)},
+            {2012, 13, 29, ALIGNED_WEEK_OF_MONTH, ValueRange.of(0, 0)},
             {2012, 1, 23, ALIGNED_WEEK_OF_MONTH, ValueRange.of(1, 4)},
             // Leap Day and Year Day in own 'week's, so (0 to 0) or (1 to 7)
-            {2012, -1, -1, DAY_OF_WEEK, ValueRange.of(0, 0)},
-            {2012, 0, 0, DAY_OF_WEEK, ValueRange.of(0, 0)},
+            {2012, 6, 29, DAY_OF_WEEK, ValueRange.of(0, 0)},
+            {2012, 13, 29, DAY_OF_WEEK, ValueRange.of(0, 0)},
             {2012, 1, 23, DAY_OF_WEEK, ValueRange.of(1, 7)},
 
             {2011, 13, 23, DAY_OF_YEAR, ValueRange.of(1, 365)},
-            {2011, 13, 23, MONTH_OF_YEAR, ValueRange.of(-1, 0, 13, 13)},
+            {2011, 13, 23, MONTH_OF_YEAR, ValueRange.of(1, 13)},
         };
     }
 
@@ -546,26 +546,26 @@ public class TestInternationalFixedChronology {
             {2012, 9, 28, ALIGNED_WEEK_OF_YEAR, 36},
             {2014, 9, 28, ALIGNED_WEEK_OF_YEAR, 36},
 
-            {2014, 0, 0, DAY_OF_WEEK, 0},
-            {2014, 0, 0, DAY_OF_MONTH, 0},
-            {2014, 0, 0, DAY_OF_YEAR, 13 * 28 + 1},
-            {2012, 0, 0, DAY_OF_YEAR, 13 * 28 + 1 + 1},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0},
-            {2014, 0, 0, ALIGNED_WEEK_OF_MONTH, 0},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0},
-            {2014, 0, 0, ALIGNED_WEEK_OF_YEAR, 0},
-            {2014, 0, 0, MONTH_OF_YEAR, 0},
-            {2014, 0, 0, PROLEPTIC_MONTH, 2014 * 13 + 13 - 1},
+            {2014, 13, 29, DAY_OF_WEEK, 0},
+            {2014, 13, 29, DAY_OF_MONTH, 29},
+            {2014, 13, 29, DAY_OF_YEAR, 13 * 28 + 1},
+            {2012, 13, 29, DAY_OF_YEAR, 13 * 28 + 1 + 1},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0},
+            {2014, 13, 29, ALIGNED_WEEK_OF_MONTH, 0},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0},
+            {2014, 13, 29, ALIGNED_WEEK_OF_YEAR, 0},
+            {2014, 13, 29, MONTH_OF_YEAR, 13},
+            {2014, 13, 29, PROLEPTIC_MONTH, 2014 * 13 + 13 - 1},
 
-            {2012, -1, -1, DAY_OF_WEEK, 0},
-            {2012, -1, -1, DAY_OF_MONTH, -1},
-            {2012, -1, -1, DAY_OF_YEAR, 6 * 28 + 1},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0},
-            {2012, -1, -1, ALIGNED_WEEK_OF_MONTH, 0},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0},
-            {2012, -1, -1, ALIGNED_WEEK_OF_YEAR, 0},
-            {2012, -1, -1, MONTH_OF_YEAR, -1},
-            {2012, -1, -1, PROLEPTIC_MONTH, 2012 * 13 + 7 - 1},
+            {2012, 6, 29, DAY_OF_WEEK, 0},
+            {2012, 6, 29, DAY_OF_MONTH, 29},
+            {2012, 6, 29, DAY_OF_YEAR, 6 * 28 + 1},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0},
+            {2012, 6, 29, ALIGNED_WEEK_OF_MONTH, 0},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0},
+            {2012, 6, 29, ALIGNED_WEEK_OF_YEAR, 0},
+            {2012, 6, 29, MONTH_OF_YEAR, 6},
+            {2012, 6, 29, PROLEPTIC_MONTH, 2012 * 13 + 6 - 1},
         };
     }
 
@@ -609,108 +609,106 @@ public class TestInternationalFixedChronology {
             {2014, 5, 26, YEAR_OF_ERA, 2014, 2014, 5, 26},
             {2014, 5, 26, ERA, 1, 2014, 5, 26},
 
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0, 2014, 0, 0},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 1, 2014, 13, 22},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 2, 2014, 13, 23},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 3, 2014, 13, 24},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 4, 2014, 13, 25},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 5, 2014, 13, 26},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 6, 2014, 13, 27},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_MONTH, 7, 2014, 13, 28},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0, 2014, 13, 29},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 1, 2014, 13, 22},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 2, 2014, 13, 23},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 3, 2014, 13, 24},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 4, 2014, 13, 25},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 5, 2014, 13, 26},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 6, 2014, 13, 27},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 7, 2014, 13, 28},
 
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0, 2014, 0, 0},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 1, 2014, 13, 22},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 2, 2014, 13, 23},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 3, 2014, 13, 24},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 4, 2014, 13, 25},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 5, 2014, 13, 26},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 6, 2014, 13, 27},
-            {2014, 0, 0, ALIGNED_DAY_OF_WEEK_IN_YEAR, 7, 2014, 13, 28},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0, 2014, 13, 29},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 1, 2014, 13, 22},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 2, 2014, 13, 23},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 3, 2014, 13, 24},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 4, 2014, 13, 25},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 5, 2014, 13, 26},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 6, 2014, 13, 27},
+            {2014, 13, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 7, 2014, 13, 28},
 
-            {2014, 0, 0, ALIGNED_WEEK_OF_MONTH, 0, 2014, 0, 0},
-            {2014, 0, 0, ALIGNED_WEEK_OF_MONTH, 3, 2014, 13, 15},
+            {2014, 13, 29, ALIGNED_WEEK_OF_MONTH, 0, 2014, 13, 29},
+            {2014, 13, 29, ALIGNED_WEEK_OF_MONTH, 3, 2014, 13, 15},
 
-            {2014, 0, 0, ALIGNED_WEEK_OF_YEAR, 0, 2014, 0, 0},
-            {2014, 0, 0, ALIGNED_WEEK_OF_YEAR, 3, 2014, 1, 15},
+            {2014, 13, 29, ALIGNED_WEEK_OF_YEAR, 0, 2014, 13, 29},
+            {2014, 13, 29, ALIGNED_WEEK_OF_YEAR, 3, 2014, 1, 15},
 
-            {2014, 0, 0, DAY_OF_WEEK, 0, 2014, 0, 0},
-            {2014, 0, 0, DAY_OF_WEEK, 1, 2014, 13, 22},
-            {2014, 0, 0, DAY_OF_WEEK, 2, 2014, 13, 23},
-            {2014, 0, 0, DAY_OF_WEEK, 3, 2014, 13, 24},
-            {2014, 0, 0, DAY_OF_WEEK, 4, 2014, 13, 25},
-            {2014, 0, 0, DAY_OF_WEEK, 5, 2014, 13, 26},
-            {2014, 0, 0, DAY_OF_WEEK, 6, 2014, 13, 27},
-            {2014, 0, 0, DAY_OF_WEEK, 7, 2014, 13, 28},
+            {2014, 13, 29, DAY_OF_WEEK, 0, 2014, 13, 29},
+            {2014, 13, 28, DAY_OF_WEEK, 1, 2014, 13, 22},
+            {2014, 13, 28, DAY_OF_WEEK, 2, 2014, 13, 23},
+            {2014, 13, 28, DAY_OF_WEEK, 3, 2014, 13, 24},
+            {2014, 13, 28, DAY_OF_WEEK, 4, 2014, 13, 25},
+            {2014, 13, 28, DAY_OF_WEEK, 5, 2014, 13, 26},
+            {2014, 13, 28, DAY_OF_WEEK, 6, 2014, 13, 27},
+            {2014, 13, 28, DAY_OF_WEEK, 7, 2014, 13, 28},
 
-            {2014, 0, 0, DAY_OF_MONTH, 0, 2014, 0, 0},
-            {2014, 0, 0, DAY_OF_MONTH, 3, 2014, 13, 3},
+            {2014, 13, 29, DAY_OF_MONTH, 1, 2014, 13, 1},
+            {2014, 13, 29, DAY_OF_MONTH, 3, 2014, 13, 3},
 
-            {2014, 0, 0, MONTH_OF_YEAR, 0, 2014, 0, 0},
-            {2014, 0, 0, MONTH_OF_YEAR, 13, 2014, 13, 28},
-            {2014, 0, 0, MONTH_OF_YEAR, 2, 2014, 2, 28},
+            {2014, 13, 29, MONTH_OF_YEAR, 1, 2014, 1, 28},
+            {2014, 13, 29, MONTH_OF_YEAR, 13, 2014, 13, 29},
+            {2014, 13, 29, MONTH_OF_YEAR, 2, 2014, 2, 28},
 
-            {2014, 0, 0, YEAR, 2014, 2014, 0, 0},
-            {2014, 0, 0, YEAR, 2013, 2013, 0, 0},
+            {2014, 13, 29, YEAR, 2014, 2014, 13, 29},
+            {2014, 13, 29, YEAR, 2013, 2013, 13, 29},
 
-            {2014, 3, 28, DAY_OF_MONTH, 0, 2014, 0, 0},
-            {2014, 1, 28, DAY_OF_MONTH, 0, 2014, 0, 0},
-            {2014, 3, 28, MONTH_OF_YEAR, 0, 2014, 0, 0},
-            {2014, 3, 28, DAY_OF_YEAR, 365, 2014, 0, 0},
-            {2012, 3, 28, DAY_OF_YEAR, 366, 2012, 0, 0},
+            {2014, 3, 28, DAY_OF_MONTH, 1, 2014, 3, 1},
+            {2014, 1, 28, DAY_OF_MONTH, 1, 2014, 1, 1},
+            {2014, 3, 28, MONTH_OF_YEAR, 1, 2014, 1, 28},
+            {2014, 3, 28, DAY_OF_YEAR, 365, 2014, 13, 29},
+            {2012, 3, 28, DAY_OF_YEAR, 366, 2012, 13, 29},
 
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0, 2012, -1, -1},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 1, 2012, 7, 1},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 2, 2012, 7, 2},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 3, 2012, 7, 3},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 4, 2012, 7, 4},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 5, 2012, 7, 5},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 6, 2012, 7, 6},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 7, 2012, 7, 7},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0, 2012, 6, 29},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 1, 2012, 6, 22},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 2, 2012, 6, 23},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 3, 2012, 6, 24},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 4, 2012, 6, 25},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 5, 2012, 6, 26},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 6, 2012, 6, 27},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_MONTH, 7, 2012, 6, 28},
 
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0, 2012, -1, -1},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 1, 2012, 7, 1},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 2, 2012, 7, 2},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 3, 2012, 7, 3},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 4, 2012, 7, 4},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 5, 2012, 7, 5},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 6, 2012, 7, 6},
-            {2012, -1, -1, ALIGNED_DAY_OF_WEEK_IN_YEAR, 7, 2012, 7, 7},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 0, 2012, 6, 29},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 1, 2012, 6, 22},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 2, 2012, 6, 23},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 3, 2012, 6, 24},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 4, 2012, 6, 25},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 5, 2012, 6, 26},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 6, 2012, 6, 27},
+            {2012, 6, 29, ALIGNED_DAY_OF_WEEK_IN_YEAR, 7, 2012, 6, 28},
 
-            {2012, -1, -1, ALIGNED_WEEK_OF_MONTH, 0, 2012, -1, -1},
-            {2012, -1, -1, ALIGNED_WEEK_OF_MONTH, 3, 2012, 7, 15},
+            {2012, 6, 29, ALIGNED_WEEK_OF_MONTH, 0, 2012, 6, 29},
+            {2012, 6, 29, ALIGNED_WEEK_OF_MONTH, 3, 2012, 6, 15},
 
-            {2012, -1, -1, ALIGNED_WEEK_OF_YEAR, 0, 2012, -1, -1},
-            {2012, -1, -1, ALIGNED_WEEK_OF_YEAR, 3, 2012, 1, 15},
+            {2012, 6, 29, ALIGNED_WEEK_OF_YEAR, 0, 2012, 6, 29},
+            {2012, 6, 29, ALIGNED_WEEK_OF_YEAR, 3, 2012, 1, 15},
             {2012, 1, 1, ALIGNED_WEEK_OF_YEAR, 52, 2012, 13, 22},
             {2012, 13, 28, ALIGNED_WEEK_OF_YEAR, 1, 2012, 1, 7},
 
-            {2012, -1, -1, DAY_OF_WEEK, 0, 2012, -1, -1},
-            {2012, -1, -1, DAY_OF_WEEK, 1, 2012, 7, 1},
-            {2012, -1, -1, DAY_OF_WEEK, 2, 2012, 7, 2},
-            {2012, -1, -1, DAY_OF_WEEK, 3, 2012, 7, 3},
-            {2012, -1, -1, DAY_OF_WEEK, 4, 2012, 7, 4},
-            {2012, -1, -1, DAY_OF_WEEK, 5, 2012, 7, 5},
-            {2012, -1, -1, DAY_OF_WEEK, 6, 2012, 7, 6},
-            {2012, -1, -1, DAY_OF_WEEK, 7, 2012, 7, 7},
+            {2012, 6, 29, DAY_OF_WEEK, 0, 2012, 6, 29},
+            {2012, 6, 29, DAY_OF_WEEK, 1, 2012, 6, 22},
+            {2012, 6, 29, DAY_OF_WEEK, 2, 2012, 6, 23},
+            {2012, 6, 29, DAY_OF_WEEK, 3, 2012, 6, 24},
+            {2012, 6, 29, DAY_OF_WEEK, 4, 2012, 6, 25},
+            {2012, 6, 29, DAY_OF_WEEK, 5, 2012, 6, 26},
+            {2012, 6, 29, DAY_OF_WEEK, 6, 2012, 6, 27},
+            {2012, 6, 29, DAY_OF_WEEK, 7, 2012, 6, 28},
 
-            {2012, -1, -1, DAY_OF_MONTH, 0, 2012, -1, -1},
-            {2012, -1, -1, DAY_OF_MONTH, -1, 2012, -1, -1},
-            {2012, -1, -1, DAY_OF_MONTH, 3, 2012, 7, 3},
+            {2012, 6, 29, DAY_OF_MONTH, 1, 2012, 6, 1},
+            {2012, 6, 29, DAY_OF_MONTH, 3, 2012, 6, 3},
 
-            {2012, -1, -1, MONTH_OF_YEAR, -1, 2012, -1, -1},
-            {2012, -1, -1, MONTH_OF_YEAR, 0, 2012, -1, -1},
-            {2012, -1, -1, MONTH_OF_YEAR, 7, 2012, 7, 1},
-            {2012, -1, -1, MONTH_OF_YEAR, 2, 2012, 2, 1},
+            {2012, 6, 29, MONTH_OF_YEAR, 6, 2012, 6, 29},
+            {2012, 6, 29, MONTH_OF_YEAR, 7, 2012, 7, 28},
+            {2012, 6, 29, MONTH_OF_YEAR, 2, 2012, 2, 28},
 
-            {2012, -1, -1, YEAR, 2012, 2012, -1, -1},
-            {2012, -1, -1, YEAR, 2013, 2013, 7, 1},
-            {2012, -1, -1, YEAR, 2011, 2011, 7, 1},
-            {2012, -1, -1, YEAR, 2016, 2016, -1, -1},
+            {2012, 6, 29, YEAR, 2012, 2012, 6, 29},
+            {2012, 6, 29, YEAR, 2013, 2013, 6, 28},
+            {2012, 6, 29, YEAR, 2011, 2011, 6, 28},
+            {2012, 6, 29, YEAR, 2016, 2016, 6, 29},
 
-            {2012, 3, 28, DAY_OF_MONTH, -1, 2012, -1, -1},
-            {2012, 1, 28, DAY_OF_MONTH, -1, 2012, -1, -1},
-            {2012, 3, 28, MONTH_OF_YEAR, -1, 2012, -1, -1},
-            {2012, 3, 28, DAY_OF_YEAR, 169, 2012, -1, -1},
+            {2012, 3, 28, DAY_OF_MONTH, 1, 2012, 3, 1},
+            {2012, 1, 28, DAY_OF_MONTH, 1, 2012, 1, 1},
+            {2012, 3, 28, MONTH_OF_YEAR, 1, 2012, 1, 28},
+            {2012, 3, 28, DAY_OF_YEAR, 169, 2012, 6, 29},
             {2013, 3, 28, DAY_OF_YEAR, 169, 2013, 7, 1},
             {2013, 7, 1, YEAR, 2012, 2012, 7, 1},
         };
@@ -752,8 +750,12 @@ public class TestInternationalFixedChronology {
             {2012, 1, 1, DAY_OF_WEEK, 8},
             {2013, 1, 1, DAY_OF_MONTH, -1},
             {2013, 1, 1, DAY_OF_MONTH, 29},
+            {2013, 6, 1, DAY_OF_MONTH, 29},
+            {2012, 6, 1, DAY_OF_MONTH, 30},
             {2012, 1, 1, DAY_OF_MONTH, -2},
             {2012, 1, 1, DAY_OF_MONTH, 29},
+            {2013, 13, 1, DAY_OF_MONTH, 30},
+            {2012, 13, 1, DAY_OF_MONTH, 30},
 
             {2013, 1, 1, DAY_OF_YEAR, 0},
             {2012, 1, 1, DAY_OF_YEAR, 0},
@@ -785,18 +787,23 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // InternationalFixedDate.with(TemporalAdjuster)
     //-----------------------------------------------------------------------
-    @Test
-    public void test_adjust1() {
-        InternationalFixedDate base = InternationalFixedDate.of(2012, 6, 23);
-        InternationalFixedDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, InternationalFixedDate.of(2012, 6, 28));
+    @DataProvider(name = "temporalAdjusters_lastDayOfMonth")
+    Object[][] data_temporalAdjusters_lastDayOfMonth() {
+        return new Object[][] {
+            {2012, 6, 23, 2012, 6, 29},
+            {2012, 6, 29, 2012, 6, 29},
+            {2009, 6, 23, 2009, 6, 28},
+            {2007, 13, 23, 2007, 13, 29},
+            {2005, 13, 29, 2005, 13, 29},
+        };
     }
 
-    @Test
-    public void test_adjust2() {
-        InternationalFixedDate base = InternationalFixedDate.of(2012, -1, -1);
-        InternationalFixedDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, InternationalFixedDate.of(2012, -1, -1));
+    @Test(dataProvider = "temporalAdjusters_lastDayOfMonth")
+    public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
+        InternationalFixedDate base = InternationalFixedDate.of(year, month, day);
+        InternationalFixedDate expected = InternationalFixedDate.of(expectedYear, expectedMonth, expectedDay);
+        InternationalFixedDate actual = base.with(TemporalAdjusters.lastDayOfMonth());
+        assertEquals(actual, expected);
     }
 
     //-----------------------------------------------------------------------
@@ -875,84 +882,84 @@ public class TestInternationalFixedChronology {
     @DataProvider(name = "plus_leap_and_year_day")
     Object[][] data_plus_leap_and_year_day() {
         return new Object[][] {
-            {2014, 0, 0, 0, DAYS, 2014, 0, 0},
-            {2014, 0, 0, 8, DAYS, 2015, 1, 8},
-            {2014, 0, 0, -3, DAYS, 2014, 13, 26},
-            {2014, 0, 0, 0, WEEKS, 2014, 0, 0},
-            {2014, 0, 0, 3, WEEKS, 2015, 1, 21},
-            {2014, 0, 0, -5, WEEKS, 2014, 12, 21},
-            {2014, 0, 0, 52, WEEKS, 2015, 0, 0},
-            {2014, 0, 0, 0, MONTHS, 2014, 0, 0},
-            {2014, 0, 0, 3, MONTHS, 2015, 3, 28},
-            {2014, 0, 0, -5, MONTHS, 2014, 8, 28},
-            {2014, 0, 0, 13, MONTHS, 2015, 0, 0},
-            {2014, 0, 0, 0, YEARS, 2014, 0, 0},
-            {2014, 0, 0, 3, YEARS, 2017, 0, 0},
-            {2014, 0, 0, -5, YEARS, 2009, 0, 0},
+            {2014, 13, 29, 0, DAYS, 2014, 13, 29},
+            {2014, 13, 29, 8, DAYS, 2015, 1, 8},
+            {2014, 13, 29, -3, DAYS, 2014, 13, 26},
+            {2014, 13, 29, 0, WEEKS, 2014, 13, 29},
+            {2014, 13, 29, 3, WEEKS, 2015, 1, 21},
+            {2014, 13, 29, -5, WEEKS, 2014, 12, 21},
+            {2014, 13, 29, 52, WEEKS, 2015, 13, 29},
+            {2014, 13, 29, 0, MONTHS, 2014, 13, 29},
+            {2014, 13, 29, 3, MONTHS, 2015, 3, 28},
+            {2014, 13, 29, -5, MONTHS, 2014, 8, 28},
+            {2014, 13, 29, 13, MONTHS, 2015, 13, 29},
+            {2014, 13, 29, 0, YEARS, 2014, 13, 29},
+            {2014, 13, 29, 3, YEARS, 2017, 13, 29},
+            {2014, 13, 29, -5, YEARS, 2009, 13, 29},
 
-            {2011, 0, 0, 4 * 6, WEEKS, 2012, 6, 28},
-            {2012, 0, 0, 4 * -7, WEEKS, 2012, 6, 28},
+            {2011, 13, 29, 4 * 6, WEEKS, 2012, 6, 29},
+            {2012, 13, 29, 4 * -7, WEEKS, 2012, 6, 29},
 
-            {2012, -1, -1, 0, DAYS, 2012, -1, -1},
-            {2012, -1, -1, 8, DAYS, 2012, 7, 8},
-            {2012, -1, -1, -3, DAYS, 2012, 6, 26},
-            {2012, -1, -1, 0, WEEKS, 2012, -1, -1},
-            {2012, -1, -1, 3, WEEKS, 2012, 7, 22},
-            {2012, -1, -1, -5, WEEKS, 2012, 5, 22},
-            {2012, -1, -1, 52 * 4, WEEKS, 2016, -1, -1},
-            {2012, -1, -1, 0, MONTHS, 2012, -1, -1},
-            {2012, -1, -1, 3, MONTHS, 2012, 10, 1},
-            {2012, -1, -1, -5, MONTHS, 2012, 2, 1},
-            {2012, -1, -1, 13 * 4, MONTHS, 2016, -1, -1},
-            {2012, -1, -1, 0, YEARS, 2012, -1, -1},
-            {2012, -1, -1, 3, YEARS, 2015, 7, 1},
-            {2012, -1, -1, -5, YEARS, 2007, 7, 1},
-            {2012, -1, -1, 4, YEARS, 2016, -1, -1},
+            {2012, 6, 29, 0, DAYS, 2012, 6, 29},
+            {2012, 6, 29, 8, DAYS, 2012, 7, 8},
+            {2012, 6, 29, -3, DAYS, 2012, 6, 26},
+            {2012, 6, 29, 0, WEEKS, 2012, 6, 29},
+            {2012, 6, 29, 3, WEEKS, 2012, 7, 22},
+            {2012, 6, 29, -5, WEEKS, 2012, 5, 22},
+            {2012, 6, 29, 52 * 4, WEEKS, 2016, 6, 29},
+            {2012, 6, 29, 0, MONTHS, 2012, 6, 29},
+            {2012, 6, 29, 3, MONTHS, 2012, 9, 28},
+            {2012, 6, 29, -5, MONTHS, 2012, 1, 28},
+            {2012, 6, 29, 13 * 4, MONTHS, 2016, 6, 29},
+            {2012, 6, 29, 0, YEARS, 2012, 6, 29},
+            {2012, 6, 29, 3, YEARS, 2015, 6, 28},
+            {2012, 6, 29, -5, YEARS, 2007, 6, 28},
+            {2012, 6, 29, 4, YEARS, 2016, 6, 29},
 
-            {2012, -1, -1, 4 * 7, WEEKS, 2013, 1, 1},
-            {2012, -1, -1, 4 * -6, WEEKS, 2012, 1, 1},
+            {2012, 6, 29, 4 * 7, WEEKS, 2012, 13, 29},
+            {2012, 6, 29, 4 * -6, WEEKS, 2011, 13, 29},
         };
     }
 
     @DataProvider(name = "minus_leap_and_year_day")
     Object[][] data_minus_leap_and_year_day() {
         return new Object[][] {
-            {2014, 0, 0, 0, DAYS, 2014, 0, 0},
-            {2014, 13, 21, 8, DAYS, 2014, 0, 0},
-            {2015, 1, 3, -3, DAYS, 2014, 0, 0},
-            {2014, 0, 0, 0, WEEKS, 2014, 0, 0},
-            {2014, 13, 7, 3, WEEKS, 2014, 0, 0},
-            {2015, 2, 7, -5, WEEKS, 2014, 0, 0},
-            {2013, 0, 0, 52, WEEKS, 2014, 0, 0},
-            {2014, 0, 0, 0, MONTHS, 2014, 0, 0},
-            {2014, 10, 28, 3, MONTHS, 2014, 0, 0},
-            {2015, 5, 28, -5, MONTHS, 2014, 0, 0},
-            {2013, 0, 0, 13, MONTHS, 2014, 0, 0},
-            {2014, 0, 0, 0, YEARS, 2014, 0, 0},
-            {2011, 0, 0, 3, YEARS, 2014, 0, 0},
-            {2019, 0, 0, -5, YEARS, 2014, 0, 0},
+            {2014, 13, 29, 0, DAYS, 2014, 13, 29},
+            {2014, 13, 21, 8, DAYS, 2014, 13, 29},
+            {2015, 1, 3, -3, DAYS, 2014, 13, 29},
+            {2014, 13, 29, 0, WEEKS, 2014, 13, 29},
+            {2014, 13, 7, 3, WEEKS, 2014, 13, 29},
+            {2015, 2, 7, -5, WEEKS, 2014, 13, 29},
+            {2013, 13, 29, 52, WEEKS, 2014, 13, 29},
+            {2014, 13, 29, 0, MONTHS, 2014, 13, 29},
+            {2014, 10, 28, 3, MONTHS, 2014, 13, 29},
+            {2015, 5, 28, -5, MONTHS, 2014, 13, 29},
+            {2013, 13, 29, 13, MONTHS, 2014, 13, 29},
+            {2014, 13, 29, 0, YEARS, 2014, 13, 29},
+            {2011, 13, 29, 3, YEARS, 2014, 13, 29},
+            {2019, 13, 29, -5, YEARS, 2014, 13, 29},
 
-            {2012, 6, 28, 4 * -6, WEEKS, 2011, 0, 0},
-            {2012, 6, 28, 4 * 7, WEEKS, 2012, 0, 0},
+            {2012, 6, 29, 4 * -6, WEEKS, 2011, 13, 29},
+            {2012, 6, 29, 4 * 7, WEEKS, 2012, 13, 29},
 
-            {2012, -1, -1, 0, DAYS, 2012, -1, -1},
-            {2012, 6, 21, 8, DAYS, 2012, -1, -1},
-            {2012, 7, 3, -3, DAYS, 2012, -1, -1},
-            {2012, -1, -1, 0, WEEKS, 2012, -1, -1},
-            {2012, 6, 8, 3, WEEKS, 2012, -1, -1},
-            {2012, 8, 8, -5, WEEKS, 2012, -1, -1},
-            {2008, -1, -1, 52 * 4, WEEKS, 2012, -1, -1},
-            {2012, -1, -1, 0, MONTHS, 2012, -1, -1},
-            {2012, 4, 1, 3, MONTHS, 2012, -1, -1},
-            {2012, 12, 1, -5, MONTHS, 2012, -1, -1},
-            {2008, -1, -1, 13 * 4, MONTHS, 2012, -1, -1},
-            {2012, -1, -1, 0, YEARS, 2012, -1, -1},
-            {2009, 7, 1, 3, YEARS, 2012, -1, -1},
-            {2017, 7, 1, -5, YEARS, 2012, -1, -1},
-            {2008, -1, -1, 4, YEARS, 2012, -1, -1},
+            {2012, 6, 29, 0, DAYS, 2012, 6, 29},
+            {2012, 6, 21, 8, DAYS, 2012, 6, 29},
+            {2012, 7, 3, -3, DAYS, 2012, 6, 29},
+            {2012, 6, 29, 0, WEEKS, 2012, 6, 29},
+            {2012, 6, 8, 3, WEEKS, 2012, 6, 29},
+            {2012, 8, 8, -5, WEEKS, 2012, 6, 29},
+            {2008, 6, 29, 52 * 4, WEEKS, 2012, 6, 29},
+            {2012, 6, 29, 0, MONTHS, 2012, 6, 29},
+            {2012, 3, 28, 3, MONTHS, 2012, 6, 29},
+            {2012, 11, 28, -5, MONTHS, 2012, 6, 29},
+            {2008, 6, 29, 13 * 4, MONTHS, 2012, 6, 29},
+            {2012, 6, 29, 0, YEARS, 2012, 6, 29},
+            {2009, 6, 28, 3, YEARS, 2012, 6, 29},
+            {2017, 6, 28, -5, YEARS, 2012, 6, 29},
+            {2008, 6, 29, 4, YEARS, 2012, 6, 29},
 
-            {2013, 1, 1, 4 * -7, WEEKS, 2012, -1, -1},
-            {2012, 1, 1, 4 * 6, WEEKS, 2012, -1, -1},
+            {2012, 13, 29, 4 * -7, WEEKS, 2012, 6, 29},
+            {2011, 13, 29, 4 * 6, WEEKS, 2012, 6, 29},
         };
     }
 
@@ -1021,107 +1028,107 @@ public class TestInternationalFixedChronology {
             {2014, 5, 26, 3014, 5, 26, ERAS, 0},
 
             {2014, 13, 28, 2015, 1, 1, DAYS, 2},
-            {2014, 13, 28, 2014, 0, 0, DAYS, 1},
-            {2014, 0, 0, 2015, 1, 1, DAYS, 1},
+            {2014, 13, 28, 2014, 13, 29, DAYS, 1},
+            {2014, 13, 29, 2015, 1, 1, DAYS, 1},
             {2015, 1, 1, 2014, 13, 24, DAYS, -6},
-            {2014, 0, 0, 2014, 0, 0, WEEKS, 0},
+            {2014, 13, 29, 2014, 13, 29, WEEKS, 0},
             {2015, 1, 1, 2015, 1, 1, WEEKS, 0},
             {2015, 1, 1, 2014, 13, 28, WEEKS, 0},
             {2015, 1, 1, 2014, 13, 23, WEEKS, 0},
             {2015, 1, 1, 2014, 13, 22, WEEKS, -1},
-            {2014, 0, 0, 2014, 13, 21, WEEKS, -1},
-            {2014, 0, 0, 2014, 13, 22, WEEKS, 0},
-            {2014, 0, 0, 2015, 1, 7, WEEKS, 0},
-            {2014, 0, 0, 2015, 1, 8, WEEKS, 1},
-            {2014, 13, 21, 2014, 0, 0, WEEKS, 1},
-            {2014, 13, 22, 2014, 0, 0, WEEKS, 0},
-            {2015, 1, 7, 2014, 0, 0, WEEKS, 0},
-            {2015, 1, 8, 2014, 0, 0, WEEKS, -1},
-            {2014, 0, 0, 2014, 0, 0, MONTHS, 0},
-            {2014, 0, 0, 2015, 1, 28, MONTHS, 0},
-            {2014, 0, 0, 2015, 2, 1, MONTHS, 1},
-            {2015, 2, 1, 2014, 0, 0, MONTHS, -1},
-            {2015, 1, 28, 2014, 0, 0, MONTHS, 0},
-            {2014, 12, 28, 2014, 0, 0, MONTHS, 1},
-            {2014, 13, 1, 2014, 0, 0, MONTHS, 0},
+            {2014, 13, 29, 2014, 13, 21, WEEKS, -1},
+            {2014, 13, 29, 2014, 13, 22, WEEKS, 0},
+            {2014, 13, 29, 2015, 1, 7, WEEKS, 0},
+            {2014, 13, 29, 2015, 1, 8, WEEKS, 1},
+            {2014, 13, 21, 2014, 13, 29, WEEKS, 1},
+            {2014, 13, 22, 2014, 13, 29, WEEKS, 0},
+            {2015, 1, 7, 2014, 13, 29, WEEKS, 0},
+            {2015, 1, 8, 2014, 13, 29, WEEKS, -1},
+            {2014, 13, 29, 2014, 13, 29, MONTHS, 0},
+            {2014, 13, 29, 2015, 1, 28, MONTHS, 0},
+            {2014, 13, 29, 2015, 2, 1, MONTHS, 1},
+            {2015, 2, 1, 2014, 13, 29, MONTHS, -1},
+            {2015, 1, 28, 2014, 13, 29, MONTHS, 0},
+            {2014, 12, 28, 2014, 13, 29, MONTHS, 1},
+            {2014, 13, 1, 2014, 13, 29, MONTHS, 0},
             {2014, 13, 1, 2015, 1, 1, MONTHS, 1},
-            {2014, 0, 0, 2014, 0, 0, YEARS, 0},
-            {2014, 0, 0, 2015, 13, 28, YEARS, 0},
-            {2014, 0, 0, 2015, 0, 0, YEARS, 1},
-            {2014, 0, 0, 2016, 1, 1, YEARS, 1},
-            {2014, 1, 1, 2014, 0, 0, YEARS, 0},
-            {2013, 0, 0, 2014, 0, 0, YEARS, 1},
-            {2013, 13, 28, 2014, 0, 0, YEARS, 1},
+            {2014, 13, 29, 2014, 13, 29, YEARS, 0},
+            {2014, 13, 29, 2015, 13, 28, YEARS, 0},
+            {2014, 13, 29, 2015, 13, 29, YEARS, 1},
+            {2014, 13, 29, 2016, 1, 1, YEARS, 1},
+            {2014, 1, 1, 2014, 13, 29, YEARS, 0},
+            {2013, 13, 29, 2014, 13, 29, YEARS, 1},
+            {2013, 13, 28, 2014, 13, 29, YEARS, 1},
 
             {2012, 6, 28, 2012, 7, 1, DAYS, 2},
-            {2012, 6, 28, 2012, -1, -1, DAYS, 1},
-            {2012, -1, -1, 2012, 7, 1, DAYS, 1},
+            {2012, 6, 28, 2012, 6, 29, DAYS, 1},
+            {2012, 6, 29, 2012, 7, 1, DAYS, 1},
             {2012, 7, 1, 2012, 6, 24, DAYS, -6},
-            {2012, -1, -1, 2012, -1, -1, WEEKS, 0},
+            {2012, 6, 29, 2012, 6, 29, WEEKS, 0},
             {2012, 7, 1, 2012, 7, 1, WEEKS, 0},
             {2012, 7, 1, 2012, 6, 28, WEEKS, 0},
             {2012, 7, 1, 2012, 6, 23, WEEKS, 0},
             {2012, 7, 1, 2012, 6, 22, WEEKS, -1},
-            {2012, -1, -1, 2012, 6, 21, WEEKS, -1},
-            {2012, -1, -1, 2012, 6, 22, WEEKS, 0},
-            {2012, -1, -1, 2012, 7, 7, WEEKS, 0},
-            {2012, -1, -1, 2012, 7, 8, WEEKS, 1},
-            {2012, 6, 21, 2012, -1, -1, WEEKS, 1},
-            {2012, 6, 22, 2012, -1, -1, WEEKS, 0},
-            {2012, 7, 7, 2012, -1, -1, WEEKS, 0},
-            {2012, 7, 8, 2012, -1, -1, WEEKS, -1},
-            {2012, -1, -1, 2012, -1, -1, MONTHS, 0},
-            {2012, -1, -1, 2012, 7, 28, MONTHS, 0},
-            {2012, -1, -1, 2012, 8, 1, MONTHS, 1},
-            {2012, 8, 1, 2012, -1, -1, MONTHS, -1},
-            {2012, 7, 28, 2012, -1, -1, MONTHS, 0},
-            {2012, 5, 28, 2012, -1, -1, MONTHS, 1},
-            {2012, 6, 1, 2012, -1, -1, MONTHS, 0},
+            {2012, 6, 29, 2012, 6, 21, WEEKS, -1},
+            {2012, 6, 29, 2012, 6, 22, WEEKS, 0},
+            {2012, 6, 29, 2012, 7, 7, WEEKS, 0},
+            {2012, 6, 29, 2012, 7, 8, WEEKS, 1},
+            {2012, 6, 21, 2012, 6, 29, WEEKS, 1},
+            {2012, 6, 22, 2012, 6, 29, WEEKS, 0},
+            {2012, 7, 7, 2012, 6, 29, WEEKS, 0},
+            {2012, 7, 8, 2012, 6, 29, WEEKS, -1},
+            {2012, 6, 29, 2012, 6, 29, MONTHS, 0},
+            {2012, 6, 29, 2012, 7, 28, MONTHS, 0},
+            {2012, 6, 29, 2012, 8, 1, MONTHS, 1},
+            {2012, 8, 1, 2012, 6, 29, MONTHS, -1},
+            {2012, 7, 28, 2012, 6, 29, MONTHS, 0},
+            {2012, 5, 28, 2012, 6, 29, MONTHS, 1},
+            {2012, 6, 1, 2012, 6, 29, MONTHS, 0},
             {2012, 6, 1, 2012, 7, 1, MONTHS, 1},
-            {2012, -1, -1, 2012, -1, -1, YEARS, 0},
-            {2012, -1, -1, 2013, 6, 28, YEARS, 0},
-            {2012, -1, -1, 2013, 7, 1, YEARS, 1},
-            {2011, 7, 1, 2012, -1, -1, YEARS, 0},
-            {2011, 6, 28, 2012, -1, -1, YEARS, 1},
+            {2012, 6, 29, 2012, 6, 29, YEARS, 0},
+            {2012, 6, 29, 2013, 6, 28, YEARS, 0},
+            {2012, 6, 29, 2013, 7, 1, YEARS, 1},
+            {2011, 7, 1, 2012, 6, 29, YEARS, 0},
+            {2011, 6, 28, 2012, 6, 29, YEARS, 1},
             {2011, 7, 1, 2012, 7, 1, YEARS, 1},
-            {2012, -1, -1, 2011, 6, 28, YEARS, -1},
-            {2012, -1, -1, 2011, 7, 1, YEARS, 0},
-            {2013, 7, 1, 2012, -1, -1, YEARS, -1},
-            {2013, 6, 28, 2012, -1, -1, YEARS, 0},
-            {2016, -1, -1, 2012, -1, -1, YEARS, -4},
-            {2012, -1, -1, 2016, -1, -1, YEARS, 4},
+            {2012, 6, 29, 2011, 6, 28, YEARS, -1},
+            {2012, 6, 29, 2011, 7, 1, YEARS, 0},
+            {2013, 7, 1, 2012, 6, 29, YEARS, -1},
+            {2013, 6, 28, 2012, 6, 29, YEARS, 0},
+            {2016, 6, 29, 2012, 6, 29, YEARS, -4},
+            {2012, 6, 29, 2016, 6, 29, YEARS, 4},
 
             // The order is the 28th, Year Day, Leap Day, the 1st.
             // Year Day is "after the 28th"
             // Leap Day is "before the 1st"
-            {2012, -1, -1, 2012, 0, 0, DAYS, 197},
-            {2012, -1, -1, 2012, 13, 28, WEEKS, 27},
-            {2012, -1, -1, 2012, 0, 0, WEEKS, 27},
-            {2012, -1, -1, 2013, 1, 1, WEEKS, 28},
-            {2012, -1, -1, 2011, 13, 28, WEEKS, -24},
-            {2012, -1, -1, 2011, 0, 0, WEEKS, -24},
-            {2012, -1, -1, 2012, 1, 1, WEEKS, -23},
-            {2012, 0, 0, 2012, 6, 28, WEEKS, -28},
-            {2012, 0, 0, 2012, -1, -1, WEEKS, -27},
-            {2012, 0, 0, 2012, 7, 1, WEEKS, -27},
-            {2011, 0, 0, 2012, 6, 28, WEEKS, 23},
-            {2011, 0, 0, 2012, -1, -1, WEEKS, 24},
-            {2011, 0, 0, 2012, 7, 1, WEEKS, 24},
-            {2012, 0, 0, 2013, 0, 0, WEEKS, 52},
-            {2012, 0, 0, 2016, 0, 0, WEEKS, 52 * 4},
-            {2012, -1, -1, 2012, 13, 28, MONTHS, 6},
-            {2012, -1, -1, 2012, 0, 0, MONTHS, 6},
-            {2012, -1, -1, 2013, 1, 1, MONTHS, 7},
-            {2012, -1, -1, 2011, 13, 28, MONTHS, -6},
-            {2012, -1, -1, 2011, 0, 0, MONTHS, -6},
-            {2012, -1, -1, 2012, 1, 1, MONTHS, -5},
-            {2012, -1, -1, 2016, -1, -1, WEEKS, 52 * 4},
-            {2012, 0, 0, 2012, 6, 28, MONTHS, -7},
-            {2012, 0, 0, 2012, -1, -1, MONTHS, -6},
-            {2012, 0, 0, 2012, 7, 1, MONTHS, -6},
-            {2011, 0, 0, 2012, 6, 28, MONTHS, 5},
-            {2011, 0, 0, 2012, -1, -1, MONTHS, 6},
-            {2011, 0, 0, 2012, 7, 1, MONTHS, 6},
+            {2012, 6, 29, 2012, 13, 29, DAYS, 197},
+            {2012, 6, 29, 2012, 13, 28, WEEKS, 27},
+            {2012, 6, 29, 2012, 13, 29, WEEKS, 28},
+            {2012, 6, 29, 2013, 1, 1, WEEKS, 28},
+            {2012, 6, 29, 2011, 13, 28, WEEKS, -24},
+            {2012, 6, 29, 2011, 13, 29, WEEKS, -24},
+            {2012, 6, 29, 2012, 1, 1, WEEKS, -23},
+            {2012, 13, 29, 2012, 6, 28, WEEKS, -28},
+            {2012, 13, 29, 2012, 6, 29, WEEKS, -28},
+            {2012, 13, 29, 2012, 7, 1, WEEKS, -27},
+            {2011, 13, 29, 2012, 6, 28, WEEKS, 23},
+            {2011, 13, 29, 2012, 6, 29, WEEKS, 24},
+            {2011, 13, 29, 2012, 7, 1, WEEKS, 24},
+            {2012, 13, 29, 2013, 13, 29, WEEKS, 52},
+            {2012, 13, 29, 2016, 13, 29, WEEKS, 52 * 4},
+            {2012, 6, 29, 2012, 13, 28, MONTHS, 6},
+            {2012, 6, 29, 2012, 13, 29, MONTHS, 7},
+            {2012, 6, 29, 2013, 1, 1, MONTHS, 7},
+            {2012, 6, 29, 2011, 13, 28, MONTHS, -6},
+            {2012, 6, 29, 2011, 13, 29, MONTHS, -6},
+            {2012, 6, 29, 2012, 1, 1, MONTHS, -5},
+            {2012, 6, 29, 2016, 6, 29, WEEKS, 52 * 4},
+            {2012, 13, 29, 2012, 6, 28, MONTHS, -7},
+            {2012, 13, 29, 2012, 6, 29, MONTHS, -7},
+            {2012, 13, 29, 2012, 7, 1, MONTHS, -6},
+            {2011, 13, 29, 2012, 6, 28, MONTHS, 5},
+            {2011, 13, 29, 2012, 6, 29, MONTHS, 6},
+            {2011, 13, 29, 2012, 7, 1, MONTHS, 6},
         };
     }
 
@@ -1154,23 +1161,23 @@ public class TestInternationalFixedChronology {
             {2012, 13, 6, 2013, 13, 6, 1, 0, 0},
 
             // start with Year Day
-            {2012, 0, 0, 2012, 0, 0, 0, 0, 0},
-            {2012, 0, 0, 2013, 0, 0, 1, 0, 0},
-            {2011, 0, 0, 2010, 0, 0, -1, 0, 0},
-            {2000, 0, 0, 2001, 0, 0, 1, 0, 0},
-            {2007, 0, 0, 2008, 1, 1, 0, 0, 1},
-            {2005, 0, 0, 2006, 2, 1, 0, 1, 1},
-            {2003, 0, 0, 2004, -1, -1, 0, 6, 1},
-            {2003, 0, 0, 2004, 7, 1, 0, 6, 2},
-            {2004, 0, 0, 2004, -1, -1, 0, -7, 0},
-            {2004, 0, 0, 2004, 7, 1, 0, -6, -27},
-            {2003, 0, 0, 2005, 1, 1, 1, 0, 1},
-            {2003, 0, 0, 2002, 13, 28, -1, 0, -1},
+            {2012, 13, 29, 2012, 13, 29, 0, 0, 0},
+            {2012, 13, 29, 2013, 13, 29, 1, 0, 0},
+            {2011, 13, 29, 2010, 13, 29, -1, 0, 0},
+            {2000, 13, 29, 2001, 13, 29, 1, 0, 0},
+            {2007, 13, 29, 2008, 1, 1, 0, 0, 1},
+            {2005, 13, 29, 2006, 2, 1, 0, 1, 1},
+            {2003, 13, 29, 2004, 6, 29, 0, 6, 0},
+            {2003, 13, 29, 2004, 7, 1, 0, 6, 1},
+            {2004, 13, 29, 2004, 6, 29, 0, -7, 0},
+            {2004, 13, 29, 2004, 7, 1, 0, -6, -27},
+            {2003, 13, 29, 2005, 1, 1, 1, 0, 1},
+            {2003, 13, 29, 2002, 13, 28, -1, 0, -1},
 
             // start with one day before Year Day
-            {2003, 13, 28, 2004, -1, -1, 0, 6, 1},
+            {2003, 13, 28, 2004, 6, 29, 0, 6, 1},
             {2003, 13, 28, 2004, 7, 1, 0, 6, 2},
-            {2004, 13, 28, 2004, -1, -1, 0, -7, 0},
+            {2004, 13, 28, 2004, 6, 29, 0, -7, 0},
             {2004, 13, 28, 2004, 7, 1, 0, -6, -27},
             {2003, 13, 28, 2005, 1, 1, 1, 0, 2},
             {2003, 13, 28, 2002, 13, 28, -1, 0, 0},
@@ -1178,23 +1185,23 @@ public class TestInternationalFixedChronology {
             {2005, 13, 28, 2006, 2, 1, 0, 1, 1},
 
             // start with Leap Day
-            {2008, -1, -1, 2008, -1, -1, 0, 0, 0},
-            {2012, -1, -1, 2016, -1, -1, 4, 0, 0},
-            {2024, -1, -1, 2020, -1, -1, -4, 0, 0},
-            {2000, -1, -1, 2032, -1, -1, 32, 0, 0},
-            {2024, -1, -1, 2000, -1, -1, -24, 0, 0},
-            {2004, -1, -1, 2004, 0, 0, 0, 7, 0},
-            {2004, -1, -1, 2004, 13, 28, 0, 6, 27},
-            {2004, -1, -1, 2003, 0, 0, 0, -6, -1},
-            {2004, -1, -1, 2003, 13, 28, 0, -6, -2},
-            {2004, -1, -1, 2003, 6, 28, -1, 0, -1},
-            {2000, -1, -1, 2000, 7, 1, 0, 0, 1},
-            {2000, -1, -1, 2000, 8, 1, 0, 1, 0},
+            {2008, 6, 29, 2008, 6, 29, 0, 0, 0},
+            {2012, 6, 29, 2016, 6, 29, 4, 0, 0},
+            {2024, 6, 29, 2020, 6, 29, -4, 0, 0},
+            {2000, 6, 29, 2032, 6, 29, 32, 0, 0},
+            {2024, 6, 29, 2000, 6, 29, -24, 0, 0},
+            {2004, 6, 29, 2004, 13, 29, 0, 7, 0},
+            {2004, 6, 29, 2004, 13, 28, 0, 6, 28}, // yes, 6 months and 28 days here, not 7 months flat
+            {2004, 6, 29, 2003, 13, 29, 0, -6, 0},
+            {2004, 6, 29, 2003, 13, 28, 0, -6, -1},
+            {2004, 6, 29, 2003, 6, 28, -1, 0, 0},
+            {2000, 6, 29, 2000, 7, 1, 0, 0, 1},
+            {2000, 6, 29, 2000, 8, 1, 0, 1, 1},
 
             // start with one day before Leap Day
-            {2004, 6, 28, 2004, 0, 0, 0, 7, 1},
+            {2004, 6, 28, 2004, 13, 29, 0, 7, 1},
             {2004, 6, 28, 2004, 13, 28, 0, 7, 0},
-            {2004, 6, 28, 2003, 0, 0, 0, -6, 0},
+            {2004, 6, 28, 2003, 13, 29, 0, -5, -28}, // yes, -5 months and -28 days here, not -6 months flat
             {2004, 6, 28, 2003, 13, 28, 0, -6, 0},
             {2000, 6, 28, 2000, 7, 1, 0, 0, 2},
             {2000, 6, 28, 2000, 8, 1, 0, 1, 1},
@@ -1260,10 +1267,10 @@ public class TestInternationalFixedChronology {
         return new Object[][] {
             {InternationalFixedDate.of(2000, 1, 3), InternationalFixedDate.of(2000, 1, 3),
                 InternationalFixedDate.of(2000, 1, 4), InternationalFixedDate.of(2000, 2, 3), InternationalFixedDate.of(2001, 1, 3)},
-            {InternationalFixedDate.of(2000, 0, 0), InternationalFixedDate.yearDay(2000),
-                InternationalFixedDate.of(2000, 13, 28), InternationalFixedDate.of(2001, 1, 1), InternationalFixedDate.of(2001, 0, 0)},
-            {InternationalFixedDate.of(2000, -1, -1), InternationalFixedDate.leapDay(2000),
-                InternationalFixedDate.of(2000, 6, 28), InternationalFixedDate.of(2000, 7, 1), InternationalFixedDate.of(2004, -1, -1)},
+            {InternationalFixedDate.of(2000, 13, 29), InternationalFixedDate.yearDay(2000),
+                InternationalFixedDate.of(2000, 13, 28), InternationalFixedDate.of(2001, 1, 1), InternationalFixedDate.of(2001, 13, 29)},
+            {InternationalFixedDate.of(2000, 6, 29), InternationalFixedDate.leapDay(2000),
+                InternationalFixedDate.of(2000, 6, 28), InternationalFixedDate.of(2000, 7, 1), InternationalFixedDate.of(2004, 6, 29)},
         };
     }
 
@@ -1291,12 +1298,12 @@ public class TestInternationalFixedChronology {
             {InternationalFixedDate.of(1, 1, 1), "Ifc CE 1/01/01"},
             {InternationalFixedDate.of(2012, 6, 23), "Ifc CE 2012/06/23"},
 
-            {InternationalFixedDate.yearDay(1), "Ifc CE 1/0/0"},
-            {InternationalFixedDate.of(1, 0, 0), "Ifc CE 1/0/0"},
-            {InternationalFixedDate.leapDay(2012), "Ifc CE 2012/-1/-1"},
-            {InternationalFixedDate.of(2012, -1, -1), "Ifc CE 2012/-1/-1"},
-            {InternationalFixedDate.yearDay(2012), "Ifc CE 2012/0/0"},
-            {InternationalFixedDate.of(2012, 0, 0), "Ifc CE 2012/0/0"},
+            {InternationalFixedDate.yearDay(1), "Ifc CE 1/13/29"},
+            {InternationalFixedDate.of(1, 13, 29), "Ifc CE 1/13/29"},
+            {InternationalFixedDate.leapDay(2012), "Ifc CE 2012/06/29"},
+            {InternationalFixedDate.of(2012, 6, 29), "Ifc CE 2012/06/29"},
+            {InternationalFixedDate.yearDay(2012), "Ifc CE 2012/13/29"},
+            {InternationalFixedDate.of(2012, 13, 29), "Ifc CE 2012/13/29"},
         };
     }
 
@@ -1304,5 +1311,4 @@ public class TestInternationalFixedChronology {
     public void test_toString(InternationalFixedDate date, String expected) {
         assertEquals(date.toString(), expected);
     }
-
 }

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -128,20 +128,17 @@ public class TestInternationalFixedChronology {
             {InternationalFixedDate.of(1, 13, 28), LocalDate.of(1, 12, 30)},
             {InternationalFixedDate.of(1, 13, 27), LocalDate.of(1, 12, 29)},
             {InternationalFixedDate.of(1, 13, 29), LocalDate.of(1, 12, 31)},
-            {InternationalFixedDate.yearDay(1), LocalDate.of(1, 12, 31)},
             {InternationalFixedDate.of(2, 1, 1), LocalDate.of(2, 1, 1)},
 
             {InternationalFixedDate.of(4, 6, 27), LocalDate.of(4, 6, 15)},
             {InternationalFixedDate.of(4, 6, 28), LocalDate.of(4, 6, 16)},
             {InternationalFixedDate.of(4, 6, 29), LocalDate.of(4, 6, 17)},
-            {InternationalFixedDate.leapDay(4), LocalDate.of(4, 6, 17)},
             {InternationalFixedDate.of(4, 7, 1), LocalDate.of(4, 6, 18)},
             {InternationalFixedDate.of(4, 7, 2), LocalDate.of(4, 6, 19)},
 
             {InternationalFixedDate.of(4, 13, 28), LocalDate.of(4, 12, 30)},
             {InternationalFixedDate.of(4, 13, 27), LocalDate.of(4, 12, 29)},
             {InternationalFixedDate.of(4, 13, 29), LocalDate.of(4, 12, 31)},
-            {InternationalFixedDate.yearDay(4), LocalDate.of(4, 12, 31)},
             {InternationalFixedDate.of(5, 1, 1), LocalDate.of(5, 1, 1)},
 
             {InternationalFixedDate.of(100, 6, 27), LocalDate.of(100, 6, 16)},
@@ -152,7 +149,6 @@ public class TestInternationalFixedChronology {
             {InternationalFixedDate.of(400, 6, 27), LocalDate.of(400, 6, 15)},
             {InternationalFixedDate.of(400, 6, 28), LocalDate.of(400, 6, 16)},
             {InternationalFixedDate.of(400, 6, 29), LocalDate.of(400, 6, 17)},
-            {InternationalFixedDate.leapDay(400), LocalDate.of(400, 6, 17)},
             {InternationalFixedDate.of(400, 7, 1), LocalDate.of(400, 6, 18)},
             {InternationalFixedDate.of(400, 7, 2), LocalDate.of(400, 6, 19)},
 
@@ -296,8 +292,8 @@ public class TestInternationalFixedChronology {
     }
 
     @Test(dataProvider = "badLeapDates", expectedExceptions = DateTimeException.class)
-    public void badLeapDayAndYearDayDates(int year) {
-        InternationalFixedDate.leapDay(year);
+    public void badLeapDayDates(int year) {
+        InternationalFixedDate.of(year, 6, 29);
     }
 
     @Test(expectedExceptions = DateTimeException.class)
@@ -361,11 +357,8 @@ public class TestInternationalFixedChronology {
 
     @Test
     public void test_lengthOfMonth_specific() {
-        assertEquals(InternationalFixedDate.yearDay(1900).lengthOfMonth(), 29);
         assertEquals(InternationalFixedDate.of(1900, 13, 29).lengthOfMonth(), 29);
-        assertEquals(InternationalFixedDate.yearDay(2000).lengthOfMonth(), 29);
         assertEquals(InternationalFixedDate.of(2000, 13, 29).lengthOfMonth(), 29);
-        assertEquals(InternationalFixedDate.leapDay(2000).lengthOfMonth(), 29);
         assertEquals(InternationalFixedDate.of(2000, 6, 29).lengthOfMonth(), 29);
     }
 
@@ -1265,28 +1258,24 @@ public class TestInternationalFixedChronology {
     @DataProvider(name = "equals")
     Object[][] data_equals() {
         return new Object[][] {
-            {InternationalFixedDate.of(2000, 1, 3), InternationalFixedDate.of(2000, 1, 3),
+            {InternationalFixedDate.of(2000, 1, 3),
                 InternationalFixedDate.of(2000, 1, 4), InternationalFixedDate.of(2000, 2, 3), InternationalFixedDate.of(2001, 1, 3)},
-            {InternationalFixedDate.of(2000, 13, 29), InternationalFixedDate.yearDay(2000),
+            {InternationalFixedDate.of(2000, 13, 29),
                 InternationalFixedDate.of(2000, 13, 28), InternationalFixedDate.of(2001, 1, 1), InternationalFixedDate.of(2001, 13, 29)},
-            {InternationalFixedDate.of(2000, 6, 29), InternationalFixedDate.leapDay(2000),
+            {InternationalFixedDate.of(2000, 6, 29),
                 InternationalFixedDate.of(2000, 6, 28), InternationalFixedDate.of(2000, 7, 1), InternationalFixedDate.of(2004, 6, 29)},
         };
     }
 
     @Test(dataProvider = "equals")
-    void test_equals(InternationalFixedDate a1, InternationalFixedDate a2,
-            InternationalFixedDate b, InternationalFixedDate c, InternationalFixedDate d) {
+    void test_equals(InternationalFixedDate a1, InternationalFixedDate b, InternationalFixedDate c, InternationalFixedDate d) {
         assertTrue(a1.equals(a1));
-        assertTrue(a1.equals(a2));
         assertFalse(a1.equals(b));
         assertFalse(a1.equals(c));
         assertFalse(a1.equals(d));
 
         assertFalse(a1.equals(null));
         assertFalse("".equals(a1));
-
-        assertEquals(a1.hashCode(), a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -1298,11 +1287,8 @@ public class TestInternationalFixedChronology {
             {InternationalFixedDate.of(1, 1, 1), "Ifc CE 1/01/01"},
             {InternationalFixedDate.of(2012, 6, 23), "Ifc CE 2012/06/23"},
 
-            {InternationalFixedDate.yearDay(1), "Ifc CE 1/13/29"},
             {InternationalFixedDate.of(1, 13, 29), "Ifc CE 1/13/29"},
-            {InternationalFixedDate.leapDay(2012), "Ifc CE 2012/06/29"},
             {InternationalFixedDate.of(2012, 6, 29), "Ifc CE 2012/06/29"},
-            {InternationalFixedDate.yearDay(2012), "Ifc CE 2012/13/29"},
             {InternationalFixedDate.of(2012, 13, 29), "Ifc CE 2012/13/29"},
         };
     }


### PR DESCRIPTION
Now both Year Day and Leap Day are associated with a month.
The implementation became more orthogonal.
Some tests had to be adapted.
