### PR TITLE
Switch statement was missing default case.

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/DiscordianDate.java
+++ b/src/main/java/org/threeten/extra/chrono/DiscordianDate.java
@@ -540,6 +540,8 @@ public final class DiscordianDate
                             return this;
                         }
                         return DiscordianDate.create(prolepticYear, 0, 0);
+                    default:
+                        break;
                 }
             }
             // currently on St Tibs


### PR DESCRIPTION
Does not change the code flow, does not hide a bug.
However, other switch statements consistently have a default case.
And stock Eclipse Neon 4.6 shows 23 warnings on line 531, not considering all enums (AMPM_OF_DAY all the way through YEAR_OF_ERA).