### PR TITLE
Documentation bug: no such method YearWeek#with(TemporalField, long)

### DIFF
--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -305,9 +305,8 @@ public final class YearWeek
      * Checks if the specified field is supported.
      * <p>
      * This checks if this year-week can be queried for the specified field.
-     * If false, then calling the {@link #range(TemporalField) range},
-     * {@link #get(TemporalField) get} and {@link #with(TemporalField, long)}
-     * methods will throw an exception.
+     * If false, then calling the {@link #range(TemporalField) range} and
+     * {@link #get(TemporalField) get} methods will throw an exception.
      * <p>
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The supported fields are:


### PR DESCRIPTION
There is only one two-argument method YearWeek#with(int, int), which is private.
It cannot be invoked from outside, whereas YearWeek#range(TemporalField) and YearWeek#get(TemporalField) are visible.