### PR TITLE
Re-enable maven checkstyle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     </resources>
     <!-- define build -->
     <plugins>
-      <!--plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <executions>
@@ -110,7 +110,7 @@
             </goals>
           </execution>
         </executions>
-      </plugin-->
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -607,7 +607,7 @@
     <maven-surefire-plugin.version>2.16</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>2.16</maven-surefire-report-plugin.version>
     <maven-toolchains-plugin.version>1.0</maven-toolchains-plugin.version>
-    <maven-checkstyle-plugin.version>2.12.1</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>2.15</maven-checkstyle-plugin.version>
     <!-- Properties for maven-compiler-plugin -->
     <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
     <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Upgrading to maven checkstyle plugin 2.15 brings Java 8 support.
Thus, the compilation of Java sources can be checked against styles again.

This is a better fix, replaces the solution presented in https://github.com/ThreeTen/threeten-extra/pull/34.