### PR TITLE
Overrride default `Require-Capabilities` manifest entry.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
             <configuration>
               <instructions>
                 <Export-Package>org.threeten.extra,org.threeten.extra.chrono,org.threeten.extra.scale</Export-Package>
+                <Require-Capability>${require.capability}</Require-Capability>
               </instructions>
             </configuration>
           </execution>
@@ -852,6 +853,8 @@
     <!-- Properties for maven-checkstyle-plugin -->
     <checkstyle.config.location>src/main/checkstyle/checkstyle.xml</checkstyle.config.location>
     <linkXRef>false</linkXRef>
+    <!-- Properties for maven-bundle-plugin -->
+    <require.capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=1.8))"</require.capability>
     <!-- Other properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
The default uses the build JDK.  Here we set it to Java 8.

Fixes issue #92