### PR TITLE
Align doc with code

### DIFF
--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -189,7 +189,7 @@ public final class YearWeek
     // from IsoFields in ThreeTen-Backport
     private static int weekRange(int weekBasedYear) {
         LocalDate date = LocalDate.of(weekBasedYear, 1, 1);
-        // 53 weeks if standard year starts on Thursday, or Wed in a leap year
+        // 53 weeks if year starts on Thursday, or Wed in a leap year
         if (date.getDayOfWeek() == THURSDAY || (date.getDayOfWeek() == WEDNESDAY && date.isLeapYear())) {
             return 53;
         }


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year), a year with 53 weeks is **any year starting on Thursday** or any leap year starting on Wednesday.

The code is alright, but the doc above it is confusing!