### PR TITLE
Add support for ISO 8601 'datetime/duration' in Interval.parse.

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -133,7 +133,17 @@ public final class Interval
         for (int i = 0; i < text.length(); i++) {
             if (text.charAt(i) == '/') {
                 Instant start = Instant.parse(text.subSequence(0, i));
-                Instant end = Instant.parse(text.subSequence(i + 1, text.length()));
+                Instant end = null;
+                if (i + 1 < text.length()) {
+                    char c = text.charAt(i + 1);
+                    if (c == 'P' || c == 'p') {
+                        Duration duration = Duration.parse(text.subSequence(i + 1, text.length()));
+                        end = start.plus(duration);
+                    }
+                }
+                if (end == null) {
+                    end = Instant.parse(text.subSequence(i + 1, text.length()));
+                }
                 return Interval.of(start, end);
             }
         }


### PR DESCRIPTION
Alas Java 8 does not support the full `PnYnMnDTnHnMnS` or `PnW` in [`Duration.parse`](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-) but oddly it does with [`Period.parse`](https://docs.oracle.com/javase/8/docs/api/java/time/Period.html#parse-java.lang.CharSequence-) but then hours, minutes and seconds are lost.
