### PR TITLE
Typo: Interval#parse accepts 4 different formats

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -130,7 +130,7 @@ public final class Interval
      * Obtains an instance of {@code Interval} from a text string such as
      * {@code 2007-12-03T10:15:30Z/2007-12-04T10:15:30Z}, where the end instant is exclusive.
      * <p>
-     * The string must consist of one of the following three formats:
+     * The string must consist of one of the following four formats:
      * <ul>
      * <li>a representations of an {@link OffsetDateTime}, followed by a forward slash,
      *  followed by a representation of a {@link OffsetDateTime}

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -45,6 +45,7 @@ import java.io.Serializable;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
@@ -153,6 +154,10 @@ public class TestInterval {
         Interval.of(NOW1, (Duration) null);
     }
 
+    /* Lower and upper bound for Intervals */
+    private static final Instant MIN_OFFSET_DATE_TIME = OffsetDateTime.MIN.plusDays(1L).toInstant();
+    private static final Instant MAX_OFFSET_DATE_TIME = OffsetDateTime.MAX.minusDays(1L).toInstant();
+
     //-----------------------------------------------------------------------
     @DataProvider(name = "parseValid")
     Object[][] data_parseValid() {
@@ -167,6 +172,7 @@ public class TestInterval {
             {NOW1.atOffset(ZoneOffset.ofHours(2)) + "/" + NOW2.atOffset(ZoneOffset.ofHours(2)), NOW1, NOW2},
             {NOW1.atOffset(ZoneOffset.ofHours(2)) + "/" + NOW2.atOffset(ZoneOffset.ofHours(3)), NOW1, NOW2},
             {NOW1.atOffset(ZoneOffset.ofHours(2)) + "/" + NOW2.atOffset(ZoneOffset.ofHours(2)).toLocalDateTime(), NOW1, NOW2},
+            {MIN_OFFSET_DATE_TIME.toString() + '/' + MAX_OFFSET_DATE_TIME, MIN_OFFSET_DATE_TIME, MAX_OFFSET_DATE_TIME}
         };
     }
     


### PR DESCRIPTION
The documentation states there are three formats, lists 4 formats though.

Also, added an minimal / maximal bounds check for Intervals.
