### PR TITLE
Documentation typo and implementation bug for era

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/Symmetry010Date.java
+++ b/src/main/java/org/threeten/extra/chrono/Symmetry010Date.java
@@ -492,7 +492,7 @@ public final class Symmetry010Date
      */
     @Override
     public IsoEra getEra() {
-        return IsoEra.CE;
+        return (prolepticYear >= 1 ? IsoEra.CE : IsoEra.BCE);
     }
 
     /**

--- a/src/main/java/org/threeten/extra/chrono/Symmetry454Date.java
+++ b/src/main/java/org/threeten/extra/chrono/Symmetry454Date.java
@@ -291,8 +291,6 @@ public final class Symmetry454Date
      *
      * @param prolepticYear  the Symmetry454 proleptic-year
      * @param month  the Symmetry454 month, from 1 to 12
-     * @param dayOfMonth  the Symmetry454 day-of-month, from 1 to 28, or 1 to 35 in February, May, August, November
-     *   and December in a Leap Year
      * @return the resolved date
      */
     private static Symmetry454Date resolvePreviousValid(int prolepticYear, int month, int day) {
@@ -489,7 +487,7 @@ public final class Symmetry454Date
      */
     @Override
     public IsoEra getEra() {
-        return IsoEra.CE;
+        return (prolepticYear >= 1 ? IsoEra.CE : IsoEra.BCE);
     }
 
     /**

--- a/src/test/java/org/threeten/extra/chrono/Test.java
+++ b/src/test/java/org/threeten/extra/chrono/Test.java
@@ -1,0 +1,7 @@
+package org.threeten.extra.chrono;
+
+/**
+ * Created by carlo on 03.06.16.
+ */
+public class Test {
+}

--- a/src/test/java/org/threeten/extra/chrono/Test.java
+++ b/src/test/java/org/threeten/extra/chrono/Test.java
@@ -1,7 +1,0 @@
-package org.threeten.extra.chrono;
-
-/**
- * Created by carlo on 03.06.16.
- */
-public class Test {
-}

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
@@ -345,6 +345,16 @@ public class TestSymmetry010Chronology {
             Symmetry010Date eraBased = Symmetry010Chronology.INSTANCE.date(era, year, 1, 1);
             assertEquals(eraBased, base);
         }
+
+        for (int year = -200; year < 0; year++) {
+            Symmetry010Date base = Symmetry010Chronology.INSTANCE.date(year, 1, 1);
+            assertEquals(year, base.get(YEAR));
+            IsoEra era = IsoEra.BCE;
+            assertEquals(era, base.getEra());
+            assertEquals(1 - year, base.get(YEAR_OF_ERA));
+            Symmetry010Date eraBased = Symmetry010Chronology.INSTANCE.date(era, year, 1, 1);
+            assertEquals(eraBased, base);
+        }
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -350,6 +350,17 @@ public class TestSymmetry454Chronology {
             Symmetry454Date eraBased = Symmetry454Chronology.INSTANCE.date(era, year, 1, 1);
             assertEquals(eraBased, base);
         }
+
+
+        for (int year = -200; year < 0; year++) {
+            Symmetry454Date base = Symmetry454Chronology.INSTANCE.date(year, 1, 1);
+            assertEquals(year, base.get(YEAR));
+            IsoEra era = IsoEra.BCE;
+            assertEquals(era, base.getEra());
+            assertEquals(1 - year, base.get(YEAR_OF_ERA));
+            Symmetry454Date eraBased = Symmetry454Chronology.INSTANCE.date(era, year, 1, 1);
+            assertEquals(eraBased, base);
+        }
     }
 
     @Test


### PR DESCRIPTION
Symmetry454Date#resolvePreviousValid(int,int,int) does not have a fourth parameter for dayOfMonth.

Both Symmetry454Date and Symmetry010Date have an embarrassingly incorrect #getEra implementation.  They both ignore the fact that proleptic years before year 1 of the Common Era are not in the Common Era, but instead in the Before Common Era.
This fix corrects the blunder.

Originally I accidentally included a scratch test class, got rid of it.