### PR TITLE
YearWeek with plusWeeks and minusWeeks

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -7,6 +7,12 @@
 
   <body>
     <!-- types are add, fix, remove, update -->
+    <release version="1.2" date="2017-05-10" description="v1.2">
+        <action dev="raupachz" type="add" >
+            Add plusWeeks/minusWeeks to YearWeek
+            See #78
+      </action>
+    </release>
     <release version="1.1" date="2017-04-24" description="v1.1">
       <action dev="jodastephen" type="add" >
         Add PeriodDuration, combining Period and Duration.

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -487,19 +487,9 @@ public final class YearWeek
         if (weeksToAdd == 0) {
             return this;
         }
-        if (weeksToAdd < 0) {
-            return minusWeeks(-weeksToAdd);
-        }
-        YearWeek yearWeek = this;
-        while (weeksToAdd-- > 0) {
-            int weeksInYear = yearWeek.is53WeekYear() ? 53 : 52;
-            if (yearWeek.week < weeksInYear) {
-                yearWeek = YearWeek.of(yearWeek.year, yearWeek.week + 1);
-            } else {
-                yearWeek = YearWeek.of(yearWeek.year + 1, 1);
-            }
-        }
-        return yearWeek;
+        long daysToAdd = weeksToAdd * 7;
+        LocalDate mondayOfWeek = atDay(DayOfWeek.MONDAY).plusDays(daysToAdd);
+        return YearWeek.from(mondayOfWeek);
     }
     
     /**
@@ -514,18 +504,12 @@ public final class YearWeek
         if (weeksToSubtract == 0) {
             return this;
         }
-        if (weeksToSubtract < 0) {
-            return plusWeeks(-weeksToSubtract);
+        if (weeksToSubtract == 0) {
+            return this;
         }
-        YearWeek yearWeek = this;
-        while (weeksToSubtract-- > 0) {
-            if (yearWeek.week > 1) {
-                yearWeek = YearWeek.of(yearWeek.year, yearWeek.week - 1);
-            } else {
-                yearWeek = YearWeek.of(yearWeek.year - 1, weekRange(yearWeek.year - 1));
-            }
-        }
-        return yearWeek;
+        long daysToAdd = weeksToSubtract * 7;
+        LocalDate mondayOfWeek = atDay(DayOfWeek.MONDAY).minusDays(daysToAdd);
+        return YearWeek.from(mondayOfWeek);
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -487,8 +487,7 @@ public final class YearWeek
         if (weeksToAdd == 0) {
             return this;
         }
-        long daysToAdd = weeksToAdd * 7;
-        LocalDate mondayOfWeek = atDay(DayOfWeek.MONDAY).plusDays(daysToAdd);
+        LocalDate mondayOfWeek = atDay(DayOfWeek.MONDAY).plusWeeks(weeksToAdd);
         return YearWeek.from(mondayOfWeek);
     }
     
@@ -504,11 +503,7 @@ public final class YearWeek
         if (weeksToSubtract == 0) {
             return this;
         }
-        if (weeksToSubtract == 0) {
-            return this;
-        }
-        long daysToAdd = weeksToSubtract * 7;
-        LocalDate mondayOfWeek = atDay(DayOfWeek.MONDAY).minusDays(daysToAdd);
+        LocalDate mondayOfWeek = atDay(DayOfWeek.MONDAY).minusWeeks(weeksToSubtract);
         return YearWeek.from(mondayOfWeek);
     }
 

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -473,6 +473,60 @@ public final class YearWeek
     public int lengthOfYear() {
         return (is53WeekYear() ? 371 : 364);
     }
+    
+    //-----------------------------------------------------------------------
+    /**
+     * Returns a copy of this year-week with the specified number of weeks added.
+     * * <p>
+     * This instance is immutable and unaffected by this method call.
+     * 
+     * @param weeksToAdd  the weeks to add, may be negative
+     * @return the year-week with the weeks added, not null
+     */
+    public YearWeek plusWeeks(long weeksToAdd) {
+        if (weeksToAdd == 0) {
+            return this;
+        }
+        if (weeksToAdd < 0) {
+            return minusWeeks(-weeksToAdd);
+        }
+        YearWeek yearWeek = this;
+        while (weeksToAdd-- > 0) {
+            int weeksInYear = yearWeek.is53WeekYear() ? 53 : 52;
+            if (yearWeek.week < weeksInYear) {
+                yearWeek = YearWeek.of(yearWeek.year, yearWeek.week + 1);
+            } else {
+                yearWeek = YearWeek.of(yearWeek.year + 1, 1);
+            }
+        }
+        return yearWeek;
+    }
+    
+    /**
+     * Returns a copy of this year-week with the specified number of weeks subtracted.
+     * * <p>
+     * This instance is immutable and unaffected by this method call.
+     * 
+     * @param weeksToSubtract  the weeks to subtract, may be negative
+     * @return the year-week with the weeks subtracted, not null
+     */
+    public YearWeek minusWeeks(long weeksToSubtract) {
+        if (weeksToSubtract == 0) {
+            return this;
+        }
+        if (weeksToSubtract < 0) {
+            return plusWeeks(-weeksToSubtract);
+        }
+        YearWeek yearWeek = this;
+        while (weeksToSubtract-- > 0) {
+            if (yearWeek.week > 1) {
+                yearWeek = YearWeek.of(yearWeek.year, yearWeek.week - 1);
+            } else {
+                yearWeek = YearWeek.of(yearWeek.year - 1, weekRange(yearWeek.year - 1));
+            }
+        }
+        return yearWeek;
+    }
 
     //-----------------------------------------------------------------------
     /**

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -744,7 +744,17 @@ public class TestYearWeek {
         assertEquals(TEST.plusWeeks(-53), YearWeek.of(2013, 52));
         assertEquals(TEST.plusWeeks(-261), YearWeek.of(2009, 53));
     }
-
+    
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_plusWeeks_max_long() {
+        TEST.plusWeeks(Long.MAX_VALUE);
+    }
+    
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_plusWeeks_min_long() {
+        TEST.plusWeeks(Long.MIN_VALUE);
+    }
+    
     //-----------------------------------------------------------------------
     // minusWeeks(long)
     //-----------------------------------------------------------------------
@@ -766,6 +776,16 @@ public class TestYearWeek {
         assertEquals(TEST.minusWeeks(-52), YearWeek.of(2015, 53));
         assertEquals(TEST.minusWeeks(-53), YearWeek.of(2016, 1));
         assertEquals(TEST.minusWeeks(-314), YearWeek.of(2021, 1));
+    }
+    
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void test_minWeeks_max_long() {
+        TEST.plusWeeks(Long.MAX_VALUE);
+    }
+    
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_minWeeks_min_long() {
+        TEST.plusWeeks(Long.MIN_VALUE);
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -760,7 +760,7 @@ public class TestYearWeek {
         TEST.plusWeeks(Long.MAX_VALUE);
     }
 
-    @Test(expectedExceptions = DateTimeException.class)
+    @Test(expectedExceptions = ArithmeticException.class)
     public void test_plusWeeks_min_long() {
         TEST.plusWeeks(Long.MIN_VALUE);
     }
@@ -793,7 +793,7 @@ public class TestYearWeek {
         TEST.plusWeeks(Long.MAX_VALUE);
     }
 
-    @Test(expectedExceptions = DateTimeException.class)
+    @Test(expectedExceptions = ArithmeticException.class)
     public void test_minWeeks_min_long() {
         TEST.plusWeeks(Long.MIN_VALUE);
     }

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -722,6 +722,16 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2014, 2).withWeek(2), YearWeek.of(2014, 2));
     }
 
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_withWeek_int_max() {
+        TEST.withWeek(Integer.MAX_VALUE);
+    }
+
+    @Test(expectedExceptions = DateTimeException.class)
+    public void test_withWeek_int_min() {
+        TEST.withWeek(Integer.MIN_VALUE);
+    }
+
     //-----------------------------------------------------------------------
     // plusWeeks(long)
     //-----------------------------------------------------------------------
@@ -734,7 +744,7 @@ public class TestYearWeek {
         assertEquals(TEST.plusWeeks(53), YearWeek.of(2016, 1));
         assertEquals(TEST.plusWeeks(314), YearWeek.of(2021, 1));
     }
-    
+
     public void test_plusWeeks_negative() {
         assertEquals(TEST.plusWeeks(0), TEST);
         assertEquals(TEST.plusWeeks(-1), YearWeek.of(2014, 52));
@@ -744,17 +754,17 @@ public class TestYearWeek {
         assertEquals(TEST.plusWeeks(-53), YearWeek.of(2013, 52));
         assertEquals(TEST.plusWeeks(-261), YearWeek.of(2009, 53));
     }
-    
+
     @Test(expectedExceptions = ArithmeticException.class)
     public void test_plusWeeks_max_long() {
         TEST.plusWeeks(Long.MAX_VALUE);
     }
-    
+
     @Test(expectedExceptions = DateTimeException.class)
     public void test_plusWeeks_min_long() {
         TEST.plusWeeks(Long.MIN_VALUE);
     }
-    
+
     //-----------------------------------------------------------------------
     // minusWeeks(long)
     //-----------------------------------------------------------------------
@@ -767,7 +777,7 @@ public class TestYearWeek {
         assertEquals(TEST.minusWeeks(53), YearWeek.of(2013, 52));
         assertEquals(TEST.minusWeeks(261), YearWeek.of(2009, 53));
     }
-    
+
     public void test_minusWeeks_negative() {
         assertEquals(TEST.minusWeeks(0), TEST);
         assertEquals(TEST.minusWeeks(-1), YearWeek.of(2015, 2));
@@ -777,12 +787,12 @@ public class TestYearWeek {
         assertEquals(TEST.minusWeeks(-53), YearWeek.of(2016, 1));
         assertEquals(TEST.minusWeeks(-314), YearWeek.of(2021, 1));
     }
-    
+
     @Test(expectedExceptions = ArithmeticException.class)
     public void test_minWeeks_max_long() {
         TEST.plusWeeks(Long.MAX_VALUE);
     }
-    
+
     @Test(expectedExceptions = DateTimeException.class)
     public void test_minWeeks_min_long() {
         TEST.plusWeeks(Long.MIN_VALUE);

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -258,25 +258,25 @@ public class TestYearWeek {
             {2014, 52, MONDAY, 2014, 12, 22},
             {2014, 52, TUESDAY, 2014, 12, 23},
             {2014, 52, WEDNESDAY, 2014, 12, 24},
-            {2014, 52, THURSDAY, 2014, 12, 25}, 
+            {2014, 52, THURSDAY, 2014, 12, 25},
             {2014, 52, FRIDAY, 2014, 12, 26},
-            {2014, 52, SATURDAY, 2014, 12, 27}, 
+            {2014, 52, SATURDAY, 2014, 12, 27},
             {2014, 52, SUNDAY, 2014, 12, 28},
-            {2015,  1, MONDAY, 2014, 12, 29},
-            {2015,  1, TUESDAY, 2014, 12, 30},
-            {2015,  1, WEDNESDAY, 2014, 12, 31},
-            {2015,  1, THURSDAY, 2015, 1, 1}, 
-            {2015,  1, FRIDAY, 2015, 1, 2},
-            {2015,  1, SATURDAY, 2015, 1, 3}, 
-            {2015,  1, SUNDAY, 2015, 1, 4},
-            {2017,  1, MONDAY, 2017, 1, 2},
-            {2017,  1, TUESDAY, 2017, 1, 3},
-            {2017,  1, WEDNESDAY, 2017, 1, 4},
-            {2017,  1, THURSDAY, 2017, 1, 5}, 
-            {2017,  1, FRIDAY, 2017, 1, 6},
-            {2017,  1, SATURDAY, 2017, 1, 7}, 
-            {2017,  1, SUNDAY, 2017, 1, 8},
-            {2025,  1, MONDAY, 2024, 12, 30}
+            {2015, 1, MONDAY, 2014, 12, 29},
+            {2015, 1, TUESDAY, 2014, 12, 30},
+            {2015, 1, WEDNESDAY, 2014, 12, 31},
+            {2015, 1, THURSDAY, 2015, 1, 1},
+            {2015, 1, FRIDAY, 2015, 1, 2},
+            {2015, 1, SATURDAY, 2015, 1, 3},
+            {2015, 1, SUNDAY, 2015, 1, 4},
+            {2017, 1, MONDAY, 2017, 1, 2},
+            {2017, 1, TUESDAY, 2017, 1, 3},
+            {2017, 1, WEDNESDAY, 2017, 1, 4},
+            {2017, 1, THURSDAY, 2017, 1, 5},
+            {2017, 1, FRIDAY, 2017, 1, 6},
+            {2017, 1, SATURDAY, 2017, 1, 7},
+            {2017, 1, SUNDAY, 2017, 1, 8},
+            {2025, 1, MONDAY, 2024, 12, 30}
         };
     }
 
@@ -640,10 +640,10 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     public void test_format() {
         DateTimeFormatter f = new DateTimeFormatterBuilder()
-            .appendValue(WEEK_BASED_YEAR, 4)
-            .appendLiteral('-')
-            .appendValue(WEEK_OF_WEEK_BASED_YEAR, 2)
-            .toFormatter();
+                .appendValue(WEEK_BASED_YEAR, 4)
+                .appendLiteral('-')
+                .appendValue(WEEK_OF_WEEK_BASED_YEAR, 2)
+                .toFormatter();
         assertEquals(TEST.format(f), "2015-01");
     }
 
@@ -722,14 +722,50 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2014, 2).withWeek(2), YearWeek.of(2014, 2));
     }
 
-    @Test(expectedExceptions = DateTimeException.class)
-    public void test_withWeek_int_max() {
-        TEST.withWeek(Integer.MAX_VALUE);
+    //-----------------------------------------------------------------------
+    // plusWeeks(long)
+    //-----------------------------------------------------------------------
+    public void test_plusWeeks() {
+        assertEquals(TEST.plusWeeks(0), TEST);
+        assertEquals(TEST.plusWeeks(1), YearWeek.of(2015, 2));
+        assertEquals(TEST.plusWeeks(2), YearWeek.of(2015, 3));
+        assertEquals(TEST.plusWeeks(51), YearWeek.of(2015, 52));
+        assertEquals(TEST.plusWeeks(52), YearWeek.of(2015, 53));
+        assertEquals(TEST.plusWeeks(53), YearWeek.of(2016, 1));
+        assertEquals(TEST.plusWeeks(314), YearWeek.of(2021, 1));
+    }
+    
+    public void test_plusWeeks_negative() {
+        assertEquals(TEST.plusWeeks(0), TEST);
+        assertEquals(TEST.plusWeeks(-1), YearWeek.of(2014, 52));
+        assertEquals(TEST.plusWeeks(-2), YearWeek.of(2014, 51));
+        assertEquals(TEST.plusWeeks(-51), YearWeek.of(2014, 2));
+        assertEquals(TEST.plusWeeks(-52), YearWeek.of(2014, 1));
+        assertEquals(TEST.plusWeeks(-53), YearWeek.of(2013, 52));
+        assertEquals(TEST.plusWeeks(-261), YearWeek.of(2009, 53));
     }
 
-    @Test(expectedExceptions = DateTimeException.class)
-    public void test_withWeek_int_min() {
-        TEST.withWeek(Integer.MIN_VALUE);
+    //-----------------------------------------------------------------------
+    // minusWeeks(long)
+    //-----------------------------------------------------------------------
+    public void test_minusWeeks() {
+        assertEquals(TEST.minusWeeks(0), TEST);
+        assertEquals(TEST.minusWeeks(1), YearWeek.of(2014, 52));
+        assertEquals(TEST.minusWeeks(2), YearWeek.of(2014, 51));
+        assertEquals(TEST.minusWeeks(51), YearWeek.of(2014, 2));
+        assertEquals(TEST.minusWeeks(52), YearWeek.of(2014, 1));
+        assertEquals(TEST.minusWeeks(53), YearWeek.of(2013, 52));
+        assertEquals(TEST.minusWeeks(261), YearWeek.of(2009, 53));
+    }
+    
+    public void test_minusWeeks_negative() {
+        assertEquals(TEST.minusWeeks(0), TEST);
+        assertEquals(TEST.minusWeeks(-1), YearWeek.of(2015, 2));
+        assertEquals(TEST.minusWeeks(-2), YearWeek.of(2015, 3));
+        assertEquals(TEST.minusWeeks(-51), YearWeek.of(2015, 52));
+        assertEquals(TEST.minusWeeks(-52), YearWeek.of(2015, 53));
+        assertEquals(TEST.minusWeeks(-53), YearWeek.of(2016, 1));
+        assertEquals(TEST.minusWeeks(-314), YearWeek.of(2021, 1));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Added the methods plusWeeks and minusWeeks in YearWeek.java

Typical use case is a calendar application that toggles between the weeks in a year. These two methods align with other found for example in java.time.LocalDate. 

JavaDoc and UnitTests included. 

The implementation is based on a loop. Probably not the best performance wise, but it was straightforward to implement. I am open to suggestion, better ideas, feedback.
