### PR TITLE
Support time zone offsets in start/end strings for Interval.parse(CharSequence)

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -35,6 +35,7 @@ import java.io.Serializable;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Objects;
 
@@ -123,9 +124,9 @@ public final class Interval
      * <p>
      * The string must consist of one of the following three formats:
      * <ul>
-     * <li>a representations of an {@link Instant}, followed by a forward slash, followed by a representation of a {@link Instant}
-     * <li>a representation of an {@link Instant}, followed by a forward slash, followed by a representation of a {@link Duration}
-     * <li>a representation of a {@link Duration}, followed by a forward slash, followed by a representation of an {@link Instant}
+     * <li>a representations of an {@link OffsetDateTime}, followed by a forward slash, followed by a representation of a {@link OffsetDateTime}
+     * <li>a representation of an {@link OffsetDateTime}, followed by a forward slash, followed by a representation of a {@link Duration}
+     * <li>a representation of a {@link Duration}, followed by a forward slash, followed by a representation of an {@link OffsetDateTime}
      * </ul>
      * 
      *
@@ -141,11 +142,11 @@ public final class Interval
                 if (firstChar == 'P' || firstChar == 'p') {
                     // duration followed by instant
                     Duration duration = Duration.parse(text.subSequence(0, i));
-                    Instant end = Instant.parse(text.subSequence(i + 1, text.length()));
+                    Instant end = OffsetDateTime.parse(text.subSequence(i + 1, text.length())).toInstant();
                     return Interval.of(end.minus(duration), end);
                 } else {
                     // instant followed by instant or duration
-                    Instant start = Instant.parse(text.subSequence(0, i));
+                    Instant start = OffsetDateTime.parse(text.subSequence(0, i)).toInstant();
                     if (i + 1 < text.length()) {
                         char c = text.charAt(i + 1);
                         if (c == 'P' || c == 'p') {
@@ -153,7 +154,7 @@ public final class Interval
                             return Interval.of(start, start.plus(duration));
                         }
                     }
-                    Instant end = Instant.parse(text.subSequence(i + 1, text.length()));
+                    Instant end = OffsetDateTime.parse(text.subSequence(i + 1, text.length())).toInstant();
                     return Interval.of(start, end);
                 }
             }

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -157,6 +157,12 @@ public class TestInterval {
         assertEquals(test.getStart(), NOW1);
         assertEquals(test.getEnd(), NOW1);
     }
+    
+    public void test_parseCharSequence_InstantInstant_with_timezones() {
+    	Interval test = Interval.parse(NOW1.atOffset(ZoneOffset.ofHours(2)).toString() + "/" + NOW2.atOffset(ZoneOffset.ofHours(2)).toString());
+    	assertEquals(test.getStart(), NOW1);
+    	assertEquals(test.getEnd(), NOW2);
+    }
 
     @Test(expectedExceptions = DateTimeException.class)
     public void test_parse_CharSequence_badOrder() {


### PR DESCRIPTION
I used `OffsetDateTime` as you suggested in #66 and added one test that calls `Interval.parse(CharSequence)` with start/end strings including a time zone offset.