### PR TITLE
Variable naming Months class

### DIFF
--- a/src/main/java/org/threeten/extra/Hours.java
+++ b/src/main/java/org/threeten/extra/Hours.java
@@ -1,0 +1,543 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra;
+
+import static java.time.temporal.ChronoUnit.HOURS;
+
+import java.io.Serializable;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A hour-based amount of time, such as '4 hours'.
+ * <p>
+ * This class models a quantity or amount of time in terms of hours. It is a
+ * type-safe way of representing a number of hours in an application.
+ * <p>
+ * The model is of a directed amount, meaning that the amount may be negative.
+ *
+ * <h3>Implementation Requirements:</h3>
+ * This class is immutable and thread-safe.
+ * <p>
+ * This class must be treated as a value type. Do not synchronize, rely on the
+ * identity hash code or use the distinction between equals() and ==.
+ */
+public final class Hours
+        implements TemporalAmount, Comparable<Hours>, Serializable {
+
+    /**
+     * A constant for zero hours.
+     */
+    public static final Hours ZERO = new Hours(0);
+    
+    /**
+     * A serialization identifier for this class.
+     */
+    private static final long serialVersionUID = -8494096666041369608L;
+
+    /**
+     * The pattern for parsing.
+     */
+    private static final Pattern PATTERN =
+            Pattern.compile("([-+]?)PT"
+                    + "(?:([-+]?[0-9]+)H)?", Pattern.CASE_INSENSITIVE);
+    
+    /**
+     * The number of hours.
+     */
+    private final int hours;
+    
+    /**
+     * Obtains a {@code Hours} representing a number of hours.
+     * <p>
+     * The resulting amount will have the specified hours.
+     *
+     * @param hours  the number of hours, positive or negative
+     * @return the number of hours, not null
+     */
+    public static Hours of(int hours) {
+        if (hours == 0) {
+            return ZERO;
+        } else {
+            return new Hours(hours);
+        }
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains an instance of {@code Hours} from a temporal amount.
+     * <p>
+     * This obtains an instance based on the specified amount. A
+     * {@code TemporalAmount} represents an amount of time, which may be
+     * date-based or time-based, which this factory extracts to a {@code Hours}.
+     * <p>
+     * The result is calculated by looping around each unit in the specified
+     * amount. Each amount is converted to hours using
+     * {@link Temporals#convertAmount}. If the conversion yields a remainder, an
+     * exception is thrown. If the amount is zero, the unit is ignored.
+     *
+     * @param amount  the temporal amount to convert, not null
+     * @return the equivalent amount, not null
+     * @throws DateTimeException if unable to convert to a {@code Hours}
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public static Hours from(TemporalAmount amount) {
+        if (amount instanceof Hours) {
+            return (Hours) amount;
+        }
+        Objects.requireNonNull(amount, "amount");
+        int hours = 0;
+        for (TemporalUnit unit : amount.getUnits()) {
+            long value = amount.get(unit);
+            if (value != 0) {
+                long[] converted = Temporals.convertAmount(value, unit, HOURS);
+                if (converted[1] != 0) {
+                    throw new DateTimeException(
+                            "Amount could not be converted to a whole number of hours: " + value + " " + unit);
+                }
+                hours = Math.addExact(hours, Math.toIntExact(converted[0]));
+            }
+        }
+        return of(hours);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code Hours} from a text string such as {@code PTnH}.
+     * <p>
+     * This will parse the string produced by {@code toString()} which is based
+     * on the ISO-8601 period format {@code PTnH}.
+     * <p>
+     * The string starts with an optional sign, denoted by the ASCII negative or
+     * positive symbol. If negative, the whole amount is negated. 
+     * The ASCII letters "P" and "T" are next in upper or lower case. 
+     * The section has the suffix "H" in ASCII in either upper or lower case.
+     * The number part must consist of ASCII digits. The number may be prefixed
+     * by the ASCII negative or positive symbol. The number must parse to an
+     * {@code int}.
+     * <p>
+     * The leading plus/minus sign, and negative value for hours is not part of
+     * the ISO-8601 standard.
+     * <p>
+     * For example, the following are valid inputs:
+     * <pre>
+     *   "PT2H"            -- Hours.of(2)
+     *   "PT-HM"           -- Hours.of(-2)
+     *   "-PT2H"           -- Hours.of(-2)
+     *   "-PT-2H"          -- Hours.of(2)
+     * </pre>
+     *
+     * @param text  the text to parse, not null
+     * @return the parsed period, not null
+     * @throws DateTimeParseException if the text cannot be parsed to a period
+     */
+    public static Hours parse(CharSequence text) {
+        Objects.requireNonNull(text, "text");
+        Matcher matcher = PATTERN.matcher(text);
+        if (matcher.matches()) {
+            int negate = ("-".equals(matcher.group(1)) ? -1 : 1);
+            String hoursStr = matcher.group(2);
+            if (hoursStr != null) {
+                try {
+                    int hours = Integer.parseInt(hoursStr);
+                    return of(negate * hours);
+                } catch (NumberFormatException ex) {
+                    throw new DateTimeParseException("Text cannot be parsed to Hours, non-numeric hours", text, 0, ex);
+                }
+            }
+        }
+        throw new DateTimeParseException("Text cannot be parsed to a Hours", text, 0);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code Hours} consisting of the number of hours between two dates.
+     * <p>
+     * The start date is included, but the end date is not.
+     * The result of this method can be negative if the end is before the start.
+     *
+     * @param startDateInclusive  the start date, inclusive, not null
+     * @param endDateExclusive  the end date, exclusive, not null
+     * @return the number of hours between this date and the end date, not null
+     */
+    public static Hours between(Temporal startDateInclusive, Temporal endDateExclusive) {
+        return of(Math.toIntExact(HOURS.between(startDateInclusive, endDateExclusive)));
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Constructs an instance using a specific number of hours.
+     *
+     * @param hours  the amount of hours
+     */
+    private Hours(int hours) {
+        this.hours = hours;
+    }
+
+    /**
+     * Resolves singletons.
+     *
+     * @return the singleton instance
+     */
+    private Object readResolve() {
+        return Hours.of(hours);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the value of the requested unit.
+     * <p>
+     * This returns a value for the supported unit -
+     * {@link ChronoUnit#HOURS HOURS}. All other units throw an exception.
+     *
+     * @param unit  the {@code TemporalUnit} for which to return the value
+     * @return the long value of the unit
+     * @throws UnsupportedTemporalTypeException if the unit is not supported
+     */
+    @Override
+    public long get(TemporalUnit unit) {
+        if (unit == HOURS) {
+            return hours;
+        }
+        throw new UnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the number of hours in this amount.
+     *
+     * @return the number of hours
+     */
+    public int getAmount() {
+        return hours;
+    }
+
+    /**
+     * Gets the set of units supported by this amount.
+     * <p>
+     * The single supported unit is {@link ChronoUnit#HOURS HOURS}.
+     * <p>
+     * This set can be used in conjunction with {@link #get(TemporalUnit)} to
+     * access the entire state of the amount.
+     *
+     * @return a list containing the hours unit, not null
+     */
+    @Override
+    public List<TemporalUnit> getUnits() {
+        return Collections.singletonList(ChronoUnit.HOURS);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this amount with the specified amount added.
+     * <p>
+     * The parameter is converted using {@link Hours#from(TemporalAmount)}.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param amountToAdd  the amount to add, not null
+     * @return a {@code Hours} based on this instance with the requested amount added, not null
+     * @throws DateTimeException if the specified amount contains an invalid unit
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public Hours plus(TemporalAmount amountToAdd) {
+        return plus(Hours.from(amountToAdd).getAmount());
+    }
+
+    /**
+     * Returns a copy of this amount with the specified number of hours added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param hours  the amount of hours to add, may be negative
+     * @return a {@code Hours} based on this instance with the requested amount added, not null
+     * @throws ArithmeticException if the result overflows an int
+     */
+    public Hours plus(int hours) {
+        if (hours == 0) {
+            return this;
+        }
+        return of(Math.addExact(this.hours, hours));
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this amount with the specified amount subtracted.
+     * <p>
+     * The parameter is converted using {@link Hours#from(TemporalAmount)}.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param amountToAdd  the amount to add, not null
+     * @return a {@code Hours} based on this instance with the requested amount
+     * subtracted, not null
+     * @throws DateTimeException if the specified amount contains an invalid
+     * unit
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public Hours minus(TemporalAmount amountToAdd) {
+        return minus(Hours.from(amountToAdd).getAmount());
+    }
+
+    /**
+     * Returns a copy of this amount with the specified number of hours
+     * subtracted.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param hours  the amount of hours to add, may be negative
+     * @return a {@code Hours} based on this instance with the requested amount
+     * subtracted, not null
+     * @throws ArithmeticException if the result overflows an int
+     */
+    public Hours minus(int hours) {
+        if (hours == 0) {
+            return this;
+        }
+        return of(Math.subtractExact(this.hours, hours));
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns an instance with the amount multiplied by the specified scalar.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param scalar  the scalar to multiply by, not null
+     * @return the amount multiplied by the specified scalar, not null
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public Hours multipliedBy(int scalar) {
+        if (scalar == 1) {
+            return this;
+        }
+        return of(Math.multiplyExact(hours, scalar));
+    }
+    
+    /**
+     * Returns an instance with the amount divided by the specified divisor.
+     * <p>
+     * The calculation uses integer division, thus 3 divided by 2 is 1.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param divisor  the amount to divide by, may be negative
+     * @return the amount divided by the specified divisor, not null
+     * @throws ArithmeticException if the divisor is zero
+     */
+    public Hours dividedBy(int divisor) {
+        if (divisor == 1) {
+            return this;
+        }
+        return of(hours / divisor);
+    }
+    
+    /**
+     * Returns an instance with the amount negated.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return the negated amount, not null
+     * @throws ArithmeticException if numeric overflow occurs, which only
+     * happens if the amount is {@code Long.MIN_VALUE}
+     */
+    public Hours negated() {
+        return multipliedBy(-1);
+    }
+    
+    /**
+     * Returns a copy of this duration with a positive length.
+     * <p>
+     * This method returns a positive duration by effectively removing the sign
+     * from any negative total length.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return the absolute amount, not null
+     * @throws ArithmeticException if numeric overflow occurs, which only
+     * happens if the amount is {@code Long.MIN_VALUE}
+     */
+    public Hours abs() {
+        return hours < 0 ? negated() : this;
+    }
+    
+    //-------------------------------------------------------------------------
+    /**
+     * Gets the number of hours as a {@code Duration}.
+     * <p>
+     * This returns a duration with the same number of months.
+     *
+     * @return the equivalent duration, not null
+     */
+    public Duration toPeriod() {
+        return Duration.ofHours(hours);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Adds this amount to the specified temporal object.
+     * <p>
+     * This returns a temporal object of the same observable type as the input
+     * with this amount added.
+     * <p>
+     * In most cases, it is clearer to reverse the calling pattern by using
+     * {@link Temporal#plus(TemporalAmount)}.
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   dateTime = thisAmount.addTo(dateTime);
+     *   dateTime = dateTime.plus(thisAmount);
+     * </pre>
+     * <p>
+     * Only non-zero amounts will be added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param temporal  the temporal object to adjust, not null
+     * @return an object of the same type with the adjustment made, not null
+     * @throws DateTimeException if unable to add
+     * @throws UnsupportedTemporalTypeException if the HOURS unit is not
+     * supported
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    @Override
+    public Temporal addTo(Temporal temporal) {
+        if (hours != 0) {
+            temporal = temporal.plus(hours, HOURS);
+        }
+        return temporal;
+    }
+
+    /**
+     * Subtracts this amount from the specified temporal object.
+     * <p>
+     * This returns a temporal object of the same observable type as the input
+     * with this amount subtracted.
+     * <p>
+     * In most cases, it is clearer to reverse the calling pattern by using
+     * {@link Temporal#minus(TemporalAmount)}.
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   dateTime = thisAmount.subtractFrom(dateTime);
+     *   dateTime = dateTime.minus(thisAmount);
+     * </pre>
+     * <p>
+     * Only non-zero amounts will be subtracted.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param temporal  the temporal object to adjust, not null
+     * @return an object of the same type with the adjustment made, not null
+     * @throws DateTimeException if unable to subtract
+     * @throws UnsupportedTemporalTypeException if the HOURS unit is not
+     * supported
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    @Override
+    public Temporal subtractFrom(Temporal temporal) {
+        if (hours != 0) {
+            temporal = temporal.minus(hours, HOURS);
+        }
+        return temporal;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Compares this amount to the specified {@code Hours}.
+     * <p>
+     * The comparison is based on the total length of the amounts. It is
+     * "consistent with equals", as defined by {@link Comparable}.
+     *
+     * @param otherAmount  the other amount, not null
+     * @return the comparator value, negative if less, positive if greater
+     */
+    @Override
+    public int compareTo(Hours otherAmount) {
+        int thisValue = this.hours;
+        int otherValue = otherAmount.hours;
+        return Integer.compare(thisValue, otherValue);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Checks if this amount is equal to the specified {@code Hours}.
+     * <p>
+     * The comparison is based on the total length of the durations.
+     *
+     * @param otherAmount  the other amount, null returns false
+     * @return true if the other amount is equal to this one
+     */
+    @Override
+    public boolean equals(Object otherAmount) {
+        if (this == otherAmount) {
+            return true;
+        }
+        if (otherAmount instanceof Hours) {
+            Hours other = (Hours) otherAmount;
+            return this.hours == other.hours;
+        }
+        return false;
+    }
+
+    /**
+     * A hash code for this amount.
+     *
+     * @return a suitable hash code
+     */
+    @Override
+    public int hashCode() {
+        return hours;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a string representation of the number of hours. This will be in
+     * the format 'PTnH' where n is the number of hours.
+     *
+     * @return the number of hours in ISO-8601 string format
+     */
+    @Override
+    public String toString() {
+        return "PT" + hours + "H";
+    }
+
+}

--- a/src/main/java/org/threeten/extra/Minutes.java
+++ b/src/main/java/org/threeten/extra/Minutes.java
@@ -1,0 +1,577 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+import java.io.Serializable;
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.Period;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.UnsupportedTemporalTypeException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A minute-based amount of time, such as '8 minutes'.
+ * <p>
+ * This class models a quantity or amount of time in terms of minutes.
+ * It is a type-safe way of representing a number of minutes in an application.
+ * <p>
+ * The model is of a directed amount, meaning that the amount may be negative.
+ *
+ * <h3>Implementation Requirements:</h3>
+ * This class is immutable and thread-safe.
+ * <p>
+ * This class must be treated as a value type. Do not synchronize, rely on the
+ * identity hash code or use the distinction between equals() and ==.
+ */
+public class Minutes
+        implements TemporalAmount, Comparable<Minutes>, Serializable {
+    
+    /**
+     * A constant for zero minutes.
+     */
+    public static final Minutes ZERO = new Minutes(0);
+    
+    /**
+     * A serialization identifier for this class.
+     */
+    private static final long serialVersionUID = 2602801843170589407L;
+    
+    /**
+     * The number of minutes per hour.
+     */
+    private static final int MINUTES_PER_HOUR = 60;
+    
+    /**
+     * The pattern for parsing.
+     */
+    private static final Pattern PATTERN =
+            Pattern.compile("([-+]?)PT"
+                    + "(?:([-+]?[0-9]+)H)?"
+                    + "(?:([-+]?[0-9]+)M)?", Pattern.CASE_INSENSITIVE);
+    
+    /**
+     * The number of minutes.
+     */
+    private final int minutes;
+    
+    /**
+     * Obtains a {@code Minutes} representing a number of minutes.
+     * <p>
+     * The resulting amount will have the specified minutes.
+     *
+     * @param minutes  the number of minutes, positive or negative
+     * @return the number of minutes, not null
+     */
+    public static Minutes of(int minutes) {
+        if (minutes == 0) {
+            return ZERO;
+        }
+        return new Minutes(minutes);
+    }
+    
+    /**
+     * Obtains a {@code Minutes} representing the number of minutes
+     * equivalent to a number of hours.
+     * <p>
+     * The resulting amount will be minute-based, with the number of minutes
+     * equal to the number of hours multiplied by 60.
+     *
+     * @param hours  the number of hours, positive or negative
+     * @return the amount with the input hours converted to minutes, not null
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public static Minutes ofHours(int hours) {
+        if (hours == 0) {
+            return ZERO;
+        }
+        return new Minutes(Math.multiplyExact(hours, MINUTES_PER_HOUR));
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains an instance of {@code Minutes} from a temporal amount.
+     * <p>
+     * This obtains an instance based on the specified amount.
+     * A {@code TemporalAmount} represents an amount of time, which may be
+     * date-based or time-based, which this factory extracts to a {@code Minutes}.
+     * <p>
+     * The result is calculated by looping around each unit in the specified amount.
+     * Each amount is converted to minutes using {@link Temporals#convertAmount}.
+     * If the conversion yields a remainder, an exception is thrown.
+     * If the amount is zero, the unit is ignored.
+     *
+     * @param amount  the temporal amount to convert, not null
+     * @return the equivalent amount, not null
+     * @throws DateTimeException if unable to convert to a {@code Minutes}
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public static Minutes from(TemporalAmount amount) {
+        if (amount instanceof Minutes) {
+            return (Minutes) amount;
+        }
+        Objects.requireNonNull(amount, "amount");
+        int minutes = 0;
+        for (TemporalUnit unit : amount.getUnits()) {
+            long value = amount.get(unit);
+            if (value != 0) {
+                long[] converted = Temporals.convertAmount(value, unit, MINUTES);
+                if (converted[1] != 0) {
+                    throw new DateTimeException(
+                            "Amount could not be converted to a whole number of minutes: " + value + " " + unit);
+                }
+                minutes = Math.addExact(minutes, Math.toIntExact(converted[0]));
+            }
+        }
+        return of(minutes);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code Minutes} from a text string such as {@code PTnM}.
+     * <p>
+     * This will parse the string produced by {@code toString()} which is
+     * based on the ISO-8601 period format {@code PTnHnM}.
+     * <p>
+     * The string starts with an optional sign, denoted by the ASCII negative
+     * or positive symbol. If negative, the whole amount is negated.
+     * The ASCII letters "P" and "T" are next in upper or lower case.
+     * There are then two sections, each consisting of a number and a suffix.
+     * At least one of the two sections must be present.
+     * The sections have suffixes in ASCII of "H" and "M" for hours and minutes,
+     * accepted in upper or lower case. The suffixes must occur in order.
+     * The number part of each section must consist of ASCII digits.
+     * The number may be prefixed by the ASCII negative or positive symbol.
+     * The number must parse to an {@code int}.
+     * <p>
+     * The leading plus/minus sign, and negative values for hours and minutes are
+     * not part of the ISO-8601 standard.
+     * <p>
+     * For example, the following are valid inputs:
+     * <pre>
+     *   "PT2M"            -- Minutes.of(2)
+     *   "PT-2M"           -- Minutes.of(-2)
+     *   "-PT2M"           -- Minutes.of(-2)
+     *   "-PT-2M"          -- Minutes.of(2)
+     *   "PT3H"            -- Minutes.of(3 * 60)
+     *   "PT3H-2M"         -- Minutes.of(3 * 60 - 2)
+     * </pre>
+     *
+     * @param text  the text to parse, not null
+     * @return the parsed period, not null
+     * @throws DateTimeParseException if the text cannot be parsed to a period
+     */
+    public static Minutes parse(CharSequence text) {
+        Objects.requireNonNull(text, "text");
+        Matcher matcher = PATTERN.matcher(text);
+        if (matcher.matches()) {
+            int negate = ("-".equals(matcher.group(1)) ? -1 : 1);
+            String hoursStr = matcher.group(2);
+            String minutesStr = matcher.group(3);
+            if (hoursStr != null || minutesStr != null) {
+                int minutes = 0;
+                if (minutesStr != null) {
+                    try {
+                        minutes = Integer.parseInt(minutesStr);
+                    } catch (NumberFormatException ex) {
+                        throw new DateTimeParseException("Text cannot be parsed to a Minutes, non-numeric minutes", text, 0, ex);
+                    }
+                }
+                if (hoursStr != null) {
+                    try {
+                        int hours = Math.multiplyExact(Integer.parseInt(hoursStr), MINUTES_PER_HOUR);
+                        minutes = Math.addExact(minutes, hours);
+                    } catch (NumberFormatException ex) {
+                        throw new DateTimeParseException("Text cannot be parsed to a Minutes, non-numeric minutes", text, 0, ex);
+                    }
+                }
+                return of(Math.multiplyExact(minutes, negate));
+            }
+        }
+        throw new DateTimeParseException("Text cannot be parsed to a Minutes", text, 0);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Obtains a {@code Minutes} consisting of the number of minutes between two dates.
+     * <p>
+     * The start date is included, but the end date is not.
+     * The result of this method can be negative if the end is before the start.
+     *
+     * @param startDateInclusive  the start date, inclusive, not null
+     * @param endDateExclusive  the end date, exclusive, not null
+     * @return the number of minutes between this date and the end date, not null
+     */
+    public static Minutes between(Temporal startDateInclusive, Temporal endDateExclusive) {
+        return of(Math.toIntExact(MINUTES.between(startDateInclusive, endDateExclusive)));
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Constructs an instance using a specific number of minutes.
+     *
+     * @param minutes  the minutes to use
+     */
+    private Minutes(int minutes) {
+        this.minutes = minutes;
+    }
+    
+    /**
+     * Resolves singletons.
+     *
+     * @return the singleton instance
+     */
+    private Object readResolve() {
+        return Minutes.of(minutes);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the value of the requested unit.
+     * <p>
+     * This returns a value for the supported unit - {@link ChronoUnit#MINUTES MINUTES}.
+     * All other units throw an exception.
+     *
+     * @param unit  the {@code TemporalUnit} for which to return the value
+     * @return the long value of the unit
+     * @throws UnsupportedTemporalTypeException if the unit is not supported
+     */
+    @Override
+    public long get(TemporalUnit unit) {
+        if (unit == MINUTES) {
+            return minutes;
+        }
+        throw new UnsupportedTemporalTypeException("Unsupported unit: " + unit);
+    }
+
+    /**
+     * Gets the set of units supported by this amount.
+     * <p>
+     * The single supported unit is {@link ChronoUnit#MINUTES MINUTES}.
+     * <p>
+     * This set can be used in conjunction with {@link #get(TemporalUnit)}
+     * to access the entire state of the amount.
+     *
+     * @return a list containing the minutes unit, not null
+     */
+    @Override
+    public List<TemporalUnit> getUnits() {
+        return Collections.singletonList(MINUTES);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the number of minutes in this amount.
+     *
+     * @return the number of minutes
+     */
+    public int getAmount() {
+        return minutes;
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this amount with the specified amount added.
+     * <p>
+     * The parameter is converted using {@link Minutes#from(TemporalAmount)}.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param amountToAdd  the amount to add, not null
+     * @return a {@code Minutes} based on this instance with the requested amount added, not null
+     * @throws DateTimeException if the specified amount  contains an invalid unit
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public Minutes plus(TemporalAmount amountToAdd) {
+        return plus(Minutes.from(amountToAdd).getAmount());
+    }
+
+    /**
+     * Returns a copy of this amount with the specified number of minutes added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param minutes  the amount of minutes to add, may be negative
+     * @return a {@code Minutes} based on this instance with the requested amount added, not null
+     * @throws ArithmeticException if the result overflows an int
+     */
+    public Minutes plus(int minutes) {
+        if (minutes == 0) {
+            return this;
+        }
+        return of(Math.addExact(this.minutes, minutes));
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this amount with the specified amount subtracted.
+     * <p>
+     * The parameter is converted using {@link Minutes#from(TemporalAmount)}.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param amountToAdd  the amount to add, not null
+     * @return a {@code Minutes} based on this instance with the requested amount subtracted, not null
+     * @throws DateTimeException if the specified amount  contains an invalid unit
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public Minutes minus(TemporalAmount amountToAdd) {
+        return minus(Minutes.from(amountToAdd).getAmount());
+    }
+    
+    /**
+     * Returns a copy of this amount with the specified number of minutes subtracted.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param minutes  the amount of minutes to add, may be negative
+     * @return a {@code Minutes} based on this instance with the requested amount subtracted, not null
+     * @throws ArithmeticException if the result overflows an int
+     */
+    public Minutes minus(int minutes) {
+        if (minutes == 0) {
+            return this;
+        }
+        return of(Math.subtractExact(this.minutes, minutes));
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns an instance with the amount multiplied by the specified scalar.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param scalar  the scalar to multiply by, not null
+     * @return the amount multiplied by the specified scalar, not null
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    public Minutes multipliedBy(int scalar) {
+        if (scalar == 1) {
+            return this;
+        }
+        return of(Math.multiplyExact(minutes, scalar));
+    }
+    
+    /**
+     * Returns an instance with the amount divided by the specified divisor.
+     * <p>
+     * The calculation uses integer division, thus 3 divided by 2 is 1.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param divisor  the amount to divide by, may be negative
+     * @return the amount divided by the specified divisor, not null
+     * @throws ArithmeticException if the divisor is zero
+     */
+    public Minutes dividedBy(int divisor) {
+        if (divisor == 1) {
+            return this;
+        }
+        return of(minutes / divisor);
+    }
+    
+    /**
+     * Returns an instance with the amount negated.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return the negated amount, not null
+     * @throws ArithmeticException if numeric overflow occurs, which only happens if
+     *  the amount is {@code Long.MIN_VALUE}
+     */
+    public Minutes negated() {
+        return multipliedBy(-1);
+    }
+    
+    /**
+     * Returns a copy of this duration with a positive length.
+     * <p>
+     * This method returns a positive duration by effectively removing the sign from any negative total length.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @return the absolute amount, not null
+     * @throws ArithmeticException if numeric overflow occurs, which only happens if
+     *  the amount is {@code Long.MIN_VALUE}
+     */
+    public Minutes abs() {
+        return minutes < 0 ? negated() : this;
+    }
+    
+    //-------------------------------------------------------------------------
+    /**
+     * Gets the number of minutes as a {@code Duration}.
+     * <p>
+     * This returns a duration with the same number of minutes.
+     *
+     * @return the equivalent duration, not null
+     */
+    public Duration toDuration() {
+        return Duration.ofMinutes(minutes);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Adds this amount to the specified temporal object.
+     * <p>
+     * This returns a temporal object of the same observable type as the input
+     * with this amount added.
+     * <p>
+     * In most cases, it is clearer to reverse the calling pattern by using
+     * {@link Temporal#plus(TemporalAmount)}.
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   dateTime = thisAmount.addTo(dateTime);
+     *   dateTime = dateTime.plus(thisAmount);
+     * </pre>
+     * <p>
+     * Only non-zero amounts will be added.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param temporal  the temporal object to adjust, not null
+     * @return an object of the same type with the adjustment made, not null
+     * @throws DateTimeException if unable to add
+     * @throws UnsupportedTemporalTypeException if the MINUTES unit is not supported
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    @Override
+    public Temporal addTo(Temporal temporal) {
+        if (minutes != 0) {
+            temporal = temporal.plus(minutes, MINUTES);
+        }
+        return temporal;
+    }
+
+    /**
+     * Subtracts this amount from the specified temporal object.
+     * <p>
+     * This returns a temporal object of the same observable type as the input
+     * with this amount subtracted.
+     * <p>
+     * In most cases, it is clearer to reverse the calling pattern by using
+     * {@link Temporal#minus(TemporalAmount)}.
+     * <pre>
+     *   // these two lines are equivalent, but the second approach is recommended
+     *   dateTime = thisAmount.subtractFrom(dateTime);
+     *   dateTime = dateTime.minus(thisAmount);
+     * </pre>
+     * <p>
+     * Only non-zero amounts will be subtracted.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param temporal  the temporal object to adjust, not null
+     * @return an object of the same type with the adjustment made, not null
+     * @throws DateTimeException if unable to subtract
+     * @throws UnsupportedTemporalTypeException if the MINUTES unit is not supported
+     * @throws ArithmeticException if numeric overflow occurs
+     */
+    @Override
+    public Temporal subtractFrom(Temporal temporal) {
+        if (minutes != 0) {
+            temporal = temporal.minus(minutes, MINUTES);
+        }
+        return temporal;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Compares this amount to the specified {@code Minutes}.
+     * <p>
+     * The comparison is based on the total length of the amounts.
+     * It is "consistent with equals", as defined by {@link Comparable}.
+     *
+     * @param otherAmount  the other amount, not null
+     * @return the comparator value, negative if less, positive if greater
+     */
+    @Override
+    public int compareTo(Minutes otherAmount) {
+        int thisValue = this.minutes;
+        int otherValue = otherAmount.minutes;
+        return Integer.compare(thisValue, otherValue);
+    }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Checks if this amount is equal to the specified {@code Minutes}.
+     * <p>
+     * The comparison is based on the total length of the durations.
+     *
+     * @param otherAmount  the other amount, null returns false
+     * @return true if the other amount is equal to this one
+     */
+    @Override
+    public boolean equals(Object otherAmount) {
+        if (this == otherAmount) {
+            return true;
+        }
+        if (otherAmount instanceof Minutes) {
+            Minutes other = (Minutes) otherAmount;
+            return this.minutes == other.minutes;
+        }
+        return false;
+    }
+
+    /**
+     * A hash code for this amount.
+     *
+     * @return a suitable hash code
+     */
+    @Override
+    public int hashCode() {
+        return minutes;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a string representation of the number of minutes.
+     * This will be in the format 'PTnM' where n is the number of minutes.
+     *
+     * @return the number of minutes in ISO-8601 string format
+     */
+    @Override
+    public String toString() {
+        return "PT" + minutes + "M";
+    }
+    
+}

--- a/src/main/java/org/threeten/extra/Months.java
+++ b/src/main/java/org/threeten/extra/Months.java
@@ -208,20 +208,20 @@ public final class Months
         Matcher matcher = PATTERN.matcher(text);
         if (matcher.matches()) {
             int negate = ("-".equals(matcher.group(1)) ? -1 : 1);
-            String weeksStr = matcher.group(2);
-            String daysStr = matcher.group(3);
-            if (weeksStr != null || daysStr != null) {
+            String yearsStr = matcher.group(2);
+            String monthsStr = matcher.group(3);
+            if (yearsStr != null || monthsStr != null) {
                 int months = 0;
-                if (daysStr != null) {
+                if (monthsStr != null) {
                     try {
-                        months = Integer.parseInt(daysStr);
+                        months = Integer.parseInt(monthsStr);
                     } catch (NumberFormatException ex) {
                         throw new DateTimeParseException("Text cannot be parsed to a Months, non-numeric months", text, 0, ex);
                     }
                 }
-                if (weeksStr != null) {
+                if (yearsStr != null) {
                     try {
-                        int years = Math.multiplyExact(Integer.parseInt(weeksStr), MONTHS_PER_YEAR);
+                        int years = Math.multiplyExact(Integer.parseInt(yearsStr), MONTHS_PER_YEAR);
                         months = Math.addExact(months, years);
                     } catch (NumberFormatException ex) {
                         throw new DateTimeParseException("Text cannot be parsed to a Months, non-numeric years", text, 0, ex);

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test class.
+ */
+@Test
+public class TestHours {
+    
+    //-----------------------------------------------------------------------
+    public void test_isSerializable() {
+        assertTrue(Serializable.class.isAssignableFrom(Hours.class));
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_deserializationSingleton() throws Exception {
+        Hours orginal = Hours.ZERO;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(orginal);
+        out.close();
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream in = new ObjectInputStream(bais);
+        Hours ser = (Hours) in.readObject();
+        assertSame(Hours.ZERO, ser);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_ZERO() {
+        assertSame(Hours.of(0), Hours.ZERO);
+        assertSame(Hours.of(0), Hours.ZERO);
+        assertEquals(Hours.ZERO.getAmount(), 0);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_of() {
+        assertEquals(Hours.of(0).getAmount(), 0);
+        assertEquals(Hours.of(1).getAmount(), 1);
+        assertEquals(Hours.of(2).getAmount(), 2);
+        assertEquals(Hours.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
+        assertEquals(Hours.of(-1).getAmount(), -1);
+        assertEquals(Hours.of(-2).getAmount(), -2);
+        assertEquals(Hours.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+    }
+    
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "parseValid")
+    Object[][] data_valid() {
+        return new Object[][] {
+            {"PT0H", 0},
+            {"PT1H", 1},
+            {"PT2H", 2},
+            {"PT123456789H", 123456789},
+            {"PT+0H", 0},
+            {"PT+2H", 2},
+            {"PT-0H", 0},
+            {"PT-2H", -2},
+        };
+    }
+
+    @Test(dataProvider = "parseValid")
+    public void test_parse_CharSequence_valid(String str, int expectedDays) {
+        assertEquals(Hours.parse(str), Hours.of(expectedDays));
+    }
+
+    @Test(dataProvider = "parseValid")
+    public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
+        assertEquals(Hours.parse("+" + str), Hours.of(expectedDays));
+    }
+
+    @Test(dataProvider = "parseValid")
+    public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
+        assertEquals(Hours.parse("-" + str), Hours.of(-expectedDays));
+    }
+
+    @DataProvider(name = "parseInvalid")
+    Object[][] data_invalid() {
+        return new Object[][] {
+            {"P3W"},
+            {"P3D"},
+            {"P3Q"},
+            {"P1M2Y"},
+
+            {"3"},
+            {"-3"},
+            {"3H"},
+            {"-3H"},
+            {"P3"},
+            {"P-3"},
+            {"PH"},
+            {"T"},
+            {"T3H"},
+        };
+    }
+
+    @Test(expectedExceptions = DateTimeParseException.class, dataProvider = "parseInvalid")
+    public void test_parse_CharSequence_invalid(String str) {
+        Hours.parse(str);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_parse_CharSequence_null() {
+        Hours.parse((CharSequence) null);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_plus_TemporalAmount_Hours() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(5), test5.plus(Hours.of(0)));
+        assertEquals(Hours.of(7), test5.plus(Hours.of(2)));
+        assertEquals(Hours.of(3), test5.plus(Hours.of(-2)));
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE - 1).plus(Hours.of(1)));
+        assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).plus(Hours.of(-1)));
+    }
+
+    public void test_plus_TemporalAmount_Period() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(5), test5.plus(Duration.ofHours(0)));
+        assertEquals(Hours.of(7), test5.plus(Duration.ofHours(2)));
+        assertEquals(Hours.of(3), test5.plus(Duration.ofHours(-2)));
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE - 1).plus(Duration.ofHours(1)));
+        assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).plus(Duration.ofHours(-1)));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_TemporalAmount_overflowTooBig() {
+        Hours.of(Integer.MAX_VALUE - 1).plus(Hours.of(2));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_TemporalAmount_overflowTooSmall() {
+        Hours.of(Integer.MIN_VALUE + 1).plus(Hours.of(-2));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_plus_TemporalAmount_null() {
+        Hours.of(Integer.MIN_VALUE + 1).plus(null);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_plus_int() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(5), test5.plus(0));
+        assertEquals(Hours.of(7), test5.plus(2));
+        assertEquals(Hours.of(3), test5.plus(-2));
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE - 1).plus(1));
+        assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).plus(-1));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_int_overflowTooBig() {
+        Hours.of(Integer.MAX_VALUE - 1).plus(2);
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_int_overflowTooSmall() {
+        Hours.of(Integer.MIN_VALUE + 1).plus(-2);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_minus_TemporalAmount_Hours() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(5), test5.minus(Hours.of(0)));
+        assertEquals(Hours.of(3), test5.minus(Hours.of(2)));
+        assertEquals(Hours.of(7), test5.minus(Hours.of(-2)));
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE - 1).minus(Hours.of(-1)));
+        assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).minus(Hours.of(1)));
+    }
+
+    public void test_minus_TemporalAmount_Duration() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(5), test5.minus(Duration.ofHours(0)));
+        assertEquals(Hours.of(3), test5.minus(Duration.ofHours(2)));
+        assertEquals(Hours.of(7), test5.minus(Duration.ofHours(-2)));
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE - 1).minus(Duration.ofHours(-1)));
+        assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).minus(Duration.ofHours(1)));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_TemporalAmount_overflowTooBig() {
+        Hours.of(Integer.MAX_VALUE - 1).minus(Hours.of(-2));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_TemporalAmount_overflowTooSmall() {
+        Hours.of(Integer.MIN_VALUE + 1).minus(Hours.of(2));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_minus_TemporalAmount_null() {
+        Hours.of(Integer.MIN_VALUE + 1).minus(null);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_minus_int() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(5), test5.minus(0));
+        assertEquals(Hours.of(3), test5.minus(2));
+        assertEquals(Hours.of(7), test5.minus(-2));
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE - 1).minus(-1));
+        assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).minus(1));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_int_overflowTooBig() {
+        Hours.of(Integer.MAX_VALUE - 1).minus(-2);
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_int_overflowTooSmall() {
+        Hours.of(Integer.MIN_VALUE + 1).minus(2);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_multipliedBy() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(0), test5.multipliedBy(0));
+        assertEquals(Hours.of(5), test5.multipliedBy(1));
+        assertEquals(Hours.of(10), test5.multipliedBy(2));
+        assertEquals(Hours.of(15), test5.multipliedBy(3));
+        assertEquals(Hours.of(-15), test5.multipliedBy(-3));
+    }
+
+    public void test_multipliedBy_negate() {
+        Hours test5 = Hours.of(5);
+        assertEquals(Hours.of(-15), test5.multipliedBy(-3));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_multipliedBy_overflowTooBig() {
+        Hours.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_multipliedBy_overflowTooSmall() {
+        Hours.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_dividedBy() {
+        Hours test12 = Hours.of(12);
+        assertEquals(Hours.of(12), test12.dividedBy(1));
+        assertEquals(Hours.of(6), test12.dividedBy(2));
+        assertEquals(Hours.of(4), test12.dividedBy(3));
+        assertEquals(Hours.of(3), test12.dividedBy(4));
+        assertEquals(Hours.of(2), test12.dividedBy(5));
+        assertEquals(Hours.of(2), test12.dividedBy(6));
+        assertEquals(Hours.of(-4), test12.dividedBy(-3));
+    }
+
+    public void test_dividedBy_negate() {
+        Hours test12 = Hours.of(12);
+        assertEquals(Hours.of(-4), test12.dividedBy(-3));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_dividedBy_divideByZero() {
+        Hours.of(1).dividedBy(0);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_negated() {
+        assertEquals(Hours.of(0), Hours.of(0).negated());
+        assertEquals(Hours.of(-12), Hours.of(12).negated());
+        assertEquals(Hours.of(12), Hours.of(-12).negated());
+        assertEquals(Hours.of(-Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE).negated());
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_negated_overflow() {
+        Hours.of(Integer.MIN_VALUE).negated();
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_abs() {
+        assertEquals(Hours.of(0), Hours.of(0).abs());
+        assertEquals(Hours.of(12), Hours.of(12).abs());
+        assertEquals(Hours.of(12), Hours.of(-12).abs());
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE).abs());
+        assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(-Integer.MAX_VALUE).abs());
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_abs_overflow() {
+        Hours.of(Integer.MIN_VALUE).abs();
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_toDuration() {
+        for (int i = -20; i < 20; i++) {
+            assertEquals(Hours.of(i).toPeriod(), Duration.ofHours(i));
+        }
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_compareTo() {
+        Hours test5 = Hours.of(5);
+        Hours test6 = Hours.of(6);
+        assertEquals(0, test5.compareTo(test5));
+        assertEquals(-1, test5.compareTo(test6));
+        assertEquals(1, test6.compareTo(test5));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_compareTo_null() {
+        Hours test5 = Hours.of(5);
+        test5.compareTo(null);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_equals() {
+        Hours test5 = Hours.of(5);
+        Hours test6 = Hours.of(6);
+        assertEquals(true, test5.equals(test5));
+        assertEquals(false, test5.equals(test6));
+        assertEquals(false, test6.equals(test5));
+    }
+
+    public void test_equals_null() {
+        Hours test5 = Hours.of(5);
+        assertEquals(false, test5.equals(null));
+    }
+
+    public void test_equals_otherClass() {
+        Hours test5 = Hours.of(5);
+        assertEquals(false, test5.equals(""));
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_hashCode() {
+        Hours test5 = Hours.of(5);
+        Hours test6 = Hours.of(6);
+        assertEquals(true, test5.hashCode() == test5.hashCode());
+        assertEquals(false, test5.hashCode() == test6.hashCode());
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_toString() {
+        Hours test5 = Hours.of(5);
+        assertEquals("PT5H", test5.toString());
+        Hours testM1 = Hours.of(-1);
+        assertEquals("PT-1H", testM1.toString());
+    }
+    
+}

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -1,0 +1,409 @@
+/*
+ * Copyright (c) 2007-present, Stephen Colebourne & Michael Nascimento Santos
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ *  * Neither the name of JSR-310 nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.threeten.extra;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Period;
+import java.time.format.DateTimeParseException;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test class.
+ */
+@Test
+public class TestMinutes {
+    
+    //-----------------------------------------------------------------------
+    public void test_isSerializable() {
+        assertTrue(Serializable.class.isAssignableFrom(Minutes.class));
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_deserializationSingleton() throws Exception {
+        Minutes orginal = Minutes.ZERO;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(orginal);
+        out.close();
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream in = new ObjectInputStream(bais);
+        Minutes ser = (Minutes) in.readObject();
+        assertSame(Minutes.ZERO, ser);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_ZERO() {
+        assertSame(Minutes.of(0), Minutes.ZERO);
+        assertSame(Minutes.of(0), Minutes.ZERO);
+        assertEquals(Minutes.ZERO.getAmount(), 0);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_of() {
+        assertEquals(Minutes.of(0).getAmount(), 0);
+        assertEquals(Minutes.of(1).getAmount(), 1);
+        assertEquals(Minutes.of(2).getAmount(), 2);
+        assertEquals(Minutes.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
+        assertEquals(Minutes.of(-1).getAmount(), -1);
+        assertEquals(Minutes.of(-2).getAmount(), -2);
+        assertEquals(Minutes.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_ofHours() {
+        assertEquals(Minutes.ofHours(0).getAmount(), 0);
+        assertEquals(Minutes.ofHours(1).getAmount(), 60);
+        assertEquals(Minutes.ofHours(2).getAmount(), 120);
+        assertEquals(Minutes.ofHours(Integer.MAX_VALUE / 60).getAmount(), (Integer.MAX_VALUE / 60) * 60);
+        assertEquals(Minutes.ofHours(-1).getAmount(), -60);
+        assertEquals(Minutes.ofHours(-2).getAmount(), -120);
+        assertEquals(Minutes.ofHours(Integer.MIN_VALUE / 60).getAmount(), (Integer.MIN_VALUE / 60) * 60);
+    }
+    
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_ofHours_overflow() {
+        Minutes.ofHours((Integer.MAX_VALUE / 60) + 60);
+    }
+    
+    //-----------------------------------------------------------------------
+    @DataProvider(name = "parseValid")
+    Object[][] data_valid() {
+        return new Object[][] {
+            {"PT0M", 0},
+            {"PT1M", 1},
+            {"PT2M", 2},
+            {"PT123456789M", 123456789},
+            {"PT+0M", 0},
+            {"PT+2M", 2},
+            {"PT-0M", 0},
+            {"PT-2M", -2},
+
+            {"PT0H", 0},
+            {"PT1H", 60},
+            {"PT2H", 120},
+            {"PT1234H", 1234 * 60},
+            {"PT+0H", 0},
+            {"PT+2H", 120},
+            {"PT-0H", 0},
+            {"PT-2H", -120},
+
+            {"PT0H0M", 0},
+            {"PT2H3M", 123},
+            {"PT+2H3M", 123},
+            {"PT2H+3M", 123},
+            {"PT-2H3M", -117},
+            {"PT2H-3M", 117},
+            {"PT-2H-3M", -123},
+        };
+    }
+
+    @Test(dataProvider = "parseValid")
+    public void test_parse_CharSequence_valid(String str, int expectedMinutes) {
+        assertEquals(Minutes.parse(str), Minutes.of(expectedMinutes));
+    }
+
+    @Test(dataProvider = "parseValid")
+    public void test_parse_CharSequence_valid_initialPlus(String str, int expectedMinutes) {
+        assertEquals(Minutes.parse("+" + str), Minutes.of(expectedMinutes));
+    }
+
+    @Test(dataProvider = "parseValid")
+    public void test_parse_CharSequence_valid_initialMinus(String str, int expectedMinutes) {
+        assertEquals(Minutes.parse("-" + str), Minutes.of(-expectedMinutes));
+    }
+
+    @DataProvider(name = "parseInvalid")
+    Object[][] data_invalid() {
+        return new Object[][] {
+            {"P3W"},
+            {"P3D"},
+            {"P3Q"},
+            {"P1M2Y"},
+
+            {"3"},
+            {"-3"},
+            {"3M"},
+            {"-3M"},
+            {"P3"},
+            {"P-3"},
+            {"PM"},
+            {"T3"},
+            {"P3M"},
+            {"PT3S"},
+            {"PT3"},
+        };
+    }
+
+    @Test(expectedExceptions = DateTimeParseException.class, dataProvider = "parseInvalid")
+    public void test_parse_CharSequence_invalid(String str) {
+        Minutes.parse(str);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_parse_CharSequence_null() {
+        Minutes.parse((CharSequence) null);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_plus_TemporalAmount_Minutes() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(Minutes.of(5), test5.plus(Minutes.of(0)));
+        assertEquals(Minutes.of(7), test5.plus(Minutes.of(2)));
+        assertEquals(Minutes.of(3), test5.plus(Minutes.of(-2)));
+        assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE - 1).plus(Minutes.of(1)));
+        assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).plus(Minutes.of(-1)));
+    }
+    
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_TemporalAmount_overflowTooBig() {
+        Minutes.of(Integer.MAX_VALUE - 1).plus(Minutes.of(2));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_TemporalAmount_overflowTooSmall() {
+        Minutes.of(Integer.MIN_VALUE + 1).plus(Minutes.of(-2));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_plus_TemporalAmount_null() {
+        Minutes.of(Integer.MIN_VALUE + 1).plus(null);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_plus_int() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(Minutes.of(5), test5.plus(0));
+        assertEquals(Minutes.of(7), test5.plus(2));
+        assertEquals(Minutes.of(3), test5.plus(-2));
+        assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE - 1).plus(1));
+        assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).plus(-1));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_int_overflowTooBig() {
+        Minutes.of(Integer.MAX_VALUE - 1).plus(2);
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plus_int_overflowTooSmall() {
+        Minutes.of(Integer.MIN_VALUE + 1).plus(-2);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_minus_TemporalAmount_Minutes() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(Minutes.of(5), test5.minus(Minutes.of(0)));
+        assertEquals(Minutes.of(3), test5.minus(Minutes.of(2)));
+        assertEquals(Minutes.of(7), test5.minus(Minutes.of(-2)));
+        assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE - 1).minus(Minutes.of(-1)));
+        assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).minus(Minutes.of(1)));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_TemporalAmount_overflowTooBig() {
+        Minutes.of(Integer.MAX_VALUE - 1).minus(Minutes.of(-2));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_TemporalAmount_overflowTooSmall() {
+        Minutes.of(Integer.MIN_VALUE + 1).minus(Minutes.of(2));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_minus_TemporalAmount_null() {
+        Minutes.of(Integer.MIN_VALUE + 1).minus(null);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_minus_int() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(Minutes.of(5), test5.minus(0));
+        assertEquals(Minutes.of(3), test5.minus(2));
+        assertEquals(Minutes.of(7), test5.minus(-2));
+        assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE - 1).minus(-1));
+        assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).minus(1));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_int_overflowTooBig() {
+        Minutes.of(Integer.MAX_VALUE - 1).minus(-2);
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minus_int_overflowTooSmall() {
+        Minutes.of(Integer.MIN_VALUE + 1).minus(2);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_multipliedBy() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(Minutes.of(0), test5.multipliedBy(0));
+        assertEquals(Minutes.of(5), test5.multipliedBy(1));
+        assertEquals(Minutes.of(10), test5.multipliedBy(2));
+        assertEquals(Minutes.of(15), test5.multipliedBy(3));
+        assertEquals(Minutes.of(-15), test5.multipliedBy(-3));
+    }
+
+    public void test_multipliedBy_negate() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(Minutes.of(-15), test5.multipliedBy(-3));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_multipliedBy_overflowTooBig() {
+        Minutes.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_multipliedBy_overflowTooSmall() {
+        Minutes.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_dividedBy() {
+        Minutes test12 = Minutes.of(12);
+        assertEquals(Minutes.of(12), test12.dividedBy(1));
+        assertEquals(Minutes.of(6), test12.dividedBy(2));
+        assertEquals(Minutes.of(4), test12.dividedBy(3));
+        assertEquals(Minutes.of(3), test12.dividedBy(4));
+        assertEquals(Minutes.of(2), test12.dividedBy(5));
+        assertEquals(Minutes.of(2), test12.dividedBy(6));
+        assertEquals(Minutes.of(-4), test12.dividedBy(-3));
+    }
+
+    public void test_dividedBy_negate() {
+        Minutes test12 = Minutes.of(12);
+        assertEquals(Minutes.of(-4), test12.dividedBy(-3));
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_dividedBy_divideByZero() {
+        Minutes.of(1).dividedBy(0);
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_negated() {
+        assertEquals(Minutes.of(0), Minutes.of(0).negated());
+        assertEquals(Minutes.of(-12), Minutes.of(12).negated());
+        assertEquals(Minutes.of(12), Minutes.of(-12).negated());
+        assertEquals(Minutes.of(-Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE).negated());
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_negated_overflow() {
+        Minutes.of(Integer.MIN_VALUE).negated();
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_abs() {
+        assertEquals(Minutes.of(0), Minutes.of(0).abs());
+        assertEquals(Minutes.of(12), Minutes.of(12).abs());
+        assertEquals(Minutes.of(12), Minutes.of(-12).abs());
+        assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE).abs());
+        assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(-Integer.MAX_VALUE).abs());
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_abs_overflow() {
+        Minutes.of(Integer.MIN_VALUE).abs();
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_toDuration() {
+        for (int i = -20; i < 20; i++) {
+            assertEquals(Minutes.of(i).toDuration(), Duration.ofMinutes(i));
+        }
+    }
+    
+    //-----------------------------------------------------------------------
+    public void test_compareTo() {
+        Minutes test5 = Minutes.of(5);
+        Minutes test6 = Minutes.of(6);
+        assertEquals(0, test5.compareTo(test5));
+        assertEquals(-1, test5.compareTo(test6));
+        assertEquals(1, test6.compareTo(test5));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void test_compareTo_null() {
+        Minutes test5 = Minutes.of(5);
+        test5.compareTo(null);
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_equals() {
+        Minutes test5 = Minutes.of(5);
+        Minutes test6 = Minutes.of(6);
+        assertEquals(true, test5.equals(test5));
+        assertEquals(false, test5.equals(test6));
+        assertEquals(false, test6.equals(test5));
+    }
+
+    public void test_equals_null() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(false, test5.equals(null));
+    }
+
+    public void test_equals_otherClass() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals(false, test5.equals(""));
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_hashCode() {
+        Minutes test5 = Minutes.of(5);
+        Minutes test6 = Minutes.of(6);
+        assertEquals(true, test5.hashCode() == test5.hashCode());
+        assertEquals(false, test5.hashCode() == test6.hashCode());
+    }
+
+    //-----------------------------------------------------------------------
+    public void test_toString() {
+        Minutes test5 = Minutes.of(5);
+        assertEquals("PT5M", test5.toString());
+        Minutes testM1 = Minutes.of(-1);
+        assertEquals("PT-1M", testM1.toString());
+    }
+    
+}


### PR DESCRIPTION
The variables `weeksStr` and `daysStr` in method parse are better named as `yearStr` and `monthsStr`