### PR TITLE
Fix assertEquals and assertSame parameters order

### DIFF
--- a/src/test/java/org/threeten/extra/TestAmPm.java
+++ b/src/test/java/org/threeten/extra/TestAmPm.java
@@ -63,6 +63,7 @@ import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
 import static java.time.temporal.ChronoUnit.HALF_DAYS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
@@ -118,10 +119,10 @@ public class TestAmPm {
     @Test
     public void test_ofHour_int_singleton() {
         for (int i = 0; i < 12; i++) {
-            assertEquals(AmPm.AM, AmPm.ofHour(i));
+            assertSame(AmPm.AM, AmPm.ofHour(i));
         }
         for (int i = 12; i < 24; i++) {
-            assertEquals(AmPm.PM, AmPm.ofHour(i));
+        	assertSame(AmPm.PM, AmPm.ofHour(i));
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestAmPm.java
+++ b/src/test/java/org/threeten/extra/TestAmPm.java
@@ -98,7 +98,7 @@ public class TestAmPm {
     public void test_of_int_singleton_equals() {
         for (int i = 0; i <= 1; i++) {
             AmPm test = AmPm.of(i);
-            assertEquals(test.getValue(), i);
+            assertEquals(i, test.getValue());
         }
     }
 
@@ -118,10 +118,10 @@ public class TestAmPm {
     @Test
     public void test_ofHour_int_singleton() {
         for (int i = 0; i < 12; i++) {
-            assertEquals(AmPm.ofHour(i), AmPm.AM);
+            assertEquals(AmPm.AM, AmPm.ofHour(i));
         }
         for (int i = 12; i < 24; i++) {
-            assertEquals(AmPm.ofHour(i), AmPm.PM);
+            assertEquals(AmPm.PM, AmPm.ofHour(i));
         }
     }
 
@@ -140,8 +140,8 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_from_TemporalAccessor() {
-        assertEquals(AmPm.from(LocalTime.of(8, 30)), AmPm.AM);
-        assertEquals(AmPm.from(LocalTime.of(17, 30)), AmPm.PM);
+        assertEquals(AmPm.AM, AmPm.from(LocalTime.of(8, 30)));
+        assertEquals(AmPm.PM, AmPm.from(LocalTime.of(17, 30)));
     }
 
     @Test(expected = DateTimeException.class)
@@ -159,7 +159,7 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_getDisplayName() {
-        assertEquals(AmPm.AM.getDisplayName(TextStyle.SHORT, Locale.US), "AM");
+        assertEquals("AM", AmPm.AM.getDisplayName(TextStyle.SHORT, Locale.US));
     }
 
     @Test(expected = NullPointerException.class)
@@ -178,37 +178,37 @@ public class TestAmPm {
     @Test
     public void test_isSupported() {
         AmPm test = AmPm.AM;
-        assertEquals(test.isSupported(null), false);
-        assertEquals(test.isSupported(NANO_OF_SECOND), false);
-        assertEquals(test.isSupported(NANO_OF_DAY), false);
-        assertEquals(test.isSupported(MICRO_OF_SECOND), false);
-        assertEquals(test.isSupported(MICRO_OF_DAY), false);
-        assertEquals(test.isSupported(MILLI_OF_SECOND), false);
-        assertEquals(test.isSupported(MILLI_OF_DAY), false);
-        assertEquals(test.isSupported(SECOND_OF_MINUTE), false);
-        assertEquals(test.isSupported(SECOND_OF_DAY), false);
-        assertEquals(test.isSupported(MINUTE_OF_HOUR), false);
-        assertEquals(test.isSupported(MINUTE_OF_DAY), false);
-        assertEquals(test.isSupported(HOUR_OF_AMPM), false);
-        assertEquals(test.isSupported(CLOCK_HOUR_OF_AMPM), false);
-        assertEquals(test.isSupported(HOUR_OF_DAY), false);
-        assertEquals(test.isSupported(CLOCK_HOUR_OF_DAY), false);
-        assertEquals(test.isSupported(AMPM_OF_DAY), true);
-        assertEquals(test.isSupported(DAY_OF_WEEK), false);
-        assertEquals(test.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH), false);
-        assertEquals(test.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR), false);
-        assertEquals(test.isSupported(DAY_OF_MONTH), false);
-        assertEquals(test.isSupported(DAY_OF_YEAR), false);
-        assertEquals(test.isSupported(EPOCH_DAY), false);
-        assertEquals(test.isSupported(ALIGNED_WEEK_OF_MONTH), false);
-        assertEquals(test.isSupported(ALIGNED_WEEK_OF_YEAR), false);
-        assertEquals(test.isSupported(MONTH_OF_YEAR), false);
-        assertEquals(test.isSupported(PROLEPTIC_MONTH), false);
-        assertEquals(test.isSupported(YEAR_OF_ERA), false);
-        assertEquals(test.isSupported(YEAR), false);
-        assertEquals(test.isSupported(ERA), false);
-        assertEquals(test.isSupported(INSTANT_SECONDS), false);
-        assertEquals(test.isSupported(OFFSET_SECONDS), false);
+        assertEquals(false, test.isSupported(null));
+        assertEquals(false, test.isSupported(NANO_OF_SECOND));
+        assertEquals(false, test.isSupported(NANO_OF_DAY));
+        assertEquals(false, test.isSupported(MICRO_OF_SECOND));
+        assertEquals(false, test.isSupported(MICRO_OF_DAY));
+        assertEquals(false, test.isSupported(MILLI_OF_SECOND));
+        assertEquals(false, test.isSupported(MILLI_OF_DAY));
+        assertEquals(false, test.isSupported(SECOND_OF_MINUTE));
+        assertEquals(false, test.isSupported(SECOND_OF_DAY));
+        assertEquals(false, test.isSupported(MINUTE_OF_HOUR));
+        assertEquals(false, test.isSupported(MINUTE_OF_DAY));
+        assertEquals(false, test.isSupported(HOUR_OF_AMPM));
+        assertEquals(false, test.isSupported(CLOCK_HOUR_OF_AMPM));
+        assertEquals(false, test.isSupported(HOUR_OF_DAY));
+        assertEquals(false, test.isSupported(CLOCK_HOUR_OF_DAY));
+        assertEquals(true, test.isSupported(AMPM_OF_DAY));
+        assertEquals(false, test.isSupported(DAY_OF_WEEK));
+        assertEquals(false, test.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(false, test.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(false, test.isSupported(DAY_OF_MONTH));
+        assertEquals(false, test.isSupported(DAY_OF_YEAR));
+        assertEquals(false, test.isSupported(EPOCH_DAY));
+        assertEquals(false, test.isSupported(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(false, test.isSupported(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(false, test.isSupported(MONTH_OF_YEAR));
+        assertEquals(false, test.isSupported(PROLEPTIC_MONTH));
+        assertEquals(false, test.isSupported(YEAR_OF_ERA));
+        assertEquals(false, test.isSupported(YEAR));
+        assertEquals(false, test.isSupported(ERA));
+        assertEquals(false, test.isSupported(INSTANT_SECONDS));
+        assertEquals(false, test.isSupported(OFFSET_SECONDS));
     }
 
     //-----------------------------------------------------------------------
@@ -216,7 +216,7 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_range() {
-        assertEquals(AmPm.AM.range(AMPM_OF_DAY), AMPM_OF_DAY.range());
+        assertEquals(AMPM_OF_DAY.range(), AmPm.AM.range(AMPM_OF_DAY));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -234,8 +234,8 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_get() {
-        assertEquals(AmPm.AM.get(AMPM_OF_DAY), 0);
-        assertEquals(AmPm.PM.get(AMPM_OF_DAY), 1);
+        assertEquals(0, AmPm.AM.get(AMPM_OF_DAY));
+        assertEquals(1, AmPm.PM.get(AMPM_OF_DAY));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -253,8 +253,8 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_getLong() {
-        assertEquals(AmPm.AM.getLong(AMPM_OF_DAY), 0);
-        assertEquals(AmPm.PM.getLong(AMPM_OF_DAY), 1);
+        assertEquals(0, AmPm.AM.getLong(AMPM_OF_DAY));
+        assertEquals(1, AmPm.PM.getLong(AMPM_OF_DAY));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -272,13 +272,13 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_query() {
-        assertEquals(AmPm.AM.query(TemporalQueries.chronology()), null);
-        assertEquals(AmPm.AM.query(TemporalQueries.localDate()), null);
-        assertEquals(AmPm.AM.query(TemporalQueries.localTime()), null);
-        assertEquals(AmPm.AM.query(TemporalQueries.offset()), null);
-        assertEquals(AmPm.AM.query(TemporalQueries.precision()), HALF_DAYS);
-        assertEquals(AmPm.AM.query(TemporalQueries.zone()), null);
-        assertEquals(AmPm.AM.query(TemporalQueries.zoneId()), null);
+        assertEquals(null, AmPm.AM.query(TemporalQueries.chronology()));
+        assertEquals(null, AmPm.AM.query(TemporalQueries.localDate()));
+        assertEquals(null, AmPm.AM.query(TemporalQueries.localTime()));
+        assertEquals(null, AmPm.AM.query(TemporalQueries.offset()));
+        assertEquals(HALF_DAYS, AmPm.AM.query(TemporalQueries.precision()));
+        assertEquals(null, AmPm.AM.query(TemporalQueries.zone()));
+        assertEquals(null, AmPm.AM.query(TemporalQueries.zoneId()));
     }
 
     //-----------------------------------------------------------------------
@@ -286,8 +286,8 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_toString() {
-        assertEquals(AmPm.AM.toString(), "AM");
-        assertEquals(AmPm.PM.toString(), "PM");
+        assertEquals("AM", AmPm.AM.toString());
+        assertEquals("PM", AmPm.PM.toString());
     }
 
     //-----------------------------------------------------------------------
@@ -295,8 +295,8 @@ public class TestAmPm {
     //-----------------------------------------------------------------------
     @Test
     public void test_enum() {
-        assertEquals(AmPm.valueOf("AM"), AmPm.AM);
-        assertEquals(AmPm.values()[0], AmPm.AM);
+        assertEquals(AmPm.AM, AmPm.valueOf("AM"));
+        assertEquals(AmPm.AM, AmPm.values()[0]);
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -74,6 +74,7 @@ import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -140,7 +141,7 @@ public class TestDayOfMonth {
         for (int i = 1; i <= MAX_LENGTH; i++) {
             DayOfMonth test = DayOfMonth.of(i);
             assertEquals(i, test.getValue());
-            assertEquals(test, DayOfMonth.of(i));
+            assertSame(test, DayOfMonth.of(i));
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -128,7 +128,7 @@ public class TestDayOfMonth {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -139,8 +139,8 @@ public class TestDayOfMonth {
     public void test_of_int_singleton() {
         for (int i = 1; i <= MAX_LENGTH; i++) {
             DayOfMonth test = DayOfMonth.of(i);
-            assertEquals(test.getValue(), i);
-            assertEquals(DayOfMonth.of(i), test);
+            assertEquals(i, test.getValue());
+            assertEquals(test, DayOfMonth.of(i));
         }
     }
 
@@ -161,51 +161,51 @@ public class TestDayOfMonth {
     public void test_from_TemporalAccessor_notLeapYear() {
         LocalDate date = LocalDate.of(2007, 1, 1);
         for (int i = 1; i <= 31; i++) {  // Jan
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 28; i++) {  // Feb
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // Mar
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 30; i++) {  // Apr
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // May
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 30; i++) {  // Jun
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // Jul
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // Aug
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 30; i++) {  // Sep
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // Oct
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 30; i++) {  // Nov
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // Dec
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
     }
@@ -214,15 +214,15 @@ public class TestDayOfMonth {
     public void test_from_TemporalAccessor_leapYear() {
         LocalDate date = LocalDate.of(2008, 1, 1);
         for (int i = 1; i <= 31; i++) {  // Jan
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 29; i++) {  // Feb
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
         for (int i = 1; i <= 31; i++) {  // Mar
-            assertEquals(DayOfMonth.from(date).getValue(), i);
+            assertEquals(i, DayOfMonth.from(date).getValue());
             date = date.plusDays(1);
         }
     }
@@ -240,7 +240,7 @@ public class TestDayOfMonth {
     @Test
     public void test_from_parse_CharSequence() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("d");
-        assertEquals(formatter.parse("3", DayOfMonth::from), DayOfMonth.of(3));
+        assertEquals(DayOfMonth.of(3), formatter.parse("3", DayOfMonth::from));
     }
 
     //-----------------------------------------------------------------------
@@ -248,37 +248,37 @@ public class TestDayOfMonth {
     //-----------------------------------------------------------------------
     @Test
     public void test_isSupported() {
-        assertEquals(TEST.isSupported((TemporalField) null), false);
-        assertEquals(TEST.isSupported(NANO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(NANO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MICRO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MICRO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MILLI_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MILLI_OF_DAY), false);
-        assertEquals(TEST.isSupported(SECOND_OF_MINUTE), false);
-        assertEquals(TEST.isSupported(SECOND_OF_DAY), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_HOUR), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_DAY), false);
-        assertEquals(TEST.isSupported(HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(AMPM_OF_DAY), false);
-        assertEquals(TEST.isSupported(DAY_OF_WEEK), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR), false);
-        assertEquals(TEST.isSupported(DAY_OF_MONTH), true);
-        assertEquals(TEST.isSupported(DAY_OF_YEAR), false);
-        assertEquals(TEST.isSupported(EPOCH_DAY), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_YEAR), false);
-        assertEquals(TEST.isSupported(MONTH_OF_YEAR), false);
-        assertEquals(TEST.isSupported(PROLEPTIC_MONTH), false);
-        assertEquals(TEST.isSupported(YEAR_OF_ERA), false);
-        assertEquals(TEST.isSupported(YEAR), false);
-        assertEquals(TEST.isSupported(ERA), false);
-        assertEquals(TEST.isSupported(INSTANT_SECONDS), false);
-        assertEquals(TEST.isSupported(OFFSET_SECONDS), false);
+        assertEquals(false, TEST.isSupported((TemporalField) null));
+        assertEquals(false, TEST.isSupported(NANO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(NANO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MICRO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MICRO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MILLI_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MILLI_OF_DAY));
+        assertEquals(false, TEST.isSupported(SECOND_OF_MINUTE));
+        assertEquals(false, TEST.isSupported(SECOND_OF_DAY));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_HOUR));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_DAY));
+        assertEquals(false, TEST.isSupported(HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(AMPM_OF_DAY));
+        assertEquals(false, TEST.isSupported(DAY_OF_WEEK));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(true, TEST.isSupported(DAY_OF_MONTH));
+        assertEquals(false, TEST.isSupported(DAY_OF_YEAR));
+        assertEquals(false, TEST.isSupported(EPOCH_DAY));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(false, TEST.isSupported(MONTH_OF_YEAR));
+        assertEquals(false, TEST.isSupported(PROLEPTIC_MONTH));
+        assertEquals(false, TEST.isSupported(YEAR_OF_ERA));
+        assertEquals(false, TEST.isSupported(YEAR));
+        assertEquals(false, TEST.isSupported(ERA));
+        assertEquals(false, TEST.isSupported(INSTANT_SECONDS));
+        assertEquals(false, TEST.isSupported(OFFSET_SECONDS));
     }
 
     //-----------------------------------------------------------------------
@@ -286,7 +286,7 @@ public class TestDayOfMonth {
     //-----------------------------------------------------------------------
     @Test
     public void test_range() {
-        assertEquals(TEST.range(DAY_OF_MONTH), DAY_OF_MONTH.range());
+        assertEquals(DAY_OF_MONTH.range(), TEST.range(DAY_OF_MONTH));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -304,7 +304,7 @@ public class TestDayOfMonth {
     //-----------------------------------------------------------------------
     @Test
     public void test_get() {
-        assertEquals(TEST.get(DAY_OF_MONTH), 12);
+        assertEquals(12, TEST.get(DAY_OF_MONTH));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -322,7 +322,7 @@ public class TestDayOfMonth {
     //-----------------------------------------------------------------------
     @Test
     public void test_getLong() {
-        assertEquals(TEST.getLong(DAY_OF_MONTH), 12L);
+        assertEquals(12L, TEST.getLong(DAY_OF_MONTH));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -341,70 +341,70 @@ public class TestDayOfMonth {
     @Test
     public void test_isValidYearMonth_31() {
         DayOfMonth test = DayOfMonth.of(31);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 1)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 2)), false);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 3)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 4)), false);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 5)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 6)), false);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 7)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 8)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 9)), false);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 10)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 11)), false);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 12)), true);
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 1)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2012, 2)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 3)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2012, 4)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 5)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2012, 6)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 7)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 8)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2012, 9)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 10)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2012, 11)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 12)));
     }
 
     @Test
     public void test_isValidYearMonth_30() {
         DayOfMonth test = DayOfMonth.of(30);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 1)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 2)), false);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 3)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 4)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 5)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 6)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 7)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 8)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 9)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 10)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 11)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 12)), true);
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 1)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2012, 2)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 3)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 4)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 5)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 6)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 7)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 8)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 9)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 10)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 11)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 12)));
     }
 
     @Test
     public void test_isValidYearMonth_29() {
         DayOfMonth test = DayOfMonth.of(29);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 1)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 2)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 3)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 4)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 5)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 6)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 7)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 8)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 9)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 10)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 11)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 12)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2011, 2)), false);
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 1)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 2)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 3)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 4)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 5)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 6)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 7)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 8)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 9)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 10)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 11)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 12)));
+        assertEquals(false, test.isValidYearMonth(YearMonth.of(2011, 2)));
     }
 
     @Test
     public void test_isValidYearMonth_28() {
         DayOfMonth test = DayOfMonth.of(28);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 1)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 2)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 3)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 4)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 5)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 6)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 7)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 8)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 9)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 10)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 11)), true);
-        assertEquals(test.isValidYearMonth(YearMonth.of(2012, 12)), true);
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 1)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 2)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 3)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 4)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 5)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 6)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 7)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 8)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 9)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 10)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 11)));
+        assertEquals(true, test.isValidYearMonth(YearMonth.of(2012, 12)));
     }
 
     //-----------------------------------------------------------------------
@@ -412,13 +412,13 @@ public class TestDayOfMonth {
     //-----------------------------------------------------------------------
     @Test
     public void test_query() {
-        assertEquals(TEST.query(TemporalQueries.chronology()), IsoChronology.INSTANCE);
-        assertEquals(TEST.query(TemporalQueries.localDate()), null);
-        assertEquals(TEST.query(TemporalQueries.localTime()), null);
-        assertEquals(TEST.query(TemporalQueries.offset()), null);
-        assertEquals(TEST.query(TemporalQueries.precision()), null);
-        assertEquals(TEST.query(TemporalQueries.zone()), null);
-        assertEquals(TEST.query(TemporalQueries.zoneId()), null);
+        assertEquals(IsoChronology.INSTANCE, TEST.query(TemporalQueries.chronology()));
+        assertEquals(null, TEST.query(TemporalQueries.localDate()));
+        assertEquals(null, TEST.query(TemporalQueries.localTime()));
+        assertEquals(null, TEST.query(TemporalQueries.offset()));
+        assertEquals(null, TEST.query(TemporalQueries.precision()));
+        assertEquals(null, TEST.query(TemporalQueries.zone()));
+        assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }
 
     //-----------------------------------------------------------------------
@@ -430,7 +430,7 @@ public class TestDayOfMonth {
         LocalDate expected = base;
         for (int i = 1; i <= MAX_LENGTH; i++) {  // Jan
             Temporal result = DayOfMonth.of(i).adjustInto(base);
-            assertEquals(result, expected);
+            assertEquals(expected, result);
             expected = expected.plusDays(1);
         }
     }
@@ -460,35 +460,35 @@ public class TestDayOfMonth {
     @Test
     public void test_atMonth_Month_31() {
         DayOfMonth test = DayOfMonth.of(31);
-        assertEquals(test.atMonth(JANUARY), MonthDay.of(1, 31));
-        assertEquals(test.atMonth(FEBRUARY), MonthDay.of(2, 29));
-        assertEquals(test.atMonth(MARCH), MonthDay.of(3, 31));
-        assertEquals(test.atMonth(APRIL), MonthDay.of(4, 30));
-        assertEquals(test.atMonth(MAY), MonthDay.of(5, 31));
-        assertEquals(test.atMonth(JUNE), MonthDay.of(6, 30));
-        assertEquals(test.atMonth(JULY), MonthDay.of(7, 31));
-        assertEquals(test.atMonth(AUGUST), MonthDay.of(8, 31));
-        assertEquals(test.atMonth(SEPTEMBER), MonthDay.of(9, 30));
-        assertEquals(test.atMonth(OCTOBER), MonthDay.of(10, 31));
-        assertEquals(test.atMonth(NOVEMBER), MonthDay.of(11, 30));
-        assertEquals(test.atMonth(DECEMBER), MonthDay.of(12, 31));
+        assertEquals(MonthDay.of(1, 31), test.atMonth(JANUARY));
+        assertEquals(MonthDay.of(2, 29), test.atMonth(FEBRUARY));
+        assertEquals(MonthDay.of(3, 31), test.atMonth(MARCH));
+        assertEquals(MonthDay.of(4, 30), test.atMonth(APRIL));
+        assertEquals(MonthDay.of(5, 31), test.atMonth(MAY));
+        assertEquals(MonthDay.of(6, 30), test.atMonth(JUNE));
+        assertEquals(MonthDay.of(7, 31), test.atMonth(JULY));
+        assertEquals(MonthDay.of(8, 31), test.atMonth(AUGUST));
+        assertEquals(MonthDay.of(9, 30), test.atMonth(SEPTEMBER));
+        assertEquals(MonthDay.of(10, 31), test.atMonth(OCTOBER));
+        assertEquals(MonthDay.of(11, 30), test.atMonth(NOVEMBER));
+        assertEquals(MonthDay.of(12, 31), test.atMonth(DECEMBER));
     }
 
     @Test
     public void test_atMonth_Month_28() {
         DayOfMonth test = DayOfMonth.of(28);
-        assertEquals(test.atMonth(JANUARY), MonthDay.of(1, 28));
-        assertEquals(test.atMonth(FEBRUARY), MonthDay.of(2, 28));
-        assertEquals(test.atMonth(MARCH), MonthDay.of(3, 28));
-        assertEquals(test.atMonth(APRIL), MonthDay.of(4, 28));
-        assertEquals(test.atMonth(MAY), MonthDay.of(5, 28));
-        assertEquals(test.atMonth(JUNE), MonthDay.of(6, 28));
-        assertEquals(test.atMonth(JULY), MonthDay.of(7, 28));
-        assertEquals(test.atMonth(AUGUST), MonthDay.of(8, 28));
-        assertEquals(test.atMonth(SEPTEMBER), MonthDay.of(9, 28));
-        assertEquals(test.atMonth(OCTOBER), MonthDay.of(10, 28));
-        assertEquals(test.atMonth(NOVEMBER), MonthDay.of(11, 28));
-        assertEquals(test.atMonth(DECEMBER), MonthDay.of(12, 28));
+        assertEquals(MonthDay.of(1, 28), test.atMonth(JANUARY));
+        assertEquals(MonthDay.of(2, 28), test.atMonth(FEBRUARY));
+        assertEquals(MonthDay.of(3, 28), test.atMonth(MARCH));
+        assertEquals(MonthDay.of(4, 28), test.atMonth(APRIL));
+        assertEquals(MonthDay.of(5, 28), test.atMonth(MAY));
+        assertEquals(MonthDay.of(6, 28), test.atMonth(JUNE));
+        assertEquals(MonthDay.of(7, 28), test.atMonth(JULY));
+        assertEquals(MonthDay.of(8, 28), test.atMonth(AUGUST));
+        assertEquals(MonthDay.of(9, 28), test.atMonth(SEPTEMBER));
+        assertEquals(MonthDay.of(10, 28), test.atMonth(OCTOBER));
+        assertEquals(MonthDay.of(11, 28), test.atMonth(NOVEMBER));
+        assertEquals(MonthDay.of(12, 28), test.atMonth(DECEMBER));
     }
 
     @Test(expected = NullPointerException.class)
@@ -502,35 +502,35 @@ public class TestDayOfMonth {
     @Test
     public void test_atMonth_int_31() {
         DayOfMonth test = DayOfMonth.of(31);
-        assertEquals(test.atMonth(1), MonthDay.of(1, 31));
-        assertEquals(test.atMonth(2), MonthDay.of(2, 29));
-        assertEquals(test.atMonth(3), MonthDay.of(3, 31));
-        assertEquals(test.atMonth(4), MonthDay.of(4, 30));
-        assertEquals(test.atMonth(5), MonthDay.of(5, 31));
-        assertEquals(test.atMonth(6), MonthDay.of(6, 30));
-        assertEquals(test.atMonth(7), MonthDay.of(7, 31));
-        assertEquals(test.atMonth(8), MonthDay.of(8, 31));
-        assertEquals(test.atMonth(9), MonthDay.of(9, 30));
-        assertEquals(test.atMonth(10), MonthDay.of(10, 31));
-        assertEquals(test.atMonth(11), MonthDay.of(11, 30));
-        assertEquals(test.atMonth(12), MonthDay.of(12, 31));
+        assertEquals(MonthDay.of(1, 31), test.atMonth(1));
+        assertEquals(MonthDay.of(2, 29), test.atMonth(2));
+        assertEquals(MonthDay.of(3, 31), test.atMonth(3));
+        assertEquals(MonthDay.of(4, 30), test.atMonth(4));
+        assertEquals(MonthDay.of(5, 31), test.atMonth(5));
+        assertEquals(MonthDay.of(6, 30), test.atMonth(6));
+        assertEquals(MonthDay.of(7, 31), test.atMonth(7));
+        assertEquals(MonthDay.of(8, 31), test.atMonth(8));
+        assertEquals(MonthDay.of(9, 30), test.atMonth(9));
+        assertEquals(MonthDay.of(10, 31), test.atMonth(10));
+        assertEquals(MonthDay.of(11, 30), test.atMonth(11));
+        assertEquals(MonthDay.of(12, 31), test.atMonth(12));
     }
 
     @Test
     public void test_atMonth_int_28() {
         DayOfMonth test = DayOfMonth.of(28);
-        assertEquals(test.atMonth(1), MonthDay.of(1, 28));
-        assertEquals(test.atMonth(2), MonthDay.of(2, 28));
-        assertEquals(test.atMonth(3), MonthDay.of(3, 28));
-        assertEquals(test.atMonth(4), MonthDay.of(4, 28));
-        assertEquals(test.atMonth(5), MonthDay.of(5, 28));
-        assertEquals(test.atMonth(6), MonthDay.of(6, 28));
-        assertEquals(test.atMonth(7), MonthDay.of(7, 28));
-        assertEquals(test.atMonth(8), MonthDay.of(8, 28));
-        assertEquals(test.atMonth(9), MonthDay.of(9, 28));
-        assertEquals(test.atMonth(10), MonthDay.of(10, 28));
-        assertEquals(test.atMonth(11), MonthDay.of(11, 28));
-        assertEquals(test.atMonth(12), MonthDay.of(12, 28));
+        assertEquals(MonthDay.of(1, 28), test.atMonth(1));
+        assertEquals(MonthDay.of(2, 28), test.atMonth(2));
+        assertEquals(MonthDay.of(3, 28), test.atMonth(3));
+        assertEquals(MonthDay.of(4, 28), test.atMonth(4));
+        assertEquals(MonthDay.of(5, 28), test.atMonth(5));
+        assertEquals(MonthDay.of(6, 28), test.atMonth(6));
+        assertEquals(MonthDay.of(7, 28), test.atMonth(7));
+        assertEquals(MonthDay.of(8, 28), test.atMonth(8));
+        assertEquals(MonthDay.of(9, 28), test.atMonth(9));
+        assertEquals(MonthDay.of(10, 28), test.atMonth(10));
+        assertEquals(MonthDay.of(11, 28), test.atMonth(11));
+        assertEquals(MonthDay.of(12, 28), test.atMonth(12));
     }
 
     @Test(expected = DateTimeException.class)
@@ -549,36 +549,36 @@ public class TestDayOfMonth {
     @Test
     public void test_atYearMonth_31() {
         DayOfMonth test = DayOfMonth.of(31);
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 1)), LocalDate.of(2012, 1, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 2)), LocalDate.of(2012, 2, 29));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 3)), LocalDate.of(2012, 3, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 4)), LocalDate.of(2012, 4, 30));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 5)), LocalDate.of(2012, 5, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 6)), LocalDate.of(2012, 6, 30));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 7)), LocalDate.of(2012, 7, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 8)), LocalDate.of(2012, 8, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 9)), LocalDate.of(2012, 9, 30));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 10)), LocalDate.of(2012, 10, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 11)), LocalDate.of(2012, 11, 30));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 12)), LocalDate.of(2012, 12, 31));
-        assertEquals(test.atYearMonth(YearMonth.of(2011, 2)), LocalDate.of(2011, 2, 28));
+        assertEquals(LocalDate.of(2012, 1, 31), test.atYearMonth(YearMonth.of(2012, 1)));
+        assertEquals(LocalDate.of(2012, 2, 29), test.atYearMonth(YearMonth.of(2012, 2)));
+        assertEquals(LocalDate.of(2012, 3, 31), test.atYearMonth(YearMonth.of(2012, 3)));
+        assertEquals(LocalDate.of(2012, 4, 30), test.atYearMonth(YearMonth.of(2012, 4)));
+        assertEquals(LocalDate.of(2012, 5, 31), test.atYearMonth(YearMonth.of(2012, 5)));
+        assertEquals(LocalDate.of(2012, 6, 30), test.atYearMonth(YearMonth.of(2012, 6)));
+        assertEquals(LocalDate.of(2012, 7, 31), test.atYearMonth(YearMonth.of(2012, 7)));
+        assertEquals(LocalDate.of(2012, 8, 31), test.atYearMonth(YearMonth.of(2012, 8)));
+        assertEquals(LocalDate.of(2012, 9, 30), test.atYearMonth(YearMonth.of(2012, 9)));
+        assertEquals(LocalDate.of(2012, 10, 31), test.atYearMonth(YearMonth.of(2012, 10)));
+        assertEquals(LocalDate.of(2012, 11, 30), test.atYearMonth(YearMonth.of(2012, 11)));
+        assertEquals(LocalDate.of(2012, 12, 31), test.atYearMonth(YearMonth.of(2012, 12)));
+        assertEquals(LocalDate.of(2011, 2, 28), test.atYearMonth(YearMonth.of(2011, 2)));
     }
 
     @Test
     public void test_atYearMonth_28() {
         DayOfMonth test = DayOfMonth.of(28);
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 1)), LocalDate.of(2012, 1, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 2)), LocalDate.of(2012, 2, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 3)), LocalDate.of(2012, 3, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 4)), LocalDate.of(2012, 4, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 5)), LocalDate.of(2012, 5, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 6)), LocalDate.of(2012, 6, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 7)), LocalDate.of(2012, 7, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 8)), LocalDate.of(2012, 8, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 9)), LocalDate.of(2012, 9, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 10)), LocalDate.of(2012, 10, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 11)), LocalDate.of(2012, 11, 28));
-        assertEquals(test.atYearMonth(YearMonth.of(2012, 12)), LocalDate.of(2012, 12, 28));
+        assertEquals(LocalDate.of(2012, 1, 28), test.atYearMonth(YearMonth.of(2012, 1)));
+        assertEquals(LocalDate.of(2012, 2, 28), test.atYearMonth(YearMonth.of(2012, 2)));
+        assertEquals(LocalDate.of(2012, 3, 28), test.atYearMonth(YearMonth.of(2012, 3)));
+        assertEquals(LocalDate.of(2012, 4, 28), test.atYearMonth(YearMonth.of(2012, 4)));
+        assertEquals(LocalDate.of(2012, 5, 28), test.atYearMonth(YearMonth.of(2012, 5)));
+        assertEquals(LocalDate.of(2012, 6, 28), test.atYearMonth(YearMonth.of(2012, 6)));
+        assertEquals(LocalDate.of(2012, 7, 28), test.atYearMonth(YearMonth.of(2012, 7)));
+        assertEquals(LocalDate.of(2012, 8, 28), test.atYearMonth(YearMonth.of(2012, 8)));
+        assertEquals(LocalDate.of(2012, 9, 28), test.atYearMonth(YearMonth.of(2012, 9)));
+        assertEquals(LocalDate.of(2012, 10, 28), test.atYearMonth(YearMonth.of(2012, 10)));
+        assertEquals(LocalDate.of(2012, 11, 28), test.atYearMonth(YearMonth.of(2012, 11)));
+        assertEquals(LocalDate.of(2012, 12, 28), test.atYearMonth(YearMonth.of(2012, 12)));
     }
 
     @Test(expected = NullPointerException.class)
@@ -596,14 +596,14 @@ public class TestDayOfMonth {
             for (int j = 1; j <= MAX_LENGTH; j++) {
                 DayOfMonth b = DayOfMonth.of(j);
                 if (i < j) {
-                    assertEquals(a.compareTo(b) < 0, true);
-                    assertEquals(b.compareTo(a) > 0, true);
+                    assertEquals(true, a.compareTo(b) < 0);
+                    assertEquals(true, b.compareTo(a) > 0);
                 } else if (i > j) {
-                    assertEquals(a.compareTo(b) > 0, true);
-                    assertEquals(b.compareTo(a) < 0, true);
+                    assertEquals(true, a.compareTo(b) > 0);
+                    assertEquals(true, b.compareTo(a) < 0);
                 } else {
-                    assertEquals(a.compareTo(b), 0);
-                    assertEquals(b.compareTo(a), 0);
+                    assertEquals(0, a.compareTo(b));
+                    assertEquals(0, b.compareTo(a));
                 }
             }
         }
@@ -625,8 +625,8 @@ public class TestDayOfMonth {
             DayOfMonth a = DayOfMonth.of(i);
             for (int j = 1; j <= MAX_LENGTH; j++) {
                 DayOfMonth b = DayOfMonth.of(j);
-                assertEquals(a.equals(b), i == j);
-                assertEquals(a.hashCode() == b.hashCode(), i == j);
+                assertEquals(i == j, a.equals(b));
+                assertEquals(i == j, a.hashCode() == b.hashCode());
             }
         }
     }
@@ -635,13 +635,13 @@ public class TestDayOfMonth {
     public void test_equals_nullDayOfMonth() {
         DayOfMonth doy = null;
         DayOfMonth test = DayOfMonth.of(1);
-        assertEquals(test.equals(doy), false);
+        assertEquals(false, test.equals(doy));
     }
 
     @Test
     public void test_equals_incorrectType() {
         DayOfMonth test = DayOfMonth.of(1);
-        assertEquals(test.equals("Incorrect type"), false);
+        assertEquals(false, test.equals("Incorrect type"));
     }
 
     //-----------------------------------------------------------------------
@@ -651,7 +651,7 @@ public class TestDayOfMonth {
     public void test_toString() {
         for (int i = 1; i <= MAX_LENGTH; i++) {
             DayOfMonth a = DayOfMonth.of(i);
-            assertEquals(a.toString(), "DayOfMonth:" + i);
+            assertEquals("DayOfMonth:" + i, a.toString());
         }
     }
 
@@ -663,7 +663,7 @@ public class TestDayOfMonth {
         for (int i = 1; i <= 31; i++) {  // Jan
             Instant instant = LocalDate.of(2008, 1, i).atStartOfDay(PARIS).toInstant();
             Clock clock = Clock.fixed(instant, PARIS);
-            assertEquals(DayOfMonth.now(clock).getValue(), i);
+            assertEquals(i, DayOfMonth.now(clock).getValue());
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -117,7 +117,7 @@ public class TestDayOfYear {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -128,8 +128,8 @@ public class TestDayOfYear {
     public void test_of_int() {
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.getValue(), i);
-            assertEquals(DayOfYear.of(i), test);
+            assertEquals(i, test.getValue());
+            assertEquals(test, DayOfYear.of(i));
         }
     }
 
@@ -151,11 +151,11 @@ public class TestDayOfYear {
         LocalDate date = LocalDate.of(2007, 1, 1);
         for (int i = 1; i <= STANDARD_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.from(date);
-            assertEquals(test.getValue(), i);
+            assertEquals(i, test.getValue());
             date = date.plusDays(1);
         }
         DayOfYear test = DayOfYear.from(date);
-        assertEquals(test.getValue(), 1);
+        assertEquals(1, test.getValue());
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TestDayOfYear {
         LocalDate date = LocalDate.of(2008, 1, 1);
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.from(date);
-            assertEquals(test.getValue(), i);
+            assertEquals(i, test.getValue());
             date = date.plusDays(1);
         }
     }
@@ -181,7 +181,7 @@ public class TestDayOfYear {
     @Test
     public void test_from_parse_CharSequence() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("D");
-        assertEquals(formatter.parse("76", DayOfYear::from), DayOfYear.of(76));
+        assertEquals(DayOfYear.of(76), formatter.parse("76", DayOfYear::from));
     }
 
     //-----------------------------------------------------------------------
@@ -189,37 +189,37 @@ public class TestDayOfYear {
     //-----------------------------------------------------------------------
     @Test
     public void test_isSupported() {
-        assertEquals(TEST.isSupported((TemporalField) null), false);
-        assertEquals(TEST.isSupported(NANO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(NANO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MICRO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MICRO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MILLI_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MILLI_OF_DAY), false);
-        assertEquals(TEST.isSupported(SECOND_OF_MINUTE), false);
-        assertEquals(TEST.isSupported(SECOND_OF_DAY), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_HOUR), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_DAY), false);
-        assertEquals(TEST.isSupported(HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(AMPM_OF_DAY), false);
-        assertEquals(TEST.isSupported(DAY_OF_WEEK), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR), false);
-        assertEquals(TEST.isSupported(DAY_OF_MONTH), false);
-        assertEquals(TEST.isSupported(DAY_OF_YEAR), true);
-        assertEquals(TEST.isSupported(EPOCH_DAY), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_YEAR), false);
-        assertEquals(TEST.isSupported(MONTH_OF_YEAR), false);
-        assertEquals(TEST.isSupported(PROLEPTIC_MONTH), false);
-        assertEquals(TEST.isSupported(YEAR_OF_ERA), false);
-        assertEquals(TEST.isSupported(YEAR), false);
-        assertEquals(TEST.isSupported(ERA), false);
-        assertEquals(TEST.isSupported(INSTANT_SECONDS), false);
-        assertEquals(TEST.isSupported(OFFSET_SECONDS), false);
+        assertEquals(false, TEST.isSupported((TemporalField) null));
+        assertEquals(false, TEST.isSupported(NANO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(NANO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MICRO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MICRO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MILLI_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MILLI_OF_DAY));
+        assertEquals(false, TEST.isSupported(SECOND_OF_MINUTE));
+        assertEquals(false, TEST.isSupported(SECOND_OF_DAY));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_HOUR));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_DAY));
+        assertEquals(false, TEST.isSupported(HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(AMPM_OF_DAY));
+        assertEquals(false, TEST.isSupported(DAY_OF_WEEK));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(false, TEST.isSupported(DAY_OF_MONTH));
+        assertEquals(true, TEST.isSupported(DAY_OF_YEAR));
+        assertEquals(false, TEST.isSupported(EPOCH_DAY));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(false, TEST.isSupported(MONTH_OF_YEAR));
+        assertEquals(false, TEST.isSupported(PROLEPTIC_MONTH));
+        assertEquals(false, TEST.isSupported(YEAR_OF_ERA));
+        assertEquals(false, TEST.isSupported(YEAR));
+        assertEquals(false, TEST.isSupported(ERA));
+        assertEquals(false, TEST.isSupported(INSTANT_SECONDS));
+        assertEquals(false, TEST.isSupported(OFFSET_SECONDS));
     }
 
     //-----------------------------------------------------------------------
@@ -227,7 +227,7 @@ public class TestDayOfYear {
     //-----------------------------------------------------------------------
     @Test
     public void test_range() {
-        assertEquals(TEST.range(DAY_OF_YEAR), DAY_OF_YEAR.range());
+        assertEquals(DAY_OF_YEAR.range(), TEST.range(DAY_OF_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -245,7 +245,7 @@ public class TestDayOfYear {
     //-----------------------------------------------------------------------
     @Test
     public void test_get() {
-        assertEquals(TEST.get(DAY_OF_YEAR), 12);
+        assertEquals(12, TEST.get(DAY_OF_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -263,7 +263,7 @@ public class TestDayOfYear {
     //-----------------------------------------------------------------------
     @Test
     public void test_getLong() {
-        assertEquals(TEST.getLong(DAY_OF_YEAR), 12L);
+        assertEquals(12L, TEST.getLong(DAY_OF_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -282,17 +282,17 @@ public class TestDayOfYear {
     @Test
     public void test_isValidYearMonth_366() {
         DayOfYear test = DayOfYear.of(366);
-        assertEquals(test.isValidYear(2011), false);
-        assertEquals(test.isValidYear(2012), true);
-        assertEquals(test.isValidYear(2013), false);
+        assertEquals(false, test.isValidYear(2011));
+        assertEquals(true, test.isValidYear(2012));
+        assertEquals(false, test.isValidYear(2013));
     }
 
     @Test
     public void test_isValidYearMonth_365() {
         DayOfYear test = DayOfYear.of(365);
-        assertEquals(test.isValidYear(2011), true);
-        assertEquals(test.isValidYear(2012), true);
-        assertEquals(test.isValidYear(2013), true);
+        assertEquals(true, test.isValidYear(2011));
+        assertEquals(true, test.isValidYear(2012));
+        assertEquals(true, test.isValidYear(2013));
     }
 
     //-----------------------------------------------------------------------
@@ -300,13 +300,13 @@ public class TestDayOfYear {
     //-----------------------------------------------------------------------
     @Test
     public void test_query() {
-        assertEquals(TEST.query(TemporalQueries.chronology()), IsoChronology.INSTANCE);
-        assertEquals(TEST.query(TemporalQueries.localDate()), null);
-        assertEquals(TEST.query(TemporalQueries.localTime()), null);
-        assertEquals(TEST.query(TemporalQueries.offset()), null);
-        assertEquals(TEST.query(TemporalQueries.precision()), null);
-        assertEquals(TEST.query(TemporalQueries.zone()), null);
-        assertEquals(TEST.query(TemporalQueries.zoneId()), null);
+        assertEquals(IsoChronology.INSTANCE, TEST.query(TemporalQueries.chronology()));
+        assertEquals(null, TEST.query(TemporalQueries.localDate()));
+        assertEquals(null, TEST.query(TemporalQueries.localTime()));
+        assertEquals(null, TEST.query(TemporalQueries.offset()));
+        assertEquals(null, TEST.query(TemporalQueries.precision()));
+        assertEquals(null, TEST.query(TemporalQueries.zone()));
+        assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }
 
     //-----------------------------------------------------------------------
@@ -318,7 +318,7 @@ public class TestDayOfYear {
         LocalDate expected = base;
         for (int i = 1; i <= STANDARD_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.adjustInto(base), expected);
+            assertEquals(expected, test.adjustInto(base));
             expected = expected.plusDays(1);
         }
     }
@@ -329,7 +329,7 @@ public class TestDayOfYear {
         LocalDate expected = LocalDate.of(2007, 1, 1);
         for (int i = 1; i <= STANDARD_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.adjustInto(base), expected);
+            assertEquals(expected, test.adjustInto(base));
             expected = expected.plusDays(1);
         }
     }
@@ -354,7 +354,7 @@ public class TestDayOfYear {
         LocalDate expected = base;
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.adjustInto(base), expected);
+            assertEquals(expected, test.adjustInto(base));
             expected = expected.plusDays(1);
         }
     }
@@ -365,7 +365,7 @@ public class TestDayOfYear {
         LocalDate expected = LocalDate.of(2008, 1, 1);
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.adjustInto(base), expected);
+            assertEquals(expected, test.adjustInto(base));
             expected = expected.plusDays(1);
         }
     }
@@ -383,7 +383,7 @@ public class TestDayOfYear {
         LocalDate expected = LocalDate.of(2007, 1, 1);
         for (int i = 1; i <= STANDARD_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.atYear(YEAR_STANDARD), expected);
+            assertEquals(expected, test.atYear(YEAR_STANDARD));
             expected = expected.plusDays(1);
         }
     }
@@ -399,7 +399,7 @@ public class TestDayOfYear {
         LocalDate expected = LocalDate.of(2008, 1, 1);
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.atYear(YEAR_LEAP), expected);
+            assertEquals(expected, test.atYear(YEAR_LEAP));
             expected = expected.plusDays(1);
         }
     }
@@ -417,7 +417,7 @@ public class TestDayOfYear {
         LocalDate expected = LocalDate.of(2007, 1, 1);
         for (int i = 1; i <= STANDARD_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.atYear(2007), expected);
+            assertEquals(expected, test.atYear(2007));
             expected = expected.plusDays(1);
         }
     }
@@ -433,7 +433,7 @@ public class TestDayOfYear {
         LocalDate expected = LocalDate.of(2008, 1, 1);
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear test = DayOfYear.of(i);
-            assertEquals(test.atYear(2008), expected);
+            assertEquals(expected, test.atYear(2008));
             expected = expected.plusDays(1);
         }
     }
@@ -453,14 +453,14 @@ public class TestDayOfYear {
             for (int j = 1; j <= LEAP_YEAR_LENGTH; j++) {
                 DayOfYear b = DayOfYear.of(j);
                 if (i < j) {
-                    assertEquals(a.compareTo(b) < 0, true);
-                    assertEquals(b.compareTo(a) > 0, true);
+                    assertEquals(true, a.compareTo(b) < 0);
+                    assertEquals(true, b.compareTo(a) > 0);
                 } else if (i > j) {
-                    assertEquals(a.compareTo(b) > 0, true);
-                    assertEquals(b.compareTo(a) < 0, true);
+                    assertEquals(true, a.compareTo(b) > 0);
+                    assertEquals(true, b.compareTo(a) < 0);
                 } else {
-                    assertEquals(a.compareTo(b), 0);
-                    assertEquals(b.compareTo(a), 0);
+                    assertEquals(0, a.compareTo(b));
+                    assertEquals(0, b.compareTo(a));
                 }
             }
         }
@@ -482,8 +482,8 @@ public class TestDayOfYear {
             DayOfYear a = DayOfYear.of(i);
             for (int j = 1; j <= LEAP_YEAR_LENGTH; j++) {
                 DayOfYear b = DayOfYear.of(j);
-                assertEquals(a.equals(b), i == j);
-                assertEquals(a.hashCode() == b.hashCode(), i == j);
+                assertEquals(i == j, a.equals(b));
+                assertEquals(i == j, a.hashCode() == b.hashCode());
             }
         }
     }
@@ -492,13 +492,13 @@ public class TestDayOfYear {
     public void test_equals_nullDayOfYear() {
         DayOfYear doy = null;
         DayOfYear test = DayOfYear.of(1);
-        assertEquals(test.equals(doy), false);
+        assertEquals(false, test.equals(doy));
     }
 
     @Test
     public void test_equals_incorrectType() {
         DayOfYear test = DayOfYear.of(1);
-        assertEquals(test.equals("Incorrect type"), false);
+        assertEquals(false, test.equals("Incorrect type"));
     }
 
     //-----------------------------------------------------------------------
@@ -508,7 +508,7 @@ public class TestDayOfYear {
     public void test_toString() {
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             DayOfYear a = DayOfYear.of(i);
-            assertEquals(a.toString(), "DayOfYear:" + i);
+            assertEquals("DayOfYear:" + i, a.toString());
         }
     }
 
@@ -522,7 +522,7 @@ public class TestDayOfYear {
             Instant instant = date.atStartOfDay(PARIS).toInstant();
             Clock clock = Clock.fixed(instant, PARIS);
             DayOfYear test = DayOfYear.now(clock);
-            assertEquals(test.getValue(), i);
+            assertEquals(i, test.getValue());
             date = date.plusDays(1);
         }
     }
@@ -534,7 +534,7 @@ public class TestDayOfYear {
             Instant instant = date.atStartOfDay(PARIS).toInstant();
             Clock clock = Clock.fixed(instant, PARIS);
             DayOfYear test = DayOfYear.now(clock);
-            assertEquals(test.getValue(), i);
+            assertEquals(i, test.getValue());
             date = date.plusDays(1);
         }
     }

--- a/src/test/java/org/threeten/extra/TestDays.java
+++ b/src/test/java/org/threeten/extra/TestDays.java
@@ -83,38 +83,38 @@ public class TestDays {
     public void test_ZERO() {
         assertSame(Days.of(0), Days.ZERO);
         assertSame(Days.of(0), Days.ZERO);
-        assertEquals(Days.ZERO.getAmount(), 0);
+        assertEquals(0, Days.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Days.of(1), Days.ONE);
         assertSame(Days.of(1), Days.ONE);
-        assertEquals(Days.ONE.getAmount(), 1);
+        assertEquals(1, Days.ONE.getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Days.of(0).getAmount(), 0);
-        assertEquals(Days.of(1).getAmount(), 1);
-        assertEquals(Days.of(2).getAmount(), 2);
-        assertEquals(Days.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Days.of(-1).getAmount(), -1);
-        assertEquals(Days.of(-2).getAmount(), -2);
-        assertEquals(Days.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(0, Days.of(0).getAmount());
+        assertEquals(1, Days.of(1).getAmount());
+        assertEquals(2, Days.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Days.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Days.of(-1).getAmount());
+        assertEquals(-2, Days.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Days.of(Integer.MIN_VALUE).getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_ofWeeks() {
-        assertEquals(Days.ofWeeks(0).getAmount(), 0);
-        assertEquals(Days.ofWeeks(1).getAmount(), 7);
-        assertEquals(Days.ofWeeks(2).getAmount(), 14);
-        assertEquals(Days.ofWeeks(Integer.MAX_VALUE / 7).getAmount(), (Integer.MAX_VALUE / 7) * 7);
-        assertEquals(Days.ofWeeks(-1).getAmount(), -7);
-        assertEquals(Days.ofWeeks(-2).getAmount(), -14);
-        assertEquals(Days.ofWeeks(Integer.MIN_VALUE / 7).getAmount(), (Integer.MIN_VALUE / 7) * 7);
+        assertEquals(0, Days.ofWeeks(0).getAmount());
+        assertEquals(7, Days.ofWeeks(1).getAmount());
+        assertEquals(14, Days.ofWeeks(2).getAmount());
+        assertEquals((Integer.MAX_VALUE / 7) * 7, Days.ofWeeks(Integer.MAX_VALUE / 7).getAmount());
+        assertEquals(-7, Days.ofWeeks(-1).getAmount());
+        assertEquals(-14, Days.ofWeeks(-2).getAmount());
+        assertEquals((Integer.MIN_VALUE / 7) * 7, Days.ofWeeks(Integer.MIN_VALUE / 7).getAmount());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -125,27 +125,27 @@ public class TestDays {
     //-----------------------------------------------------------------------
     @Test
     public void test_from_Period_P0D() {
-        assertEquals(Days.from(Period.ofDays(0)), Days.of(0));
+        assertEquals(Days.of(0), Days.from(Period.ofDays(0)));
     }
 
     @Test
     public void test_from_Period_P2D() {
-        assertEquals(Days.from(Period.ofDays(2)), Days.of(2));
+        assertEquals(Days.of(2), Days.from(Period.ofDays(2)));
     }
 
     @Test
     public void test_from_P2W() {
-        assertEquals(Days.from(new MockWeeksDays(2, 0)), Days.of(14));
+        assertEquals(Days.of(14), Days.from(new MockWeeksDays(2, 0)));
     }
 
     @Test
     public void test_from_P2W3D() {
-        assertEquals(Days.from(new MockWeeksDays(2, 3)), Days.of(17));
+        assertEquals(Days.of(17), Days.from(new MockWeeksDays(2, 3)));
     }
 
     @Test
     public void test_from_Duration() {
-        assertEquals(Days.from(Duration.ofDays(2)), Days.of(2));
+        assertEquals(Days.of(2), Days.from(Duration.ofDays(2)));
     }
 
     @Test(expected = DateTimeException.class)
@@ -198,19 +198,19 @@ public class TestDays {
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
-        assertEquals(Days.parse(str), Days.of(expectedDays));
+        assertEquals(Days.of(expectedDays), Days.parse(str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
-        assertEquals(Days.parse("+" + str), Days.of(expectedDays));
+        assertEquals(Days.of(expectedDays), Days.parse("+" + str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
-        assertEquals(Days.parse("-" + str), Days.of(-expectedDays));
+        assertEquals(Days.of(-expectedDays), Days.parse("-" + str));
     }
 
     @DataProvider
@@ -462,7 +462,7 @@ public class TestDays {
     @Test
     public void test_toPeriod() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Days.of(i).toPeriod(), Period.ofDays(i));
+            assertEquals(Period.ofDays(i), Days.of(i).toPeriod());
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestDays.java
+++ b/src/test/java/org/threeten/extra/TestDays.java
@@ -74,7 +74,7 @@ public class TestDays {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 
@@ -82,14 +82,14 @@ public class TestDays {
     @Test
     public void test_ZERO() {
         assertSame(Days.of(0), Days.ZERO);
-        assertSame(Days.of(0), Days.ZERO);
+        assertEquals(Days.of(0), Days.ZERO);
         assertEquals(0, Days.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Days.of(1), Days.ONE);
-        assertSame(Days.of(1), Days.ONE);
+        assertEquals(Days.of(1), Days.ONE);
         assertEquals(1, Days.ONE.getAmount());
     }
 

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -81,19 +81,19 @@ public class TestHours {
     public void test_ZERO() {
         assertSame(Hours.of(0), Hours.ZERO);
         assertSame(Hours.of(0), Hours.ZERO);
-        assertEquals(Hours.ZERO.getAmount(), 0);
+        assertEquals(0, Hours.ZERO.getAmount());
     }
     
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Hours.of(0).getAmount(), 0);
-        assertEquals(Hours.of(1).getAmount(), 1);
-        assertEquals(Hours.of(2).getAmount(), 2);
-        assertEquals(Hours.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Hours.of(-1).getAmount(), -1);
-        assertEquals(Hours.of(-2).getAmount(), -2);
-        assertEquals(Hours.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(0, Hours.of(0).getAmount());
+        assertEquals(1, Hours.of(1).getAmount());
+        assertEquals(2, Hours.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Hours.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Hours.of(-1).getAmount());
+        assertEquals(-2, Hours.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Hours.of(Integer.MIN_VALUE).getAmount());
     }
     
     //-----------------------------------------------------------------------
@@ -126,19 +126,19 @@ public class TestHours {
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
-        assertEquals(Hours.parse(str), Hours.of(expectedDays));
+        assertEquals(Hours.of(expectedDays), Hours.parse(str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
-        assertEquals(Hours.parse("+" + str), Hours.of(expectedDays));
+        assertEquals(Hours.of(expectedDays), Hours.parse("+" + str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
-        assertEquals(Hours.parse("-" + str), Hours.of(-expectedDays));
+        assertEquals(Hours.of(-expectedDays), Hours.parse("-" + str));
     }
 
     @DataProvider
@@ -370,24 +370,24 @@ public class TestHours {
     @Test
     public void test_addTo() {
         LocalTime base = LocalTime.of(11, 30);
-        assertEquals(Hours.of(0).addTo(base), LocalTime.of(11, 30));
-        assertEquals(Hours.of(6).addTo(base), LocalTime.of(17, 30));
+        assertEquals(LocalTime.of(11, 30), Hours.of(0).addTo(base));
+        assertEquals(LocalTime.of(17, 30), Hours.of(6).addTo(base));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_subtractFrom() {
         LocalTime base = LocalTime.of(11, 30);
-        assertEquals(Hours.of(0).subtractFrom(base), LocalTime.of(11, 30));
-        assertEquals(Hours.of(6).subtractFrom(base), LocalTime.of(5, 30));
+        assertEquals(LocalTime.of(11, 30), Hours.of(0).subtractFrom(base));
+        assertEquals(LocalTime.of(5, 30), Hours.of(6).subtractFrom(base));
     }
 
     //-----------------------------------------------------------------------
     @SuppressWarnings("deprecation")
     public void test_toDuration() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Hours.of(i).toPeriod(), Duration.ofHours(i));
-            assertEquals(Hours.of(i).toDuration(), Duration.ofHours(i));
+            assertEquals(Duration.ofHours(i), Hours.of(i).toPeriod());
+            assertEquals(Duration.ofHours(i), Hours.of(i).toDuration());
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -72,7 +72,7 @@ public class TestHours {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
     
@@ -80,7 +80,7 @@ public class TestHours {
     @Test
     public void test_ZERO() {
         assertSame(Hours.of(0), Hours.ZERO);
-        assertSame(Hours.of(0), Hours.ZERO);
+        assertEquals(Hours.of(0), Hours.ZERO);
         assertEquals(0, Hours.ZERO.getAmount());
     }
     

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -83,7 +83,7 @@ public class TestInterval {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -91,32 +91,32 @@ public class TestInterval {
     @Test
     public void test_ALL() {
         Interval test = Interval.ALL;
-        assertEquals(test.getStart(), Instant.MIN);
-        assertEquals(test.getEnd(), Instant.MAX);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), true);
+        assertEquals(Instant.MIN, test.getStart());
+        assertEquals(Instant.MAX, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_of_Instant_Instant() {
         Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(test.getStart(), NOW1);
-        assertEquals(test.getEnd(), NOW2);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), false);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW2, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
     }
 
     @Test
     public void test_of_Instant_Instant_empty() {
         Interval test = Interval.of(NOW1, NOW1);
-        assertEquals(test.getStart(), NOW1);
-        assertEquals(test.getEnd(), NOW1);
-        assertEquals(test.isEmpty(), true);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), false);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW1, test.getEnd());
+        assertEquals(true, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -138,15 +138,15 @@ public class TestInterval {
     @Test
     public void test_of_Instant_Duration() {
         Interval test = Interval.of(NOW1, Duration.ofSeconds(60));
-        assertEquals(test.getStart(), NOW1);
-        assertEquals(test.getEnd(), NOW2);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW2, test.getEnd());
     }
 
     @Test
     public void test_of_Instant_Duration_zero() {
         Interval test = Interval.of(NOW1, Duration.ZERO);
-        assertEquals(test.getStart(), NOW1);
-        assertEquals(test.getEnd(), NOW1);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW1, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -199,8 +199,8 @@ public class TestInterval {
     @UseDataProvider("data_parseValid")
     public void test_parse_CharSequence(String input, Instant start, Instant end) {
         Interval test = Interval.parse(input);
-        assertEquals(test.getStart(), start);
-        assertEquals(test.getEnd(), end);
+        assertEquals(start, test.getStart());
+        assertEquals(end, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -223,8 +223,8 @@ public class TestInterval {
     public void test_withStart() {
         Interval base = Interval.of(NOW1, NOW3);
         Interval test = base.withStart(NOW2);
-        assertEquals(test.getStart(), NOW2);
-        assertEquals(test.getEnd(), NOW3);
+        assertEquals(NOW2, test.getStart());
+        assertEquals(NOW3, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -244,8 +244,8 @@ public class TestInterval {
     public void test_withEnd() {
         Interval base = Interval.of(NOW1, NOW3);
         Interval test = base.withEnd(NOW2);
-        assertEquals(test.getStart(), NOW1);
-        assertEquals(test.getEnd(), NOW2);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW2, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -264,29 +264,29 @@ public class TestInterval {
     @Test
     public void test_contains_Instant() {
         Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(test.contains(NOW1.minusSeconds(1)), false);
-        assertEquals(test.contains(NOW1), true);
-        assertEquals(test.contains(NOW1.plusSeconds(1)), true);
-        assertEquals(test.contains(NOW2.minusSeconds(1)), true);
-        assertEquals(test.contains(NOW2), false);
+        assertEquals(false, test.contains(NOW1.minusSeconds(1)));
+        assertEquals(true, test.contains(NOW1));
+        assertEquals(true, test.contains(NOW1.plusSeconds(1)));
+        assertEquals(true, test.contains(NOW2.minusSeconds(1)));
+        assertEquals(false, test.contains(NOW2));
     }
 
     @Test
     public void test_contains_Instant_baseEmpty() {
         Interval test = Interval.of(NOW1, NOW1);
-        assertEquals(test.contains(NOW1.minusSeconds(1)), false);
-        assertEquals(test.contains(NOW1), false);
-        assertEquals(test.contains(NOW1.plusSeconds(1)), false);
+        assertEquals(false, test.contains(NOW1.minusSeconds(1)));
+        assertEquals(false, test.contains(NOW1));
+        assertEquals(false, test.contains(NOW1.plusSeconds(1)));
     }
 
     @Test
     public void test_contains_max() {
         Interval test = Interval.of(NOW2, Instant.MAX);
-        assertEquals(test.contains(Instant.MIN), false);
-        assertEquals(test.contains(NOW1), false);
-        assertEquals(test.contains(NOW2), true);
-        assertEquals(test.contains(NOW3), true);
-        assertEquals(test.contains(Instant.MAX), true);
+        assertEquals(false, test.contains(Instant.MIN));
+        assertEquals(false, test.contains(NOW1));
+        assertEquals(true, test.contains(NOW2));
+        assertEquals(true, test.contains(NOW3));
+        assertEquals(true, test.contains(Instant.MAX));
     }
 
     @Test(expected = NullPointerException.class)
@@ -300,35 +300,35 @@ public class TestInterval {
     public void test_encloses_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before
-        assertEquals(test.encloses(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.encloses(Interval.of(NOW1.minusSeconds(1), NOW1)), false);
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // partly before
-        assertEquals(test.encloses(Interval.of(NOW1.minusSeconds(1), NOW2)), false);
-        assertEquals(test.encloses(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))), false);
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW2)));
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
         // contained
-        assertEquals(test.encloses(Interval.of(NOW1, NOW2.minusSeconds(1))), true);
-        assertEquals(test.encloses(Interval.of(NOW1, NOW2)), true);
-        assertEquals(test.encloses(Interval.of(NOW1.plusSeconds(1), NOW2)), true);
+        assertEquals(true, test.encloses(Interval.of(NOW1, NOW2.minusSeconds(1))));
+        assertEquals(true, test.encloses(Interval.of(NOW1, NOW2)));
+        assertEquals(true, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW2)));
         // partly after
-        assertEquals(test.encloses(Interval.of(NOW1, NOW2.plusSeconds(1))), false);
-        assertEquals(test.encloses(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))), false);
+        assertEquals(false, test.encloses(Interval.of(NOW1, NOW2.plusSeconds(1))));
+        assertEquals(false, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
-        assertEquals(test.encloses(Interval.of(NOW2, NOW2.plusSeconds(1))), false);
-        assertEquals(test.encloses(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))), false);
+        assertEquals(false, test.encloses(Interval.of(NOW2, NOW2.plusSeconds(1))));
+        assertEquals(false, test.encloses(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
     }
 
     @Test
     public void test_encloses_Interval_empty() {
         Interval test = Interval.of(NOW1, NOW1);
         // completely before
-        assertEquals(test.encloses(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
         // partly before
-        assertEquals(test.encloses(Interval.of(NOW1.minusSeconds(1), NOW1)), false);
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // equal
-        assertEquals(test.encloses(Interval.of(NOW1, NOW1)), true);
+        assertEquals(true, test.encloses(Interval.of(NOW1, NOW1)));
         // completely after
-        assertEquals(test.encloses(Interval.of(NOW1, NOW1.plusSeconds(1))), false);
-        assertEquals(test.encloses(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))), false);
+        assertEquals(false, test.encloses(Interval.of(NOW1, NOW1.plusSeconds(1))));
+        assertEquals(false, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
     @Test(expected = NullPointerException.class)
@@ -342,34 +342,34 @@ public class TestInterval {
     public void test_abuts_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before
-        assertEquals(test.abuts(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.abuts(Interval.of(NOW1.minusSeconds(1), NOW1)), true);
+        assertEquals(false, test.abuts(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(true, test.abuts(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // partly before
-        assertEquals(test.abuts(Interval.of(NOW1.minusSeconds(1), NOW2)), false);
-        assertEquals(test.abuts(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))), false);
+        assertEquals(false, test.abuts(Interval.of(NOW1.minusSeconds(1), NOW2)));
+        assertEquals(false, test.abuts(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
         // contained
-        assertEquals(test.abuts(Interval.of(NOW1, NOW2.minusSeconds(1))), false);
-        assertEquals(test.abuts(Interval.of(NOW1, NOW2)), false);
-        assertEquals(test.abuts(Interval.of(NOW1.plusSeconds(1), NOW2)), false);
+        assertEquals(false, test.abuts(Interval.of(NOW1, NOW2.minusSeconds(1))));
+        assertEquals(false, test.abuts(Interval.of(NOW1, NOW2)));
+        assertEquals(false, test.abuts(Interval.of(NOW1.plusSeconds(1), NOW2)));
         // partly after
-        assertEquals(test.abuts(Interval.of(NOW1, NOW2.plusSeconds(1))), false);
-        assertEquals(test.abuts(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))), false);
+        assertEquals(false, test.abuts(Interval.of(NOW1, NOW2.plusSeconds(1))));
+        assertEquals(false, test.abuts(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
-        assertEquals(test.abuts(Interval.of(NOW2, NOW2.plusSeconds(1))), true);
-        assertEquals(test.abuts(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))), false);
+        assertEquals(true, test.abuts(Interval.of(NOW2, NOW2.plusSeconds(1))));
+        assertEquals(false, test.abuts(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
     }
 
     @Test
     public void test_abuts_Interval_empty() {
         Interval test = Interval.of(NOW1, NOW1);
         // completely before
-        assertEquals(test.abuts(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.abuts(Interval.of(NOW1.minusSeconds(1), NOW1)), true);
+        assertEquals(false, test.abuts(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(true, test.abuts(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // equal
-        assertEquals(test.abuts(Interval.of(NOW1, NOW1)), false);
+        assertEquals(false, test.abuts(Interval.of(NOW1, NOW1)));
         // completely after
-        assertEquals(test.abuts(Interval.of(NOW1, NOW1.plusSeconds(1))), true);
-        assertEquals(test.abuts(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))), false);
+        assertEquals(true, test.abuts(Interval.of(NOW1, NOW1.plusSeconds(1))));
+        assertEquals(false, test.abuts(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
     @Test(expected = NullPointerException.class)
@@ -383,34 +383,34 @@ public class TestInterval {
     public void test_isConnected_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before
-        assertEquals(test.isConnected(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW1)), true);
+        assertEquals(false, test.isConnected(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(true, test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // partly before
-        assertEquals(test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW2)), true);
-        assertEquals(test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))), true);
+        assertEquals(true, test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW2)));
+        assertEquals(true, test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
         // contained
-        assertEquals(test.isConnected(Interval.of(NOW1, NOW2.minusSeconds(1))), true);
-        assertEquals(test.isConnected(Interval.of(NOW1, NOW2)), true);
-        assertEquals(test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW2)), true);
+        assertEquals(true, test.isConnected(Interval.of(NOW1, NOW2.minusSeconds(1))));
+        assertEquals(true, test.isConnected(Interval.of(NOW1, NOW2)));
+        assertEquals(true, test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW2)));
         // partly after
-        assertEquals(test.isConnected(Interval.of(NOW1, NOW2.plusSeconds(1))), true);
-        assertEquals(test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))), true);
+        assertEquals(true, test.isConnected(Interval.of(NOW1, NOW2.plusSeconds(1))));
+        assertEquals(true, test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
-        assertEquals(test.isConnected(Interval.of(NOW2, NOW2.plusSeconds(1))), true);
-        assertEquals(test.isConnected(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))), false);
+        assertEquals(true, test.isConnected(Interval.of(NOW2, NOW2.plusSeconds(1))));
+        assertEquals(false, test.isConnected(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
     }
 
     @Test
     public void test_isConnected_Interval_empty() {
         Interval test = Interval.of(NOW1, NOW1);
         // completely before
-        assertEquals(test.isConnected(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW1)), true);
+        assertEquals(false, test.isConnected(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(true, test.isConnected(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // equal
-        assertEquals(test.isConnected(Interval.of(NOW1, NOW1)), true);
+        assertEquals(true, test.isConnected(Interval.of(NOW1, NOW1)));
         // completely after
-        assertEquals(test.isConnected(Interval.of(NOW1, NOW1.plusSeconds(1))), true);
-        assertEquals(test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))), false);
+        assertEquals(true, test.isConnected(Interval.of(NOW1, NOW1.plusSeconds(1))));
+        assertEquals(false, test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
     @Test(expected = NullPointerException.class)
@@ -424,34 +424,34 @@ public class TestInterval {
     public void test_overlaps_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before
-        assertEquals(test.overlaps(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW1)), false);
+        assertEquals(false, test.overlaps(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(false, test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // partly before
-        assertEquals(test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW2)), true);
-        assertEquals(test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))), true);
+        assertEquals(true, test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW2)));
+        assertEquals(true, test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
         // contained
-        assertEquals(test.overlaps(Interval.of(NOW1, NOW2.minusSeconds(1))), true);
-        assertEquals(test.overlaps(Interval.of(NOW1, NOW2)), true);
-        assertEquals(test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW2)), true);
+        assertEquals(true, test.overlaps(Interval.of(NOW1, NOW2.minusSeconds(1))));
+        assertEquals(true, test.overlaps(Interval.of(NOW1, NOW2)));
+        assertEquals(true, test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW2)));
         // partly after
-        assertEquals(test.overlaps(Interval.of(NOW1, NOW2.plusSeconds(1))), true);
-        assertEquals(test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))), true);
+        assertEquals(true, test.overlaps(Interval.of(NOW1, NOW2.plusSeconds(1))));
+        assertEquals(true, test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
-        assertEquals(test.overlaps(Interval.of(NOW2, NOW2.plusSeconds(1))), false);
-        assertEquals(test.overlaps(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))), false);
+        assertEquals(false, test.overlaps(Interval.of(NOW2, NOW2.plusSeconds(1))));
+        assertEquals(false, test.overlaps(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
     }
 
     @Test
     public void test_overlaps_Interval_empty() {
         Interval test = Interval.of(NOW1, NOW1);
         // completely before
-        assertEquals(test.overlaps(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW1)), false);
+        assertEquals(false, test.overlaps(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(false, test.overlaps(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // equal
-        assertEquals(test.overlaps(Interval.of(NOW1, NOW1)), true);
+        assertEquals(true, test.overlaps(Interval.of(NOW1, NOW1)));
         // completely after
-        assertEquals(test.overlaps(Interval.of(NOW1, NOW1.plusSeconds(1))), false);
-        assertEquals(test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))), false);
+        assertEquals(false, test.overlaps(Interval.of(NOW1, NOW1.plusSeconds(1))));
+        assertEquals(false, test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
     @Test(expected = NullPointerException.class)
@@ -486,7 +486,7 @@ public class TestInterval {
         Interval test2 = Interval.of(start2, end2);
         Interval expected = Interval.of(expStart, expEnd);
         assertTrue(test1.isConnected(test2));
-        assertEquals(test1.intersection(test2), expected);
+        assertEquals(expected, test1.intersection(test2));
     }
 
     @Test
@@ -498,21 +498,21 @@ public class TestInterval {
         Interval test2 = Interval.of(start2, end2);
         Interval expected = Interval.of(expStart, expEnd);
         assertTrue(test2.isConnected(test1));
-        assertEquals(test2.intersection(test1), expected);
+        assertEquals(expected, test2.intersection(test1));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_intersectionBad() {
         Interval test1 = Interval.of(NOW1, NOW2);
         Interval test2 = Interval.of(NOW3, NOW4);
-        assertEquals(test1.isConnected(test2), false);
+        assertEquals(false, test1.isConnected(test2));
         test1.intersection(test2);
     }
 
     @Test
     public void test_intersection_same() {
         Interval test = Interval.of(NOW2, NOW4);
-        assertEquals(test.intersection(test), test);
+        assertEquals(test, test.intersection(test));
     }
 
     //-----------------------------------------------------------------------
@@ -541,8 +541,8 @@ public class TestInterval {
         Interval test2 = Interval.of(start2, end2);
         Interval expected = Interval.of(expStart, expEnd);
         assertTrue(test1.isConnected(test2));
-        assertEquals(test1.union(test2), expected);
-        assertEquals(test1.span(test2), expected);
+        assertEquals(expected, test1.union(test2));
+        assertEquals(expected, test1.span(test2));
     }
 
     @Test
@@ -554,8 +554,8 @@ public class TestInterval {
         Interval test2 = Interval.of(start2, end2);
         Interval expected = Interval.of(expStart, expEnd);
         assertTrue(test2.isConnected(test1));
-        assertEquals(test2.union(test1), expected);
-        assertEquals(test2.span(test1), expected);
+        assertEquals(expected, test2.union(test1));
+        assertEquals(expected, test2.span(test1));
     }
 
     @Test
@@ -566,8 +566,8 @@ public class TestInterval {
         Interval test1 = Interval.of(start1, end1);
         Interval test2 = Interval.of(start2, end2);
         Interval expected = Interval.of(expStart, expEnd);
-        assertEquals(expected.encloses(test1), true);
-        assertEquals(expected.encloses(test2), true);
+        assertEquals(true, expected.encloses(test1));
+        assertEquals(true, expected.encloses(test2));
     }
 
     @Test(expected = DateTimeException.class)
@@ -583,52 +583,52 @@ public class TestInterval {
         Interval test1 = Interval.of(NOW1, NOW2);
         Interval test2 = Interval.of(NOW3, NOW4);
         assertFalse(test1.isConnected(test2));
-        assertEquals(test1.span(test2), Interval.of(NOW1, NOW4));
+        assertEquals(Interval.of(NOW1, NOW4), test1.span(test2));
     }
 
     @Test
     public void test_unionAndSpan_same() {
         Interval test = Interval.of(NOW2, NOW4);
-        assertEquals(test.union(test), test);
-        assertEquals(test.span(test), test);
+        assertEquals(test, test.union(test));
+        assertEquals(test, test.span(test));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_isAfter_Instant() {
         Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(test.isAfter(NOW1.minusSeconds(2)), true);
-        assertEquals(test.isAfter(NOW1.minusSeconds(1)), true);
-        assertEquals(test.isAfter(NOW1), false);
-        assertEquals(test.isAfter(NOW2), false);
-        assertEquals(test.isAfter(NOW2.plusSeconds(1)), false);
+        assertEquals(true, test.isAfter(NOW1.minusSeconds(2)));
+        assertEquals(true, test.isAfter(NOW1.minusSeconds(1)));
+        assertEquals(false, test.isAfter(NOW1));
+        assertEquals(false, test.isAfter(NOW2));
+        assertEquals(false, test.isAfter(NOW2.plusSeconds(1)));
     }
 
     @Test
     public void test_isAfter_Instant_empty() {
         Interval test = Interval.of(NOW1, NOW1);
-        assertEquals(test.isAfter(NOW1.minusSeconds(2)), true);
-        assertEquals(test.isAfter(NOW1.minusSeconds(1)), true);
-        assertEquals(test.isAfter(NOW1), false);
-        assertEquals(test.isAfter(NOW1.plusSeconds(1)), false);
+        assertEquals(true, test.isAfter(NOW1.minusSeconds(2)));
+        assertEquals(true, test.isAfter(NOW1.minusSeconds(1)));
+        assertEquals(false, test.isAfter(NOW1));
+        assertEquals(false, test.isAfter(NOW1.plusSeconds(1)));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_isBefore_Instant() {
         Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(test.isBefore(NOW1.minusSeconds(1)), false);
-        assertEquals(test.isBefore(NOW1), false);
-        assertEquals(test.isBefore(NOW2), true);
-        assertEquals(test.isBefore(NOW2.plusSeconds(1)), true);
+        assertEquals(false, test.isBefore(NOW1.minusSeconds(1)));
+        assertEquals(false, test.isBefore(NOW1));
+        assertEquals(true, test.isBefore(NOW2));
+        assertEquals(true, test.isBefore(NOW2.plusSeconds(1)));
     }
 
     @Test
     public void test_isBefore_Instant_empty() {
         Interval test = Interval.of(NOW1, NOW1);
-        assertEquals(test.isBefore(NOW1.minusSeconds(1)), false);
-        assertEquals(test.isBefore(NOW1), false);
-        assertEquals(test.isBefore(NOW1.plusSeconds(1)), true);
+        assertEquals(false, test.isBefore(NOW1.minusSeconds(1)));
+        assertEquals(false, test.isBefore(NOW1));
+        assertEquals(true, test.isBefore(NOW1.plusSeconds(1)));
     }
 
     //-----------------------------------------------------------------------
@@ -636,34 +636,34 @@ public class TestInterval {
     public void test_isAfter_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before
-        assertEquals(test.isAfter(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), true);
-        assertEquals(test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW1)), true);
+        assertEquals(true, test.isAfter(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(true, test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // partly before
-        assertEquals(test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW2)), false);
-        assertEquals(test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))), false);
+        assertEquals(false, test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW2)));
+        assertEquals(false, test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
         // contained
-        assertEquals(test.isAfter(Interval.of(NOW1, NOW2.minusSeconds(1))), false);
-        assertEquals(test.isAfter(Interval.of(NOW1, NOW2)), false);
-        assertEquals(test.isAfter(Interval.of(NOW1.plusSeconds(1), NOW2)), false);
+        assertEquals(false, test.isAfter(Interval.of(NOW1, NOW2.minusSeconds(1))));
+        assertEquals(false, test.isAfter(Interval.of(NOW1, NOW2)));
+        assertEquals(false, test.isAfter(Interval.of(NOW1.plusSeconds(1), NOW2)));
         // partly after
-        assertEquals(test.isAfter(Interval.of(NOW1, NOW2.plusSeconds(1))), false);
-        assertEquals(test.isAfter(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))), false);
+        assertEquals(false, test.isAfter(Interval.of(NOW1, NOW2.plusSeconds(1))));
+        assertEquals(false, test.isAfter(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
-        assertEquals(test.isAfter(Interval.of(NOW2, NOW2.plusSeconds(1))), false);
-        assertEquals(test.isAfter(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))), false);
+        assertEquals(false, test.isAfter(Interval.of(NOW2, NOW2.plusSeconds(1))));
+        assertEquals(false, test.isAfter(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
     }
 
     @Test
     public void test_isAfter_Interval_empty() {
         Interval test = Interval.of(NOW1, NOW1);
         // completely before
-        assertEquals(test.isAfter(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), true);
-        assertEquals(test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW1)), true);
+        assertEquals(true, test.isAfter(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(true, test.isAfter(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // equal
-        assertEquals(test.isAfter(Interval.of(NOW1, NOW1)), false);
+        assertEquals(false, test.isAfter(Interval.of(NOW1, NOW1)));
         // completely after
-        assertEquals(test.isAfter(Interval.of(NOW1, NOW1.plusSeconds(1))), false);
-        assertEquals(test.isAfter(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))), false);
+        assertEquals(false, test.isAfter(Interval.of(NOW1, NOW1.plusSeconds(1))));
+        assertEquals(false, test.isAfter(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
     //-----------------------------------------------------------------------
@@ -671,41 +671,41 @@ public class TestInterval {
     public void test_isBefore_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before
-        assertEquals(test.isBefore(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW1)), false);
+        assertEquals(false, test.isBefore(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(false, test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // partly before
-        assertEquals(test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW2)), false);
-        assertEquals(test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))), false);
+        assertEquals(false, test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW2)));
+        assertEquals(false, test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
         // contained
-        assertEquals(test.isBefore(Interval.of(NOW1, NOW2.minusSeconds(1))), false);
-        assertEquals(test.isBefore(Interval.of(NOW1, NOW2)), false);
-        assertEquals(test.isBefore(Interval.of(NOW1.plusSeconds(1), NOW2)), false);
+        assertEquals(false, test.isBefore(Interval.of(NOW1, NOW2.minusSeconds(1))));
+        assertEquals(false, test.isBefore(Interval.of(NOW1, NOW2)));
+        assertEquals(false, test.isBefore(Interval.of(NOW1.plusSeconds(1), NOW2)));
         // partly after
-        assertEquals(test.isBefore(Interval.of(NOW1, NOW2.plusSeconds(1))), false);
-        assertEquals(test.isBefore(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))), false);
+        assertEquals(false, test.isBefore(Interval.of(NOW1, NOW2.plusSeconds(1))));
+        assertEquals(false, test.isBefore(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
-        assertEquals(test.isBefore(Interval.of(NOW2, NOW2.plusSeconds(1))), true);
-        assertEquals(test.isBefore(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))), true);
+        assertEquals(true, test.isBefore(Interval.of(NOW2, NOW2.plusSeconds(1))));
+        assertEquals(true, test.isBefore(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
     }
 
     @Test
     public void test_isBefore_Interval_empty() {
         Interval test = Interval.of(NOW1, NOW1);
         // completely before
-        assertEquals(test.isBefore(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))), false);
-        assertEquals(test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW1)), false);
+        assertEquals(false, test.isBefore(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
+        assertEquals(false, test.isBefore(Interval.of(NOW1.minusSeconds(1), NOW1)));
         // equal
-        assertEquals(test.isBefore(Interval.of(NOW1, NOW1)), false);
+        assertEquals(false, test.isBefore(Interval.of(NOW1, NOW1)));
         // completely after
-        assertEquals(test.isBefore(Interval.of(NOW1, NOW1.plusSeconds(1))), true);
-        assertEquals(test.isBefore(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))), true);
+        assertEquals(true, test.isBefore(Interval.of(NOW1, NOW1.plusSeconds(1))));
+        assertEquals(true, test.isBefore(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_toDuration() {
         Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(test.toDuration(), Duration.between(NOW1, NOW2));
+        assertEquals(Duration.between(NOW1, NOW2), test.toDuration());
     }
 
     //-----------------------------------------------------------------------
@@ -715,20 +715,20 @@ public class TestInterval {
         Interval a2 = Interval.of(NOW1, NOW2);
         Interval b = Interval.of(NOW1, NOW3);
         Interval c = Interval.of(NOW2, NOW2);
-        assertEquals(a.equals(a), true);
-        assertEquals(a.equals(a2), true);
-        assertEquals(a.equals(b), false);
-        assertEquals(a.equals(c), false);
-        assertEquals(a.equals(null), false);
-        assertEquals(a.equals(""), false);
-        assertEquals(a.hashCode() == a2.hashCode(), true);
+        assertEquals(true, a.equals(a));
+        assertEquals(true, a.equals(a2));
+        assertEquals(false, a.equals(b));
+        assertEquals(false, a.equals(c));
+        assertEquals(false, a.equals(null));
+        assertEquals(false, a.equals(""));
+        assertEquals(true, a.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_toString() {
         Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(test.toString(), NOW1 + "/" + NOW2);
+        assertEquals(NOW1 + "/" + NOW2, test.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -77,86 +77,86 @@ public class TestLocalDateRange {
     @Test
     public void test_ALL() {
         LocalDateRange test = LocalDateRange.ALL;
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), LocalDate.MAX);
-        assertEquals(test.getEnd(), LocalDate.MAX);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), true);
-        assertEquals(test.toString(), "-999999999-01-01/+999999999-12-31");
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
+        assertEquals("-999999999-01-01/+999999999-12-31", test.toString());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "2012-07-28/2012-07-31");
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("2012-07-28/2012-07-31", test.toString());
     }
 
     @Test
     public void test_of_MIN() {
         LocalDateRange test = LocalDateRange.of(LocalDate.MIN, DATE_2012_07_31);
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "-999999999-01-01/2012-07-31");
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("-999999999-01-01/2012-07-31", test.toString());
     }
 
     @Test
     public void test_of_MAX() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX);
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), LocalDate.MAX);
-        assertEquals(test.getEnd(), LocalDate.MAX);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), true);
-        assertEquals(test.toString(), "2012-07-28/+999999999-12-31");
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
+        assertEquals("2012-07-28/+999999999-12-31", test.toString());
     }
 
     @Test
     public void test_of_MIN_MAX() {
         LocalDateRange test = LocalDateRange.of(LocalDate.MIN, LocalDate.MAX);
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), LocalDate.MAX);
-        assertEquals(test.getEnd(), LocalDate.MAX);
-        assertEquals(test.isEmpty(), false);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), true);
-        assertEquals(test.toString(), "-999999999-01-01/+999999999-12-31");
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
+        assertEquals("-999999999-01-01/+999999999-12-31", test.toString());
     }
 
     @Test
     public void test_of_MIN_MIN() {
         LocalDateRange test = LocalDateRange.of(LocalDate.MIN, LocalDate.MIN);
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), LocalDate.MIN);
-        assertEquals(test.getEnd(), LocalDate.MIN);
-        assertEquals(test.isEmpty(), true);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "-999999999-01-01/-999999999-01-01");
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(LocalDate.MIN, test.getEndInclusive());
+        assertEquals(LocalDate.MIN, test.getEnd());
+        assertEquals(true, test.isEmpty());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("-999999999-01-01/-999999999-01-01", test.toString());
     }
 
     @Test
     public void test_of_empty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_30);
-        assertEquals(test.getStart(), DATE_2012_07_30);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_29);
-        assertEquals(test.getEnd(), DATE_2012_07_30);
-        assertEquals(test.isEmpty(), true);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "2012-07-30/2012-07-30");
+        assertEquals(DATE_2012_07_30, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEndInclusive());
+        assertEquals(DATE_2012_07_30, test.getEnd());
+        assertEquals(true, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("2012-07-30/2012-07-30", test.toString());
     }
 
     @Test(expected = DateTimeException.class)
@@ -168,45 +168,45 @@ public class TestLocalDateRange {
     @Test
     public void test_ofClosed() {
         LocalDateRange test = LocalDateRange.ofClosed(DATE_2012_07_28, DATE_2012_07_30);
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "2012-07-28/2012-07-31");
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("2012-07-28/2012-07-31", test.toString());
     }
 
     @Test
     public void test_ofClosed_MIN() {
         LocalDateRange test = LocalDateRange.ofClosed(LocalDate.MIN, DATE_2012_07_30);
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "-999999999-01-01/2012-07-31");
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("-999999999-01-01/2012-07-31", test.toString());
     }
 
     @Test
     public void test_ofClosed_MAX() {
         LocalDateRange test = LocalDateRange.ofClosed(DATE_2012_07_28, LocalDate.MAX);
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), LocalDate.MAX);
-        assertEquals(test.getEnd(), LocalDate.MAX);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), true);
-        assertEquals(test.toString(), "2012-07-28/+999999999-12-31");
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
+        assertEquals("2012-07-28/+999999999-12-31", test.toString());
     }
 
     @Test
     public void test_ofClosed_MIN_MAX() {
         LocalDateRange test = LocalDateRange.ofClosed(LocalDate.MIN, LocalDate.MAX);
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), LocalDate.MAX);
-        assertEquals(test.getEnd(), LocalDate.MAX);
-        assertEquals(test.isUnboundedStart(), true);
-        assertEquals(test.isUnboundedEnd(), true);
-        assertEquals(test.toString(), "-999999999-01-01/+999999999-12-31");
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
+        assertEquals("-999999999-01-01/+999999999-12-31", test.toString());
     }
 
     @Test(expected = DateTimeException.class)
@@ -218,12 +218,12 @@ public class TestLocalDateRange {
     @Test
     public void test_of_period() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, Period.ofDays(3));
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
-        assertEquals(test.isUnboundedStart(), false);
-        assertEquals(test.isUnboundedEnd(), false);
-        assertEquals(test.toString(), "2012-07-28/2012-07-31");
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+        assertEquals("2012-07-28/2012-07-31", test.toString());
     }
 
     @Test(expected = DateTimeException.class)
@@ -235,43 +235,43 @@ public class TestLocalDateRange {
     @Test
     public void test_parse_CharSequence() {
         LocalDateRange test = LocalDateRange.parse(DATE_2012_07_27 + "/" + DATE_2012_07_29);
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEnd(), DATE_2012_07_29);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEnd());
     }
 
     @Test
     public void test_parse_CharSequence_PeriodLocalDate() {
         LocalDateRange test = LocalDateRange.parse("P2D/" + DATE_2012_07_29);
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEnd(), DATE_2012_07_29);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEnd());
     }
 
     @Test
     public void test_parse_CharSequence_PeriodLocalDate_case() {
         LocalDateRange test = LocalDateRange.parse("p2d/" + DATE_2012_07_29);
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEnd(), DATE_2012_07_29);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEnd());
     }
 
     @Test
     public void test_parse_CharSequence_LocalDatePeriod() {
         LocalDateRange test = LocalDateRange.parse(DATE_2012_07_27 + "/P2D");
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEnd(), DATE_2012_07_29);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEnd());
     }
 
     @Test
     public void test_parse_CharSequence_LocalDatePeriod_case() {
         LocalDateRange test = LocalDateRange.parse(DATE_2012_07_27 + "/p2d");
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEnd(), DATE_2012_07_29);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEnd());
     }
 
     @Test
     public void test_parse_CharSequence_empty() {
         LocalDateRange test = LocalDateRange.parse(DATE_2012_07_27 + "/" + DATE_2012_07_27);
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEnd(), DATE_2012_07_27);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_27, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -303,7 +303,7 @@ public class TestLocalDateRange {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -312,36 +312,36 @@ public class TestLocalDateRange {
     public void test_withStart() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withStart(DATE_2012_07_27);
-        assertEquals(test.getStart(), DATE_2012_07_27);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
+        assertEquals(DATE_2012_07_27, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
     }
 
     @Test
     public void test_withStart_adjuster() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withStart(date -> date.minus(1, ChronoUnit.WEEKS));
-        assertEquals(test.getStart(), DATE_2012_07_28.minusWeeks(1));
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
+        assertEquals(DATE_2012_07_28.minusWeeks(1), test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
     }
 
     @Test
     public void test_withStart_min() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withStart(LocalDate.MIN);
-        assertEquals(test.getStart(), LocalDate.MIN);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
+        assertEquals(LocalDate.MIN, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
     }
 
     @Test
     public void test_withStart_empty() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withStart(DATE_2012_07_31);
-        assertEquals(test.getStart(), DATE_2012_07_31);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30);
-        assertEquals(test.getEnd(), DATE_2012_07_31);
+        assertEquals(DATE_2012_07_31, test.getStart());
+        assertEquals(DATE_2012_07_30, test.getEndInclusive());
+        assertEquals(DATE_2012_07_31, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -355,36 +355,36 @@ public class TestLocalDateRange {
     public void test_withEnd() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withEnd(DATE_2012_07_30);
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_29);
-        assertEquals(test.getEnd(), DATE_2012_07_30);
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEndInclusive());
+        assertEquals(DATE_2012_07_30, test.getEnd());
     }
 
     @Test
     public void test_withEnd_adjuster() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withEnd(date -> date.plus(1, ChronoUnit.WEEKS));
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_30.plusWeeks(1));
-        assertEquals(test.getEnd(), DATE_2012_07_31.plusWeeks(1));
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_30.plusWeeks(1), test.getEndInclusive());
+        assertEquals(DATE_2012_07_31.plusWeeks(1), test.getEnd());
     }
 
     @Test
     public void test_withEnd_max() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange test = base.withEnd(LocalDate.MAX);
-        assertEquals(test.getStart(), DATE_2012_07_28);
-        assertEquals(test.getEndInclusive(), LocalDate.MAX);
-        assertEquals(test.getEnd(), LocalDate.MAX);
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
     }
 
     @Test
     public void test_withEnd_empty() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_31);
         LocalDateRange test = base.withEnd(DATE_2012_07_30);
-        assertEquals(test.getStart(), DATE_2012_07_30);
-        assertEquals(test.getEndInclusive(), DATE_2012_07_29);
-        assertEquals(test.getEnd(), DATE_2012_07_30);
+        assertEquals(DATE_2012_07_30, test.getStart());
+        assertEquals(DATE_2012_07_29, test.getEndInclusive());
+        assertEquals(DATE_2012_07_30, test.getEnd());
     }
 
     @Test(expected = DateTimeException.class)
@@ -397,37 +397,37 @@ public class TestLocalDateRange {
     @Test
     public void test_contains() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.contains(LocalDate.MIN), false);
-        assertEquals(test.contains(DATE_2012_07_27), false);
-        assertEquals(test.contains(DATE_2012_07_28), true);
-        assertEquals(test.contains(DATE_2012_07_29), true);
-        assertEquals(test.contains(DATE_2012_07_30), true);
-        assertEquals(test.contains(DATE_2012_07_31), false);
-        assertEquals(test.contains(DATE_2012_08_01), false);
-        assertEquals(test.contains(LocalDate.MAX), false);
+        assertEquals(false, test.contains(LocalDate.MIN));
+        assertEquals(false, test.contains(DATE_2012_07_27));
+        assertEquals(true, test.contains(DATE_2012_07_28));
+        assertEquals(true, test.contains(DATE_2012_07_29));
+        assertEquals(true, test.contains(DATE_2012_07_30));
+        assertEquals(false, test.contains(DATE_2012_07_31));
+        assertEquals(false, test.contains(DATE_2012_08_01));
+        assertEquals(false, test.contains(LocalDate.MAX));
     }
 
     @Test
     public void test_contains_baseEmpty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28);
-        assertEquals(test.contains(LocalDate.MIN), false);
-        assertEquals(test.contains(DATE_2012_07_27), false);
-        assertEquals(test.contains(DATE_2012_07_28), false);
-        assertEquals(test.contains(DATE_2012_07_29), false);
-        assertEquals(test.contains(LocalDate.MAX), false);
+        assertEquals(false, test.contains(LocalDate.MIN));
+        assertEquals(false, test.contains(DATE_2012_07_27));
+        assertEquals(false, test.contains(DATE_2012_07_28));
+        assertEquals(false, test.contains(DATE_2012_07_29));
+        assertEquals(false, test.contains(LocalDate.MAX));
     }
 
     @Test
     public void test_contains_max() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX);
-        assertEquals(test.contains(LocalDate.MIN), false);
-        assertEquals(test.contains(DATE_2012_07_27), false);
-        assertEquals(test.contains(DATE_2012_07_28), true);
-        assertEquals(test.contains(DATE_2012_07_29), true);
-        assertEquals(test.contains(DATE_2012_07_30), true);
-        assertEquals(test.contains(DATE_2012_07_31), true);
-        assertEquals(test.contains(DATE_2012_08_01), true);
-        assertEquals(test.contains(LocalDate.MAX), true);
+        assertEquals(false, test.contains(LocalDate.MIN));
+        assertEquals(false, test.contains(DATE_2012_07_27));
+        assertEquals(true, test.contains(DATE_2012_07_28));
+        assertEquals(true, test.contains(DATE_2012_07_29));
+        assertEquals(true, test.contains(DATE_2012_07_30));
+        assertEquals(true, test.contains(DATE_2012_07_31));
+        assertEquals(true, test.contains(DATE_2012_08_01));
+        assertEquals(true, test.contains(LocalDate.MAX));
     }
 
     //-----------------------------------------------------------------------
@@ -485,7 +485,7 @@ public class TestLocalDateRange {
     public void test_encloses(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.encloses(LocalDateRange.of(start, end)), isEnclosedBy);
+        assertEquals(isEnclosedBy, test.encloses(LocalDateRange.of(start, end)));
     }
 
     @Test
@@ -493,7 +493,7 @@ public class TestLocalDateRange {
     public void test_abuts(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.abuts(LocalDateRange.of(start, end)), abuts);
+        assertEquals(abuts, test.abuts(LocalDateRange.of(start, end)));
     }
 
     @Test
@@ -501,7 +501,7 @@ public class TestLocalDateRange {
     public void test_isConnected(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.isConnected(LocalDateRange.of(start, end)), isConnected);
+        assertEquals(isConnected, test.isConnected(LocalDateRange.of(start, end)));
     }
 
     @Test
@@ -509,7 +509,7 @@ public class TestLocalDateRange {
     public void test_overlaps(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.overlaps(LocalDateRange.of(start, end)), overlaps);
+        assertEquals(overlaps, test.overlaps(LocalDateRange.of(start, end)));
     }
 
     @Test
@@ -518,114 +518,114 @@ public class TestLocalDateRange {
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         LocalDateRange input = LocalDateRange.of(start, end);
-        assertEquals(test.isConnected(input), test.overlaps(input) || test.abuts(input));
-        assertEquals(test.overlaps(input), test.isConnected(input) && !test.abuts(input));
+        assertEquals(test.overlaps(input) || test.abuts(input), test.isConnected(input));
+        assertEquals(test.isConnected(input) && !test.abuts(input), test.overlaps(input));
     }
 
     @Test
     public void test_encloses_max() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)), true);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29)), true);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX)), true);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_27)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_27, LocalDate.MAX)), false);
+        assertEquals(true, test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)));
+        assertEquals(true, test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29)));
+        assertEquals(true, test.encloses(LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_27)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_27, LocalDate.MAX)));
     }
 
     @Test
     public void test_encloses_baseEmpty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)), true);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_27, LocalDate.MAX)), false);
-        assertEquals(test.encloses(LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX)), false);
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)));
+        assertEquals(true, test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_27, LocalDate.MAX)));
+        assertEquals(false, test.encloses(LocalDateRange.of(DATE_2012_07_28, LocalDate.MAX)));
     }
 
     @Test
     public void test_encloses_baseEmptyMax() {
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .encloses(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))), false);
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .encloses(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     @Test
     public void test_abuts_baseEmpty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28);
-        assertEquals(test.abuts(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)), false);
-        assertEquals(test.abuts(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)), false);
-        assertEquals(test.abuts(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)), false);
-        assertEquals(test.abuts(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)), true);
-        assertEquals(test.abuts(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29)), true);
+        assertEquals(false, test.abuts(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)));
+        assertEquals(false, test.abuts(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)));
+        assertEquals(false, test.abuts(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)));
+        assertEquals(true, test.abuts(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)));
+        assertEquals(true, test.abuts(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29)));
     }
 
     @Test
     public void test_abuts_baseEmptyMax() {
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .abuts(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))), false);
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .abuts(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     @Test
     public void test_isConnected_baseEmpty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28);
-        assertEquals(test.isConnected(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)), false);
-        assertEquals(test.isConnected(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)), true);
-        assertEquals(test.isConnected(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)), false);
+        assertEquals(false, test.isConnected(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)));
+        assertEquals(true, test.isConnected(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)));
+        assertEquals(false, test.isConnected(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)));
     }
 
     @Test
     public void test_isConnected_baseEmptyMax() {
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .isConnected(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))), false);
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .isConnected(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     @Test
     public void test_overlaps_baseEmpty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28);
-        assertEquals(test.overlaps(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)), false);
-        assertEquals(test.overlaps(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)), true);
-        assertEquals(test.overlaps(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)), false);
+        assertEquals(false, test.overlaps(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_27)));
+        assertEquals(true, test.overlaps(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)));
+        assertEquals(false, test.overlaps(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)));
     }
 
     @Test
     public void test_overlaps_baseEmptyMax() {
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .overlaps(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)), true);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-                .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))), false);
-        assertEquals(LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-                .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))), false);
+        assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .overlaps(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
+				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+        assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
+				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     //-----------------------------------------------------------------------
@@ -654,7 +654,7 @@ public class TestLocalDateRange {
         LocalDateRange test2 = LocalDateRange.of(start2, end2);
         LocalDateRange expected = LocalDateRange.of(expStart, expEnd);
         assertTrue(test1.isConnected(test2));
-        assertEquals(test1.intersection(test2), expected);
+        assertEquals(expected, test1.intersection(test2));
     }
 
     @Test
@@ -666,21 +666,21 @@ public class TestLocalDateRange {
         LocalDateRange test2 = LocalDateRange.of(start2, end2);
         LocalDateRange expected = LocalDateRange.of(expStart, expEnd);
         assertTrue(test2.isConnected(test1));
-        assertEquals(test2.intersection(test1), expected);
+        assertEquals(expected, test2.intersection(test1));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_intersectionBad() {
         LocalDateRange test1 = LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_28);
         LocalDateRange test2 = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30);
-        assertEquals(test1.isConnected(test2), false);
+        assertEquals(false, test1.isConnected(test2));
         test1.intersection(test2);
     }
 
     @Test
     public void test_intersection_same() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.intersection(test), test);
+        assertEquals(test, test.intersection(test));
     }
 
     //-----------------------------------------------------------------------
@@ -709,8 +709,8 @@ public class TestLocalDateRange {
         LocalDateRange test2 = LocalDateRange.of(start2, end2);
         LocalDateRange expected = LocalDateRange.of(expStart, expEnd);
         assertTrue(test1.isConnected(test2));
-        assertEquals(test1.union(test2), expected);
-        assertEquals(test1.span(test2), expected);
+        assertEquals(expected, test1.union(test2));
+        assertEquals(expected, test1.span(test2));
     }
 
     @Test
@@ -722,8 +722,8 @@ public class TestLocalDateRange {
         LocalDateRange test2 = LocalDateRange.of(start2, end2);
         LocalDateRange expected = LocalDateRange.of(expStart, expEnd);
         assertTrue(test2.isConnected(test1));
-        assertEquals(test2.union(test1), expected);
-        assertEquals(test2.span(test1), expected);
+        assertEquals(expected, test2.union(test1));
+        assertEquals(expected, test2.span(test1));
     }
 
     @Test
@@ -734,8 +734,8 @@ public class TestLocalDateRange {
         LocalDateRange test1 = LocalDateRange.of(start1, end1);
         LocalDateRange test2 = LocalDateRange.of(start2, end2);
         LocalDateRange expected = LocalDateRange.of(expStart, expEnd);
-        assertEquals(expected.encloses(test1), true);
-        assertEquals(expected.encloses(test2), true);
+        assertEquals(true, expected.encloses(test1));
+        assertEquals(true, expected.encloses(test2));
     }
 
     @Test(expected = DateTimeException.class)
@@ -751,14 +751,14 @@ public class TestLocalDateRange {
         LocalDateRange test1 = LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_28);
         LocalDateRange test2 = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30);
         assertFalse(test1.isConnected(test2));
-        assertEquals(test1.span(test2), LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_30));
+        assertEquals(LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_30), test1.span(test2));
     }
 
     @Test
     public void test_unionAndSpan_same() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.union(test), test);
-        assertEquals(test.span(test), test);
+        assertEquals(test, test.union(test));
+        assertEquals(test, test.span(test));
     }
 
     //-----------------------------------------------------------------------
@@ -766,10 +766,10 @@ public class TestLocalDateRange {
     public void test_stream() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         List<LocalDate> result = test.stream().collect(Collectors.toList());
-        assertEquals(result.size(), 3);
-        assertEquals(result.get(0), DATE_2012_07_28);
-        assertEquals(result.get(1), DATE_2012_07_29);
-        assertEquals(result.get(2), DATE_2012_07_30);
+        assertEquals(3, result.size());
+        assertEquals(DATE_2012_07_28, result.get(0));
+        assertEquals(DATE_2012_07_29, result.get(1));
+        assertEquals(DATE_2012_07_30, result.get(2));
     }
 
     //-----------------------------------------------------------------------
@@ -820,33 +820,33 @@ public class TestLocalDateRange {
     @UseDataProvider("data_isBefore")
     public void test_isBefore_range(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.isBefore(LocalDateRange.of(start, end)), before);
+        assertEquals(before, test.isBefore(LocalDateRange.of(start, end)));
     }
 
     @Test
     @UseDataProvider("data_isBefore")
     public void test_isBefore_date(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.isBefore(start), before);
+        assertEquals(before, test.isBefore(start));
     }
 
     @Test
     public void test_isBefore_range_empty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29);
-        assertEquals(test.isBefore(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)), false);
-        assertEquals(test.isBefore(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29)), false);
-        assertEquals(test.isBefore(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)), false);
-        assertEquals(test.isBefore(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30)), true);
-        assertEquals(test.isBefore(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_30)), true);
-        assertEquals(test.isBefore(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_31)), true);
+        assertEquals(false, test.isBefore(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)));
+        assertEquals(false, test.isBefore(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29)));
+        assertEquals(false, test.isBefore(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)));
+        assertEquals(true, test.isBefore(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30)));
+        assertEquals(true, test.isBefore(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_30)));
+        assertEquals(true, test.isBefore(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_31)));
     }
 
     @Test
     public void test_isBefore_date_empty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29);
-        assertEquals(test.isBefore(DATE_2012_07_28), false);
-        assertEquals(test.isBefore(DATE_2012_07_29), false);
-        assertEquals(test.isBefore(DATE_2012_07_30), true);
+        assertEquals(false, test.isBefore(DATE_2012_07_28));
+        assertEquals(false, test.isBefore(DATE_2012_07_29));
+        assertEquals(true, test.isBefore(DATE_2012_07_30));
     }
 
     //-----------------------------------------------------------------------
@@ -900,49 +900,49 @@ public class TestLocalDateRange {
     @UseDataProvider("data_isAfter")
     public void test_isAfter_range(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.isAfter(LocalDateRange.of(start, end)), before);
+        assertEquals(before, test.isAfter(LocalDateRange.of(start, end)));
     }
 
     @Test
     @UseDataProvider("data_isAfter")
     public void test_isAfter_date(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertEquals(test.isAfter(end.minusDays(1)), before);
+        assertEquals(before, test.isAfter(end.minusDays(1)));
     }
 
     @Test
     public void test_isAfter_range_empty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)), true);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29)), true);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)), true);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)), false);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30)), false);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_30)), false);
-        assertEquals(test.isAfter(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_31)), false);
+        assertEquals(true, test.isAfter(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_28)));
+        assertEquals(true, test.isAfter(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29)));
+        assertEquals(true, test.isAfter(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_28)));
+        assertEquals(false, test.isAfter(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29)));
+        assertEquals(false, test.isAfter(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30)));
+        assertEquals(false, test.isAfter(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_30)));
+        assertEquals(false, test.isAfter(LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_31)));
     }
 
     @Test
     public void test_isAfter_date_empty() {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29);
-        assertEquals(test.isAfter(DATE_2012_07_28), true);
-        assertEquals(test.isAfter(DATE_2012_07_29), false);
-        assertEquals(test.isAfter(DATE_2012_07_30), false);
+        assertEquals(true, test.isAfter(DATE_2012_07_28));
+        assertEquals(false, test.isAfter(DATE_2012_07_29));
+        assertEquals(false, test.isAfter(DATE_2012_07_30));
     }
 
   //-----------------------------------------------------------------------
     @Test
     public void test_lengthInDays() {
-        assertEquals(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29).lengthInDays(), 2);
-        assertEquals(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29).lengthInDays(), 1);
-        assertEquals(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29).lengthInDays(), 0);
+        assertEquals(2, LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29).lengthInDays());
+        assertEquals(1, LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29).lengthInDays());
+        assertEquals(0, LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29).lengthInDays());
     }
 
     @Test
     public void test_toPeriod() {
-        assertEquals(LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29).toPeriod(), Period.ofDays(2));
-        assertEquals(LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29).toPeriod(), Period.ofDays(1));
-        assertEquals(LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29).toPeriod(), Period.ofDays(0));
+        assertEquals(Period.ofDays(2), LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29).toPeriod());
+        assertEquals(Period.ofDays(1), LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29).toPeriod());
+        assertEquals(Period.ofDays(0), LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29).toPeriod());
     }
 
     //-----------------------------------------------------------------------
@@ -952,13 +952,13 @@ public class TestLocalDateRange {
         LocalDateRange a2 = LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_29);
         LocalDateRange b = LocalDateRange.of(DATE_2012_07_27, DATE_2012_07_30);
         LocalDateRange c = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_29);
-        assertEquals(a.equals(a), true);
-        assertEquals(a.equals(a2), true);
-        assertEquals(a.equals(b), false);
-        assertEquals(a.equals(c), false);
-        assertEquals(a.equals(null), false);
-        assertEquals(a.equals(""), false);
-        assertEquals(a.hashCode() == a2.hashCode(), true);
+        assertEquals(true, a.equals(a));
+        assertEquals(true, a.equals(a2));
+        assertEquals(false, a.equals(b));
+        assertEquals(false, a.equals(c));
+        assertEquals(false, a.equals(null));
+        assertEquals(false, a.equals(""));
+        assertEquals(true, a.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -995,7 +995,7 @@ public class TestLocalDateRange {
 
         boolean extra = extraRange1.encloses(extraRange2);
         boolean guava = guavaRange1.encloses(guavaRange2);
-        assertEquals(extra, guava);
+        assertEquals(guava, extra);
     }
 
     @Test
@@ -1008,7 +1008,7 @@ public class TestLocalDateRange {
 
         boolean extra = extraRange1.isConnected(extraRange2);
         boolean guava = guavaRange1.isConnected(guavaRange2);
-        assertEquals(extra, guava);
+        assertEquals(guava, extra);
     }
 
     @Test
@@ -1032,10 +1032,10 @@ public class TestLocalDateRange {
             // continue
         }
         if (extra == null) {
-            assertEquals(extra, guava);
+            assertEquals(guava, extra);
         } else if (guava != null) {
-            assertEquals(extra.getStart(), guava.lowerEndpoint());
-            assertEquals(extra.getEnd(), guava.upperEndpoint());
+            assertEquals(guava.lowerEndpoint(), extra.getStart());
+            assertEquals(guava.upperEndpoint(), extra.getEnd());
         }
     }
 
@@ -1049,8 +1049,8 @@ public class TestLocalDateRange {
 
         LocalDateRange extra = extraRange1.span(extraRange2);
         Range<LocalDate> guava = guavaRange1.span(guavaRange2);
-        assertEquals(extra.getStart(), guava.lowerEndpoint());
-        assertEquals(extra.getEnd(), guava.upperEndpoint());
+        assertEquals(guava.lowerEndpoint(), extra.getStart());
+        assertEquals(guava.upperEndpoint(), extra.getEnd());
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -549,15 +549,15 @@ public class TestLocalDateRange {
     @Test
     public void test_encloses_baseEmptyMax() {
         assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .encloses(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+                        .encloses(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+                        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
+                        .encloses(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     @Test
@@ -573,15 +573,15 @@ public class TestLocalDateRange {
     @Test
     public void test_abuts_baseEmptyMax() {
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .abuts(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+                        .abuts(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
         assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+                        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(true, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
+                        .abuts(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     @Test
@@ -595,15 +595,15 @@ public class TestLocalDateRange {
     @Test
     public void test_isConnected_baseEmptyMax() {
         assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .isConnected(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+                        .isConnected(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
         assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+                        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(true, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
+                        .isConnected(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     @Test
@@ -617,15 +617,15 @@ public class TestLocalDateRange {
     @Test
     public void test_overlaps_baseEmptyMax() {
         assertEquals(true, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .overlaps(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
+                        .overlaps(LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
+                        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX)));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX, LocalDate.MAX)
-				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
+                        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(1))));
         assertEquals(false, LocalDateRange.of(LocalDate.MAX.minusDays(1), LocalDate.MAX.minusDays(1))
-				        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
+                        .overlaps(LocalDateRange.of(DATE_2012_07_01, LocalDate.MAX.minusDays(2))));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -72,7 +72,7 @@ public class TestMinutes {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
     
@@ -80,7 +80,7 @@ public class TestMinutes {
     @Test
     public void test_ZERO() {
         assertSame(Minutes.of(0), Minutes.ZERO);
-        assertSame(Minutes.of(0), Minutes.ZERO);
+        assertEquals(Minutes.of(0), Minutes.ZERO);
         assertEquals(0, Minutes.ZERO.getAmount());
     }
     

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -81,31 +81,31 @@ public class TestMinutes {
     public void test_ZERO() {
         assertSame(Minutes.of(0), Minutes.ZERO);
         assertSame(Minutes.of(0), Minutes.ZERO);
-        assertEquals(Minutes.ZERO.getAmount(), 0);
+        assertEquals(0, Minutes.ZERO.getAmount());
     }
     
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Minutes.of(0).getAmount(), 0);
-        assertEquals(Minutes.of(1).getAmount(), 1);
-        assertEquals(Minutes.of(2).getAmount(), 2);
-        assertEquals(Minutes.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Minutes.of(-1).getAmount(), -1);
-        assertEquals(Minutes.of(-2).getAmount(), -2);
-        assertEquals(Minutes.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(0, Minutes.of(0).getAmount());
+        assertEquals(1, Minutes.of(1).getAmount());
+        assertEquals(2, Minutes.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Minutes.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Minutes.of(-1).getAmount());
+        assertEquals(-2, Minutes.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Minutes.of(Integer.MIN_VALUE).getAmount());
     }
     
     //-----------------------------------------------------------------------
     @Test
     public void test_ofHours() {
-        assertEquals(Minutes.ofHours(0).getAmount(), 0);
-        assertEquals(Minutes.ofHours(1).getAmount(), 60);
-        assertEquals(Minutes.ofHours(2).getAmount(), 120);
-        assertEquals(Minutes.ofHours(Integer.MAX_VALUE / 60).getAmount(), (Integer.MAX_VALUE / 60) * 60);
-        assertEquals(Minutes.ofHours(-1).getAmount(), -60);
-        assertEquals(Minutes.ofHours(-2).getAmount(), -120);
-        assertEquals(Minutes.ofHours(Integer.MIN_VALUE / 60).getAmount(), (Integer.MIN_VALUE / 60) * 60);
+        assertEquals(0, Minutes.ofHours(0).getAmount());
+        assertEquals(60, Minutes.ofHours(1).getAmount());
+        assertEquals(120, Minutes.ofHours(2).getAmount());
+        assertEquals((Integer.MAX_VALUE / 60) * 60, Minutes.ofHours(Integer.MAX_VALUE / 60).getAmount());
+        assertEquals(-60, Minutes.ofHours(-1).getAmount());
+        assertEquals(-120, Minutes.ofHours(-2).getAmount());
+        assertEquals((Integer.MIN_VALUE / 60) * 60, Minutes.ofHours(Integer.MIN_VALUE / 60).getAmount());
     }
     
     @Test(expected = ArithmeticException.class)
@@ -160,19 +160,19 @@ public class TestMinutes {
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedMinutes) {
-        assertEquals(Minutes.parse(str), Minutes.of(expectedMinutes));
+        assertEquals(Minutes.of(expectedMinutes), Minutes.parse(str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedMinutes) {
-        assertEquals(Minutes.parse("+" + str), Minutes.of(expectedMinutes));
+        assertEquals(Minutes.of(expectedMinutes), Minutes.parse("+" + str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedMinutes) {
-        assertEquals(Minutes.parse("-" + str), Minutes.of(-expectedMinutes));
+        assertEquals(Minutes.of(-expectedMinutes), Minutes.parse("-" + str));
     }
 
     @DataProvider
@@ -386,23 +386,23 @@ public class TestMinutes {
     @Test
     public void test_addTo() {
         LocalTime base = LocalTime.of(11, 30);
-        assertEquals(Minutes.of(0).addTo(base), LocalTime.of(11, 30));
-        assertEquals(Minutes.of(6).addTo(base), LocalTime.of(11, 36));
+        assertEquals(LocalTime.of(11, 30), Minutes.of(0).addTo(base));
+        assertEquals(LocalTime.of(11, 36), Minutes.of(6).addTo(base));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_subtractFrom() {
         LocalTime base = LocalTime.of(11, 30);
-        assertEquals(Minutes.of(0).subtractFrom(base), LocalTime.of(11, 30));
-        assertEquals(Minutes.of(6).subtractFrom(base), LocalTime.of(11, 24));
+        assertEquals(LocalTime.of(11, 30), Minutes.of(0).subtractFrom(base));
+        assertEquals(LocalTime.of(11, 24), Minutes.of(6).subtractFrom(base));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_toDuration() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Minutes.of(i).toDuration(), Duration.ofMinutes(i));
+            assertEquals(Duration.ofMinutes(i), Minutes.of(i).toDuration());
         }
     }
     

--- a/src/test/java/org/threeten/extra/TestMonths.java
+++ b/src/test/java/org/threeten/extra/TestMonths.java
@@ -83,38 +83,38 @@ public class TestMonths {
     public void test_ZERO() {
         assertSame(Months.of(0), Months.ZERO);
         assertSame(Months.of(0), Months.ZERO);
-        assertEquals(Months.ZERO.getAmount(), 0);
+        assertEquals(0, Months.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Months.of(1), Months.ONE);
         assertSame(Months.of(1), Months.ONE);
-        assertEquals(Months.ONE.getAmount(), 1);
+        assertEquals(1, Months.ONE.getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Months.of(0).getAmount(), 0);
-        assertEquals(Months.of(1).getAmount(), 1);
-        assertEquals(Months.of(2).getAmount(), 2);
-        assertEquals(Months.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Months.of(-1).getAmount(), -1);
-        assertEquals(Months.of(-2).getAmount(), -2);
-        assertEquals(Months.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(0, Months.of(0).getAmount());
+        assertEquals(1, Months.of(1).getAmount());
+        assertEquals(2, Months.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Months.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Months.of(-1).getAmount());
+        assertEquals(-2, Months.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Months.of(Integer.MIN_VALUE).getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_ofYears() {
-        assertEquals(Months.ofYears(0).getAmount(), 0);
-        assertEquals(Months.ofYears(1).getAmount(), 12);
-        assertEquals(Months.ofYears(2).getAmount(), 24);
-        assertEquals(Months.ofYears(Integer.MAX_VALUE / 12).getAmount(), (Integer.MAX_VALUE / 12) * 12);
-        assertEquals(Months.ofYears(-1).getAmount(), -12);
-        assertEquals(Months.ofYears(-2).getAmount(), -24);
-        assertEquals(Months.ofYears(Integer.MIN_VALUE / 12).getAmount(), (Integer.MIN_VALUE / 12) * 12);
+        assertEquals(0, Months.ofYears(0).getAmount());
+        assertEquals(12, Months.ofYears(1).getAmount());
+        assertEquals(24, Months.ofYears(2).getAmount());
+        assertEquals((Integer.MAX_VALUE / 12) * 12, Months.ofYears(Integer.MAX_VALUE / 12).getAmount());
+        assertEquals(-12, Months.ofYears(-1).getAmount());
+        assertEquals(-24, Months.ofYears(-2).getAmount());
+        assertEquals((Integer.MIN_VALUE / 12) * 12, Months.ofYears(Integer.MIN_VALUE / 12).getAmount());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -125,27 +125,27 @@ public class TestMonths {
     //-----------------------------------------------------------------------
     @Test
     public void test_from_Period_P0M() {
-        assertEquals(Months.from(Period.ofMonths(0)), Months.of(0));
+        assertEquals(Months.of(0), Months.from(Period.ofMonths(0)));
     }
 
     @Test
     public void test_from_Period_P2M() {
-        assertEquals(Months.from(Period.ofMonths(2)), Months.of(2));
+        assertEquals(Months.of(2), Months.from(Period.ofMonths(2)));
     }
 
     @Test
     public void test_from_P2Y() {
-        assertEquals(Months.from(new MockYearsMonths(2, 0)), Months.of(24));
+        assertEquals(Months.of(24), Months.from(new MockYearsMonths(2, 0)));
     }
 
     @Test
     public void test_from_P2Y3M() {
-        assertEquals(Months.from(new MockYearsMonths(2, 3)), Months.of(27));
+        assertEquals(Months.of(27), Months.from(new MockYearsMonths(2, 3)));
     }
 
     @Test
     public void test_from_yearsAndMonths() {
-        assertEquals(Months.from(Period.of(3, 5, 0)), Months.of(41));
+        assertEquals(Months.of(41), Months.from(Period.of(3, 5, 0)));
     }
 
     @Test(expected = DateTimeException.class)
@@ -193,19 +193,19 @@ public class TestMonths {
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
-        assertEquals(Months.parse(str), Months.of(expectedDays));
+        assertEquals(Months.of(expectedDays), Months.parse(str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
-        assertEquals(Months.parse("+" + str), Months.of(expectedDays));
+        assertEquals(Months.of(expectedDays), Months.parse("+" + str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
-        assertEquals(Months.parse("-" + str), Months.of(-expectedDays));
+        assertEquals(Months.of(-expectedDays), Months.parse("-" + str));
     }
 
     @DataProvider
@@ -455,7 +455,7 @@ public class TestMonths {
     @Test
     public void test_toPeriod() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Months.of(i).toPeriod(), Period.ofMonths(i));
+            assertEquals(Period.ofMonths(i), Months.of(i).toPeriod());
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestMonths.java
+++ b/src/test/java/org/threeten/extra/TestMonths.java
@@ -74,7 +74,7 @@ public class TestMonths {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 
@@ -82,14 +82,14 @@ public class TestMonths {
     @Test
     public void test_ZERO() {
         assertSame(Months.of(0), Months.ZERO);
-        assertSame(Months.of(0), Months.ZERO);
+        assertEquals(Months.of(0), Months.ZERO);
         assertEquals(0, Months.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Months.of(1), Months.ONE);
-        assertSame(Months.of(1), Months.ONE);
+        assertEquals(Months.of(1), Months.ONE);
         assertEquals(1, Months.ONE.getAmount());
     }
 

--- a/src/test/java/org/threeten/extra/TestMutableClock.java
+++ b/src/test/java/org/threeten/extra/TestMutableClock.java
@@ -70,23 +70,23 @@ public class TestMutableClock {
     @Test
     public void test_of() {
         assertEquals(
-                MutableClock.of(Instant.EPOCH, ZoneOffset.UTC).instant(),
-                Instant.EPOCH);
+                Instant.EPOCH,
+                MutableClock.of(Instant.EPOCH, ZoneOffset.UTC).instant());
         assertEquals(
-                MutableClock.of(Instant.MIN, ZoneOffset.UTC).instant(),
-                Instant.MIN);
+                Instant.MIN,
+                MutableClock.of(Instant.MIN, ZoneOffset.UTC).instant());
         assertEquals(
-                MutableClock.of(Instant.MAX, ZoneOffset.UTC).instant(),
-                Instant.MAX);
+                Instant.MAX,
+                MutableClock.of(Instant.MAX, ZoneOffset.UTC).instant());
         assertEquals(
-                MutableClock.of(Instant.EPOCH, ZoneOffset.UTC).getZone(),
-                ZoneOffset.UTC);
+                ZoneOffset.UTC,
+                MutableClock.of(Instant.EPOCH, ZoneOffset.UTC).getZone());
         assertEquals(
-                MutableClock.of(Instant.EPOCH, ZoneOffset.MIN).getZone(),
-                ZoneOffset.MIN);
+                ZoneOffset.MIN,
+                MutableClock.of(Instant.EPOCH, ZoneOffset.MIN).getZone());
         assertEquals(
-                MutableClock.of(Instant.EPOCH, ZoneOffset.MAX).getZone(),
-                ZoneOffset.MAX);
+                ZoneOffset.MAX,
+                MutableClock.of(Instant.EPOCH, ZoneOffset.MAX).getZone());
     }
 
     @Test(expected = NullPointerException.class)
@@ -101,20 +101,20 @@ public class TestMutableClock {
 
     @Test
     public void test_epochUTC() {
-        assertEquals(MutableClock.epochUTC().instant(), Instant.EPOCH);
-        assertEquals(MutableClock.epochUTC().getZone(), ZoneOffset.UTC);
+        assertEquals(Instant.EPOCH, MutableClock.epochUTC().instant());
+        assertEquals(ZoneOffset.UTC, MutableClock.epochUTC().getZone());
     }
 
     @Test
     public void test_setInstant() {
         MutableClock clock = MutableClock.epochUTC();
-        assertEquals(clock.instant(), Instant.EPOCH);
+        assertEquals(Instant.EPOCH, clock.instant());
         clock.setInstant(Instant.MIN);
-        assertEquals(clock.instant(), Instant.MIN);
+        assertEquals(Instant.MIN, clock.instant());
         clock.setInstant(Instant.MAX);
-        assertEquals(clock.instant(), Instant.MAX);
+        assertEquals(Instant.MAX, clock.instant());
         clock.setInstant(Instant.EPOCH.plusSeconds(10));
-        assertEquals(clock.instant(), Instant.EPOCH.plusSeconds(10));
+        assertEquals(Instant.EPOCH.plusSeconds(10), clock.instant());
     }
 
     @Test(expected = NullPointerException.class)
@@ -132,13 +132,13 @@ public class TestMutableClock {
         clock.add(Duration.ZERO);
         clock.add(Period.ZERO);
         assertEquals(
-                clock.instant(),
                 ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC)
                         .plusNanos(3)
                         .plusMonths(2)
                         .minusSeconds(5)
                         .minusWeeks(7)
-                        .toInstant());
+                        .toInstant(),
+                clock.instant());
     }
 
     @Test(expected = NullPointerException.class)
@@ -156,13 +156,13 @@ public class TestMutableClock {
         clock.add(0, ChronoUnit.MILLIS);
         clock.add(0, ChronoUnit.YEARS);
         assertEquals(
-                clock.instant(),
                 ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC)
                         .plusNanos(3)
                         .plusMonths(2)
                         .minusSeconds(5)
                         .minusWeeks(7)
-                        .toInstant());
+                        .toInstant(),
+                clock.instant());
     }
 
     @Test(expected = NullPointerException.class)
@@ -178,14 +178,14 @@ public class TestMutableClock {
         clock.set(TemporalAdjusters.firstDayOfNextMonth());
         clock.set(TemporalAdjusters.next(DayOfWeek.WEDNESDAY));
         assertEquals(
-                clock.instant(),
                 LocalDateTime.of(0, 1, 2, 3, 4, 5)
                         .with(TemporalAdjusters.firstDayOfNextMonth())
                         .with(TemporalAdjusters.next(DayOfWeek.WEDNESDAY))
                         .atZone(ZoneOffset.UTC)
-                        .toInstant());
+                        .toInstant(),
+                clock.instant());
         clock.set(Instant.EPOCH);
-        assertEquals(clock.instant(), Instant.EPOCH);
+        assertEquals(Instant.EPOCH, clock.instant());
     }
 
     @Test(expected = NullPointerException.class)
@@ -203,10 +203,10 @@ public class TestMutableClock {
         clock.set(ChronoField.MINUTE_OF_HOUR, 4);
         clock.set(ChronoField.SECOND_OF_MINUTE, 5);
         assertEquals(
-                clock.instant(),
                 LocalDateTime.of(0, 1, 2, 3, 4, 5)
                         .atZone(ZoneOffset.UTC)
-                        .toInstant());
+                        .toInstant(),
+                clock.instant());
     }
 
     @Test(expected = NullPointerException.class)
@@ -219,9 +219,9 @@ public class TestMutableClock {
         MutableClock clock = MutableClock.epochUTC();
         MutableClock withOtherZone = clock.withZone(ZoneOffset.MIN);
         MutableClock ofOtherZone = MutableClock.of(Instant.EPOCH, ZoneOffset.MAX);
-        assertEquals(clock.getZone(), ZoneOffset.UTC);
-        assertEquals(withOtherZone.getZone(), ZoneOffset.MIN);
-        assertEquals(ofOtherZone.getZone(), ZoneOffset.MAX);
+        assertEquals(ZoneOffset.UTC, clock.getZone());
+        assertEquals(ZoneOffset.MIN, withOtherZone.getZone());
+        assertEquals(ZoneOffset.MAX, ofOtherZone.getZone());
     }
 
     @Test
@@ -230,12 +230,12 @@ public class TestMutableClock {
         MutableClock withOtherZone = clock.withZone(ZoneOffset.MIN);
         MutableClock withSameZone = withOtherZone.withZone(ZoneOffset.UTC);
         clock.setInstant(Instant.MIN);
-        assertEquals(withOtherZone.instant(), Instant.MIN);
-        assertEquals(withSameZone.instant(), Instant.MIN);
-        assertEquals(withOtherZone.getZone(), ZoneOffset.MIN);
-        assertEquals(withSameZone.getZone(), ZoneOffset.UTC);
-        assertNotEquals(withOtherZone, clock);
-        assertEquals(withSameZone, clock);
+        assertEquals(Instant.MIN, withOtherZone.instant());
+        assertEquals(Instant.MIN, withSameZone.instant());
+        assertEquals(ZoneOffset.MIN, withOtherZone.getZone());
+        assertEquals(ZoneOffset.UTC, withSameZone.getZone());
+        assertNotEquals(clock, withOtherZone);
+        assertEquals(clock, withSameZone);
     }
 
     @Test(expected = NullPointerException.class)
@@ -247,12 +247,12 @@ public class TestMutableClock {
     public void test_instant() {
         MutableClock clock = MutableClock.epochUTC();
         MutableClock withOtherZone = clock.withZone(ZoneOffset.MIN);
-        assertEquals(clock.instant(), Instant.EPOCH);
+        assertEquals(Instant.EPOCH, clock.instant());
         clock.add(Duration.ofSeconds(5));
-        assertEquals(clock.instant(), Instant.EPOCH.plusSeconds(5));
+        assertEquals(Instant.EPOCH.plusSeconds(5), clock.instant());
         clock.setInstant(Instant.MIN);
-        assertEquals(clock.instant(), Instant.MIN);
-        assertEquals(withOtherZone.instant(), Instant.MIN);
+        assertEquals(Instant.MIN, clock.instant());
+        assertEquals(Instant.MIN, withOtherZone.instant());
     }
 
     @Test
@@ -265,8 +265,8 @@ public class TestMutableClock {
         assertNotEquals(null, clock);
         assertNotEquals("", clock);
         assertNotEquals(withOtherZone, clock);
-        assertEquals(withSameZone, clock);
-        assertNotEquals(independent, clock);
+        assertEquals(clock, withSameZone);
+        assertNotEquals(clock, independent);
     }
 
     @Test
@@ -274,13 +274,13 @@ public class TestMutableClock {
         MutableClock clock = MutableClock.epochUTC();
         int hash = clock.hashCode();
         clock.add(Period.ofMonths(1));
-        assertEquals(clock.hashCode(), hash);
+        assertEquals(hash, clock.hashCode());
         clock.add(1, ChronoUnit.DAYS);
-        assertEquals(clock.hashCode(), hash);
+        assertEquals(hash, clock.hashCode());
         clock.set(Year.of(2000));
-        assertEquals(clock.hashCode(), hash);
+        assertEquals(hash, clock.hashCode());
         clock.set(ChronoField.INSTANT_SECONDS, -1);
-        assertEquals(clock.hashCode(), hash);
+        assertEquals(hash, clock.hashCode());
     }
 
     @Test
@@ -295,16 +295,16 @@ public class TestMutableClock {
     public void test_toString() {
         MutableClock clock = MutableClock.epochUTC();
         assertEquals(
-                clock.toString(),
-                "MutableClock[1970-01-01T00:00:00Z,Z]");
+                "MutableClock[1970-01-01T00:00:00Z,Z]",
+                clock.toString());
         clock.add(Period.ofYears(30));
         assertEquals(
-                clock.toString(),
-                "MutableClock[2000-01-01T00:00:00Z,Z]");
+                "MutableClock[2000-01-01T00:00:00Z,Z]",
+                clock.toString());
         MutableClock withOtherZone = clock.withZone(ZoneOffset.MIN);
         assertEquals(
-                withOtherZone.toString(),
-                "MutableClock[2000-01-01T00:00:00Z,-18:00]");
+                "MutableClock[2000-01-01T00:00:00Z,-18:00]",
+                withOtherZone.toString());
     }
 
     @Test
@@ -321,8 +321,8 @@ public class TestMutableClock {
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
             MutableClock ser = (MutableClock) ois.readObject();
-            assertEquals(ser.instant(), test.instant());
-            assertEquals(ser.getZone(), test.getZone());
+            assertEquals(test.instant(), ser.instant());
+            assertEquals(test.getZone(), ser.getZone());
             // no shared updates
             assertNotEquals(ser, test);
             test.add(Duration.ofSeconds(1));
@@ -352,7 +352,7 @@ public class TestMutableClock {
             }
         }
         assertEquals(
-                clock.instant(),
-                Instant.EPOCH.plus(increment.multipliedBy(updateCount)));
+                Instant.EPOCH.plus(increment.multipliedBy(updateCount)),
+                clock.instant());
     }
 }

--- a/src/test/java/org/threeten/extra/TestPackedFields.java
+++ b/src/test/java/org/threeten/extra/TestPackedFields.java
@@ -57,15 +57,15 @@ public class TestPackedFields {
     //-----------------------------------------------------------------------
     @Test
     public void test_date_basics() {
-        assertEquals(PackedFields.PACKED_DATE.toString(), "PackedDate");
-        assertEquals(PackedFields.PACKED_DATE.getBaseUnit(), DAYS);
-        assertEquals(PackedFields.PACKED_DATE.getRangeUnit(), FOREVER);
-        assertEquals(PackedFields.PACKED_DATE.isDateBased(), true);
-        assertEquals(PackedFields.PACKED_DATE.isTimeBased(), false);
-        assertEquals(PackedFields.PACKED_DATE.isSupportedBy(LocalDate.of(2015, 3, 12)), true);
-        assertEquals(PackedFields.PACKED_DATE.isSupportedBy(LocalTime.of(11, 30)), false);
-        assertEquals(PackedFields.PACKED_DATE.range().getMinimum(), 10000101);
-        assertEquals(PackedFields.PACKED_DATE.range().getMaximum(), 99991231);
+        assertEquals("PackedDate", PackedFields.PACKED_DATE.toString());
+        assertEquals(DAYS, PackedFields.PACKED_DATE.getBaseUnit());
+        assertEquals(FOREVER, PackedFields.PACKED_DATE.getRangeUnit());
+        assertEquals(true, PackedFields.PACKED_DATE.isDateBased());
+        assertEquals(false, PackedFields.PACKED_DATE.isTimeBased());
+        assertEquals(true, PackedFields.PACKED_DATE.isSupportedBy(LocalDate.of(2015, 3, 12)));
+        assertEquals(false, PackedFields.PACKED_DATE.isSupportedBy(LocalTime.of(11, 30)));
+        assertEquals(10000101, PackedFields.PACKED_DATE.range().getMinimum());
+        assertEquals(99991231, PackedFields.PACKED_DATE.range().getMaximum());
     }
 
     @Test(expected = DateTimeException.class)
@@ -75,9 +75,9 @@ public class TestPackedFields {
 
     @Test
     public void test_date_getFrom() {
-        assertEquals(LocalDate.of(2015, 12, 3).get(PackedFields.PACKED_DATE), 20151203);
-        assertEquals(LocalDate.of(1000, 1, 1).get(PackedFields.PACKED_DATE), 10000101);
-        assertEquals(LocalDate.of(9999, 12, 31).get(PackedFields.PACKED_DATE), 99991231);
+        assertEquals(20151203, LocalDate.of(2015, 12, 3).get(PackedFields.PACKED_DATE));
+        assertEquals(10000101, LocalDate.of(1000, 1, 1).get(PackedFields.PACKED_DATE));
+        assertEquals(99991231, LocalDate.of(9999, 12, 31).get(PackedFields.PACKED_DATE));
     }
 
     @Test(expected = DateTimeException.class)
@@ -92,7 +92,7 @@ public class TestPackedFields {
 
     @Test
     public void test_date_adjustInto() {
-        assertEquals(LocalDate.MIN.with(PackedFields.PACKED_DATE, 20151203), LocalDate.of(2015, 12, 3));
+        assertEquals(LocalDate.of(2015, 12, 3), LocalDate.MIN.with(PackedFields.PACKED_DATE, 20151203));
     }
 
     @Test(expected = DateTimeException.class)
@@ -103,7 +103,7 @@ public class TestPackedFields {
     @Test
     public void test_date_resolve() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_DATE).toFormatter();
-        assertEquals(LocalDate.parse("20151203", f), LocalDate.of(2015, 12, 3));
+        assertEquals(LocalDate.of(2015, 12, 3), LocalDate.parse("20151203", f));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -115,7 +115,7 @@ public class TestPackedFields {
     @Test
     public void test_date_resolve_invalid_lenient() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_DATE).toFormatter();
-        assertEquals(LocalDate.parse("20151403", f.withResolverStyle(ResolverStyle.LENIENT)), LocalDate.of(2016, 2, 3));
+        assertEquals(LocalDate.of(2016, 2, 3), LocalDate.parse("20151403", f.withResolverStyle(ResolverStyle.LENIENT)));
     }
 
     //-----------------------------------------------------------------------
@@ -123,15 +123,15 @@ public class TestPackedFields {
     //-----------------------------------------------------------------------
     @Test
     public void test_hourMin_basics() {
-        assertEquals(PackedFields.PACKED_HOUR_MIN.toString(), "PackedHourMin");
-        assertEquals(PackedFields.PACKED_HOUR_MIN.getBaseUnit(), MINUTES);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.getRangeUnit(), DAYS);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.isDateBased(), false);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.isTimeBased(), true);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.isSupportedBy(LocalTime.of(11, 30)), true);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.isSupportedBy(LocalDate.of(2015, 3, 12)), false);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.range().getMinimum(), 0);
-        assertEquals(PackedFields.PACKED_HOUR_MIN.range().getMaximum(), 2359);
+        assertEquals("PackedHourMin", PackedFields.PACKED_HOUR_MIN.toString());
+        assertEquals(MINUTES, PackedFields.PACKED_HOUR_MIN.getBaseUnit());
+        assertEquals(DAYS, PackedFields.PACKED_HOUR_MIN.getRangeUnit());
+        assertEquals(false, PackedFields.PACKED_HOUR_MIN.isDateBased());
+        assertEquals(true, PackedFields.PACKED_HOUR_MIN.isTimeBased());
+        assertEquals(true, PackedFields.PACKED_HOUR_MIN.isSupportedBy(LocalTime.of(11, 30)));
+        assertEquals(false, PackedFields.PACKED_HOUR_MIN.isSupportedBy(LocalDate.of(2015, 3, 12)));
+        assertEquals(0, PackedFields.PACKED_HOUR_MIN.range().getMinimum());
+        assertEquals(2359, PackedFields.PACKED_HOUR_MIN.range().getMaximum());
     }
 
     @Test(expected = DateTimeException.class)
@@ -141,13 +141,13 @@ public class TestPackedFields {
 
     @Test
     public void test_hourMin_getFrom() {
-        assertEquals(LocalTime.of(11, 30).get(PackedFields.PACKED_HOUR_MIN), 1130);
-        assertEquals(LocalTime.of(1, 21).get(PackedFields.PACKED_HOUR_MIN), 121);
+        assertEquals(1130, LocalTime.of(11, 30).get(PackedFields.PACKED_HOUR_MIN));
+        assertEquals(121, LocalTime.of(1, 21).get(PackedFields.PACKED_HOUR_MIN));
     }
 
     @Test
     public void test_hourMin_adjustInto() {
-        assertEquals(LocalTime.MIDNIGHT.with(PackedFields.PACKED_HOUR_MIN, 1130), LocalTime.of(11, 30));
+        assertEquals(LocalTime.of(11, 30), LocalTime.MIDNIGHT.with(PackedFields.PACKED_HOUR_MIN, 1130));
     }
 
     @Test(expected = DateTimeException.class)
@@ -158,7 +158,7 @@ public class TestPackedFields {
     @Test
     public void test_hourMin_resolve() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_HOUR_MIN).toFormatter();
-        assertEquals(LocalTime.parse("1130", f), LocalTime.of(11, 30));
+        assertEquals(LocalTime.of(11, 30), LocalTime.parse("1130", f));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -170,7 +170,7 @@ public class TestPackedFields {
     @Test
     public void test_hourMin_resolve_invalid_lenient() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_HOUR_MIN).toFormatter();
-        assertEquals(LocalTime.parse("1173", f.withResolverStyle(ResolverStyle.LENIENT)), LocalTime.of(12, 13));
+        assertEquals(LocalTime.of(12, 13), LocalTime.parse("1173", f.withResolverStyle(ResolverStyle.LENIENT)));
     }
 
     //-----------------------------------------------------------------------
@@ -178,15 +178,15 @@ public class TestPackedFields {
     //-----------------------------------------------------------------------
     @Test
     public void test_time_basics() {
-        assertEquals(PackedFields.PACKED_TIME.toString(), "PackedTime");
-        assertEquals(PackedFields.PACKED_TIME.getBaseUnit(), SECONDS);
-        assertEquals(PackedFields.PACKED_TIME.getRangeUnit(), DAYS);
-        assertEquals(PackedFields.PACKED_TIME.isDateBased(), false);
-        assertEquals(PackedFields.PACKED_TIME.isTimeBased(), true);
-        assertEquals(PackedFields.PACKED_TIME.isSupportedBy(LocalTime.of(11, 30)), true);
-        assertEquals(PackedFields.PACKED_TIME.isSupportedBy(LocalDate.of(2015, 3, 12)), false);
-        assertEquals(PackedFields.PACKED_TIME.range().getMinimum(), 0);
-        assertEquals(PackedFields.PACKED_TIME.range().getMaximum(), 235959);
+        assertEquals("PackedTime", PackedFields.PACKED_TIME.toString());
+        assertEquals(SECONDS, PackedFields.PACKED_TIME.getBaseUnit());
+        assertEquals(DAYS, PackedFields.PACKED_TIME.getRangeUnit());
+        assertEquals(false, PackedFields.PACKED_TIME.isDateBased());
+        assertEquals(true, PackedFields.PACKED_TIME.isTimeBased());
+        assertEquals(true, PackedFields.PACKED_TIME.isSupportedBy(LocalTime.of(11, 30)));
+        assertEquals(false, PackedFields.PACKED_TIME.isSupportedBy(LocalDate.of(2015, 3, 12)));
+        assertEquals(0, PackedFields.PACKED_TIME.range().getMinimum());
+        assertEquals(235959, PackedFields.PACKED_TIME.range().getMaximum());
     }
 
     @Test(expected = DateTimeException.class)
@@ -196,14 +196,14 @@ public class TestPackedFields {
 
     @Test
     public void test_time_getFrom() {
-        assertEquals(LocalTime.of(11, 30, 52).get(PackedFields.PACKED_TIME), 113052);
-        assertEquals(LocalTime.of(11, 30).get(PackedFields.PACKED_TIME), 113000);
-        assertEquals(LocalTime.of(1, 21).get(PackedFields.PACKED_TIME), 12100);
+        assertEquals(113052, LocalTime.of(11, 30, 52).get(PackedFields.PACKED_TIME));
+        assertEquals(113000, LocalTime.of(11, 30).get(PackedFields.PACKED_TIME));
+        assertEquals(12100, LocalTime.of(1, 21).get(PackedFields.PACKED_TIME));
     }
 
     @Test
     public void test_time_adjustInto() {
-        assertEquals(LocalTime.MIDNIGHT.with(PackedFields.PACKED_TIME, 113052), LocalTime.of(11, 30, 52));
+        assertEquals(LocalTime.of(11, 30, 52), LocalTime.MIDNIGHT.with(PackedFields.PACKED_TIME, 113052));
     }
 
     @Test(expected = DateTimeException.class)
@@ -214,7 +214,7 @@ public class TestPackedFields {
     @Test
     public void test_time_resolve() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_TIME).toFormatter();
-        assertEquals(LocalTime.parse("113052", f), LocalTime.of(11, 30, 52));
+        assertEquals(LocalTime.of(11, 30, 52), LocalTime.parse("113052", f));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -226,7 +226,7 @@ public class TestPackedFields {
     @Test
     public void test_time_resolve_invalid_lenient() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_TIME).toFormatter();
-        assertEquals(LocalTime.parse("117361", f.withResolverStyle(ResolverStyle.LENIENT)), LocalTime.of(12, 14, 1));
+        assertEquals(LocalTime.of(12, 14, 1), LocalTime.parse("117361", f.withResolverStyle(ResolverStyle.LENIENT)));
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestPeriodDuration.java
+++ b/src/test/java/org/threeten/extra/TestPeriodDuration.java
@@ -86,25 +86,25 @@ public class TestPeriodDuration {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_ZERO() {
-        assertEquals(PeriodDuration.of(Period.ZERO, Duration.ZERO), PeriodDuration.ZERO);
-        assertEquals(PeriodDuration.of(Period.ZERO), PeriodDuration.ZERO);
-        assertEquals(PeriodDuration.of(Duration.ZERO), PeriodDuration.ZERO);
-        assertEquals(PeriodDuration.ZERO.getPeriod(), Period.ZERO);
-        assertEquals(PeriodDuration.ZERO.getDuration(), Duration.ZERO);
-        assertEquals(PeriodDuration.ZERO.isZero(), true);
-        assertEquals(PeriodDuration.ZERO.getUnits(), Arrays.asList(YEARS, MONTHS, DAYS, SECONDS, NANOS));
-        assertEquals(PeriodDuration.ZERO.get(YEARS), 0);
-        assertEquals(PeriodDuration.ZERO.get(MONTHS), 0);
-        assertEquals(PeriodDuration.ZERO.get(DAYS), 0);
-        assertEquals(PeriodDuration.ZERO.get(SECONDS), 0);
-        assertEquals(PeriodDuration.ZERO.get(NANOS), 0);
+        assertEquals(PeriodDuration.ZERO, PeriodDuration.of(Period.ZERO, Duration.ZERO));
+        assertEquals(PeriodDuration.ZERO, PeriodDuration.of(Period.ZERO));
+        assertEquals(PeriodDuration.ZERO, PeriodDuration.of(Duration.ZERO));
+        assertEquals(Period.ZERO, PeriodDuration.ZERO.getPeriod());
+        assertEquals(Duration.ZERO, PeriodDuration.ZERO.getDuration());
+        assertEquals(true, PeriodDuration.ZERO.isZero());
+        assertEquals(Arrays.asList(YEARS, MONTHS, DAYS, SECONDS, NANOS), PeriodDuration.ZERO.getUnits());
+        assertEquals(0, PeriodDuration.ZERO.get(YEARS));
+        assertEquals(0, PeriodDuration.ZERO.get(MONTHS));
+        assertEquals(0, PeriodDuration.ZERO.get(DAYS));
+        assertEquals(0, PeriodDuration.ZERO.get(SECONDS));
+        assertEquals(0, PeriodDuration.ZERO.get(NANOS));
     }
 
     @Test(expected = DateTimeException.class)
@@ -116,82 +116,82 @@ public class TestPeriodDuration {
     @Test
     public void test_of_both() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(4));
-        assertEquals(test.getPeriod(), P1Y2M3D);
-        assertEquals(test.getDuration(), Duration.ofSeconds(4));
-        assertEquals(test.isZero(), false);
-        assertEquals(test.get(YEARS), 1);
-        assertEquals(test.get(MONTHS), 2);
-        assertEquals(test.get(DAYS), 3);
-        assertEquals(test.get(SECONDS), 4);
-        assertEquals(test.get(NANOS), 0);
+        assertEquals(P1Y2M3D, test.getPeriod());
+        assertEquals(Duration.ofSeconds(4), test.getDuration());
+        assertEquals(false, test.isZero());
+        assertEquals(1, test.get(YEARS));
+        assertEquals(2, test.get(MONTHS));
+        assertEquals(3, test.get(DAYS));
+        assertEquals(4, test.get(SECONDS));
+        assertEquals(0, test.get(NANOS));
     }
 
     @Test
     public void test_of_period() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D);
-        assertEquals(test.getPeriod(), P1Y2M3D);
-        assertEquals(test.getDuration(), Duration.ZERO);
-        assertEquals(test.isZero(), false);
-        assertEquals(test.get(YEARS), 1);
-        assertEquals(test.get(MONTHS), 2);
-        assertEquals(test.get(DAYS), 3);
-        assertEquals(test.get(SECONDS), 0);
-        assertEquals(test.get(NANOS), 0);
+        assertEquals(P1Y2M3D, test.getPeriod());
+        assertEquals(Duration.ZERO, test.getDuration());
+        assertEquals(false, test.isZero());
+        assertEquals(1, test.get(YEARS));
+        assertEquals(2, test.get(MONTHS));
+        assertEquals(3, test.get(DAYS));
+        assertEquals(0, test.get(SECONDS));
+        assertEquals(0, test.get(NANOS));
     }
 
     @Test
     public void test_of_duration() {
         PeriodDuration test = PeriodDuration.of(Duration.ofSeconds(4));
-        assertEquals(test.getPeriod(), Period.ZERO);
-        assertEquals(test.getDuration(), Duration.ofSeconds(4));
-        assertEquals(test.isZero(), false);
-        assertEquals(test.get(YEARS), 0);
-        assertEquals(test.get(MONTHS), 0);
-        assertEquals(test.get(DAYS), 0);
-        assertEquals(test.get(SECONDS), 4);
-        assertEquals(test.get(NANOS), 0);
+        assertEquals(Period.ZERO, test.getPeriod());
+        assertEquals(Duration.ofSeconds(4), test.getDuration());
+        assertEquals(false, test.isZero());
+        assertEquals(0, test.get(YEARS));
+        assertEquals(0, test.get(MONTHS));
+        assertEquals(0, test.get(DAYS));
+        assertEquals(4, test.get(SECONDS));
+        assertEquals(0, test.get(NANOS));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_between_dates() {
         PeriodDuration test = PeriodDuration.between(LocalDate.of(2012, 6, 20), LocalDate.of(2012, 8, 25));
-        assertEquals(test.getPeriod(), Period.between(LocalDate.of(2012, 6, 20), LocalDate.of(2012, 8, 25)));
-        assertEquals(test.getDuration(), Duration.ZERO);
+        assertEquals(Period.between(LocalDate.of(2012, 6, 20), LocalDate.of(2012, 8, 25)), test.getPeriod());
+        assertEquals(Duration.ZERO, test.getDuration());
     }
 
     @Test
     public void test_between_times() {
         PeriodDuration test = PeriodDuration.between(LocalTime.of(11, 20), LocalTime.of(12, 25));
-        assertEquals(test.getPeriod(), Period.ZERO);
-        assertEquals(test.getDuration(), Duration.between(LocalTime.of(11, 20), LocalTime.of(12, 25)));
+        assertEquals(Period.ZERO, test.getPeriod());
+        assertEquals(Duration.between(LocalTime.of(11, 20), LocalTime.of(12, 25)), test.getDuration());
     }
 
     @Test
     public void test_between_mixed1() {
         PeriodDuration test = PeriodDuration.between(LocalDate.of(2012, 6, 20), LocalTime.of(11, 25));
-        assertEquals(test.getPeriod(), Period.ZERO);
-        assertEquals(test.getDuration(), Duration.ofHours(11).plusMinutes(25));
+        assertEquals(Period.ZERO, test.getPeriod());
+        assertEquals(Duration.ofHours(11).plusMinutes(25), test.getDuration());
     }
 
     @Test
     public void test_between_mixed2() {
         PeriodDuration test = PeriodDuration.between(LocalDate.of(2012, 6, 20), LocalDateTime.of(2012, 7, 22, 11, 25));
-        assertEquals(test.getPeriod(), Period.of(0, 1, 2));
-        assertEquals(test.getDuration(), Duration.ofHours(11).plusMinutes(25));
+        assertEquals(Period.of(0, 1, 2), test.getPeriod());
+        assertEquals(Duration.ofHours(11).plusMinutes(25), test.getDuration());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_from() {
         assertEquals(PeriodDuration.from(PeriodDuration.of(P1Y2M3D)), PeriodDuration.from(PeriodDuration.of(P1Y2M3D)));
-        assertEquals(PeriodDuration.from(Period.ofYears(2)), PeriodDuration.of(Period.ofYears(2)));
-        assertEquals(PeriodDuration.from(Duration.ofSeconds(2)), PeriodDuration.of(Duration.ofSeconds(2)));
-        assertEquals(PeriodDuration.from(Years.of(2)), PeriodDuration.of(Period.ofYears(2)));
-        assertEquals(PeriodDuration.from(Months.of(2)), PeriodDuration.of(Period.ofMonths(2)));
-        assertEquals(PeriodDuration.from(Weeks.of(2)), PeriodDuration.of(Period.ofWeeks(2)));
-        assertEquals(PeriodDuration.from(Days.of(2)), PeriodDuration.of(Period.ofDays(2)));
-        assertEquals(PeriodDuration.from(Hours.of(2)), PeriodDuration.of(Duration.ofHours(2)));
+        assertEquals(PeriodDuration.of(Period.ofYears(2)), PeriodDuration.from(Period.ofYears(2)));
+        assertEquals(PeriodDuration.of(Duration.ofSeconds(2)), PeriodDuration.from(Duration.ofSeconds(2)));
+        assertEquals(PeriodDuration.of(Period.ofYears(2)), PeriodDuration.from(Years.of(2)));
+        assertEquals(PeriodDuration.of(Period.ofMonths(2)), PeriodDuration.from(Months.of(2)));
+        assertEquals(PeriodDuration.of(Period.ofWeeks(2)), PeriodDuration.from(Weeks.of(2)));
+        assertEquals(PeriodDuration.of(Period.ofDays(2)), PeriodDuration.from(Days.of(2)));
+        assertEquals(PeriodDuration.of(Duration.ofHours(2)), PeriodDuration.from(Hours.of(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -223,19 +223,19 @@ public class TestPeriodDuration {
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, Period period, Duration duration) {
-        assertEquals(PeriodDuration.parse(str), PeriodDuration.of(period, duration));
+        assertEquals(PeriodDuration.of(period, duration), PeriodDuration.parse(str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, Period period, Duration duration) {
-        assertEquals(PeriodDuration.parse("+" + str), PeriodDuration.of(period, duration));
+        assertEquals(PeriodDuration.of(period, duration), PeriodDuration.parse("+" + str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, Period period, Duration duration) {
-        assertEquals(PeriodDuration.parse("-" + str), PeriodDuration.of(period, duration).negated());
+        assertEquals(PeriodDuration.of(period, duration).negated(), PeriodDuration.parse("-" + str));
     }
 
     @DataProvider
@@ -271,8 +271,8 @@ public class TestPeriodDuration {
     @Test
     public void test_plus_TemporalAmount_PeriodDuration() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D, DUR_5);
-        assertEquals(test.plus(Period.of(3, 2, 1)), PeriodDuration.of(Period.of(4, 4, 4), DUR_5));
-        assertEquals(test.plus(Duration.ofSeconds(4)), PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(9)));
+        assertEquals(PeriodDuration.of(Period.of(4, 4, 4), DUR_5), test.plus(Period.of(3, 2, 1)));
+        assertEquals(PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(9)), test.plus(Duration.ofSeconds(4)));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -294,8 +294,8 @@ public class TestPeriodDuration {
     @Test
     public void test_minus_TemporalAmount_PeriodDuration() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D, DUR_5);
-        assertEquals(test.minus(Period.of(1, 1, 1)), PeriodDuration.of(Period.of(0, 1, 2), DUR_5));
-        assertEquals(test.minus(Duration.ofSeconds(4)), PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(1)));
+        assertEquals(PeriodDuration.of(Period.of(0, 1, 2), DUR_5), test.minus(Period.of(1, 1, 1)));
+        assertEquals(PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(1)), test.minus(Duration.ofSeconds(4)));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -317,10 +317,10 @@ public class TestPeriodDuration {
     @Test
     public void test_multipliedBy() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D, DUR_5);
-        assertEquals(test.multipliedBy(0), PeriodDuration.ZERO);
-        assertEquals(test.multipliedBy(1), test);
-        assertEquals(test.multipliedBy(5), PeriodDuration.of(Period.of(5,  10, 15), Duration.ofSeconds(25)));
-        assertEquals(test.multipliedBy(-3), PeriodDuration.of(Period.of(-3,  -6, -9), Duration.ofSeconds(-15)));
+        assertEquals(PeriodDuration.ZERO, test.multipliedBy(0));
+        assertEquals(test, test.multipliedBy(1));
+        assertEquals(PeriodDuration.of(Period.of(5,  10, 15), Duration.ofSeconds(25)), test.multipliedBy(5));
+        assertEquals(PeriodDuration.of(Period.of(-3,  -6, -9), Duration.ofSeconds(-15)), test.multipliedBy(-3));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -336,7 +336,7 @@ public class TestPeriodDuration {
     //-----------------------------------------------------------------------
     @Test
     public void test_negated() {
-        assertEquals(PeriodDuration.of(P1Y2M3D, DUR_5).negated(), PeriodDuration.of(P1Y2M3D.negated(), DUR_5.negated()));
+        assertEquals(PeriodDuration.of(P1Y2M3D.negated(), DUR_5.negated()), PeriodDuration.of(P1Y2M3D, DUR_5).negated());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -347,21 +347,21 @@ public class TestPeriodDuration {
     //-----------------------------------------------------------------------
     @Test
     public void test_normalizedYears() {
-        assertEquals(PeriodDuration.of(P1Y2M3D, DUR_5).normalizedYears(), PeriodDuration.of(P1Y2M3D.normalized(), DUR_5));
+        assertEquals(PeriodDuration.of(P1Y2M3D.normalized(), DUR_5), PeriodDuration.of(P1Y2M3D, DUR_5).normalizedYears());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_normalizedStandardDays() {
         assertEquals(
-                PeriodDuration.of(P1Y2M3D, Duration.ofHours(5)).normalizedStandardDays(),
-                PeriodDuration.of(P1Y2M3D, Duration.ofHours(5)));
+                PeriodDuration.of(P1Y2M3D, Duration.ofHours(5)),
+                PeriodDuration.of(P1Y2M3D, Duration.ofHours(5)).normalizedStandardDays());
         assertEquals(
-                PeriodDuration.of(P1Y2M3D, Duration.ofHours(25)).normalizedStandardDays(),
-                PeriodDuration.of(P1Y2M3D.plusDays(1), Duration.ofHours(1)));
+                PeriodDuration.of(P1Y2M3D.plusDays(1), Duration.ofHours(1)),
+                PeriodDuration.of(P1Y2M3D, Duration.ofHours(25)).normalizedStandardDays());
         assertEquals(
-                PeriodDuration.of(P1Y2M3D, Duration.ofHours(-73)).normalizedStandardDays(),
-                PeriodDuration.of(P1Y2M3D.plusDays(-3), Duration.ofHours(-1)));
+                PeriodDuration.of(P1Y2M3D.plusDays(-3), Duration.ofHours(-1)),
+                PeriodDuration.of(P1Y2M3D, Duration.ofHours(-73)).normalizedStandardDays());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -373,14 +373,14 @@ public class TestPeriodDuration {
     @Test
     public void test_addTo() {
         LocalDateTime base = LocalDateTime.of(2012, 6, 20, 11, 30, 0);
-        assertEquals(PeriodDuration.of(P1Y2M3D, DUR_5).addTo(base), LocalDateTime.of(2013, 8, 23, 11, 30, 5));
+        assertEquals(LocalDateTime.of(2013, 8, 23, 11, 30, 5), PeriodDuration.of(P1Y2M3D, DUR_5).addTo(base));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_subtractFrom() {
         LocalDateTime base = LocalDateTime.of(2012, 6, 20, 11, 30, 0);
-        assertEquals(PeriodDuration.of(P1Y2M3D, DUR_5).subtractFrom(base), LocalDateTime.of(2011, 4, 17, 11, 29, 55));
+        assertEquals(LocalDateTime.of(2011, 4, 17, 11, 29, 55), PeriodDuration.of(P1Y2M3D, DUR_5).subtractFrom(base));
     }
 
     //-----------------------------------------------------------------------
@@ -388,21 +388,21 @@ public class TestPeriodDuration {
     public void test_equals() {
         PeriodDuration test5 = PeriodDuration.of(P1Y2M3D, DUR_5);
         PeriodDuration test6 = PeriodDuration.of(P1Y2M3D, DUR_6);
-        assertEquals(test5.equals(test5), true);
-        assertEquals(test5.equals(test6), false);
-        assertEquals(test6.equals(test5), false);
+        assertEquals(true, test5.equals(test5));
+        assertEquals(false, test5.equals(test6));
+        assertEquals(false, test6.equals(test5));
     }
 
     @Test
     public void test_equals_null() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D, DUR_5);
-        assertEquals(test.equals(null), false);
+        assertEquals(false, test.equals(null));
     }
 
     @Test
     public void test_equals_otherClass() {
         PeriodDuration test = PeriodDuration.of(P1Y2M3D, DUR_5);
-        assertEquals(test.equals(""), false);
+        assertEquals(false, test.equals(""));
     }
 
     //-----------------------------------------------------------------------
@@ -410,8 +410,8 @@ public class TestPeriodDuration {
     public void test_hashCode() {
         PeriodDuration test5 = PeriodDuration.of(P1Y2M3D, DUR_5);
         PeriodDuration test6 = PeriodDuration.of(P1Y2M3D, DUR_6);
-        assertEquals(test5.hashCode() == test5.hashCode(), true);
-        assertEquals(test5.hashCode() == test6.hashCode(), false);
+        assertEquals(true, test5.hashCode() == test5.hashCode());
+        assertEquals(false, test5.hashCode() == test6.hashCode());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestQuarter.java
+++ b/src/test/java/org/threeten/extra/TestQuarter.java
@@ -110,7 +110,7 @@ public class TestQuarter {
     public void test_of_int_singleton() {
         for (int i = 1; i <= 4; i++) {
             Quarter test = Quarter.of(i);
-            assertEquals(test.getValue(), i);
+            assertEquals(i, test.getValue());
         }
     }
 
@@ -129,18 +129,18 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_ofMonth_int_singleton() {
-        assertEquals(Quarter.ofMonth(1), Quarter.Q1);
-        assertEquals(Quarter.ofMonth(2), Quarter.Q1);
-        assertEquals(Quarter.ofMonth(3), Quarter.Q1);
-        assertEquals(Quarter.ofMonth(4), Quarter.Q2);
-        assertEquals(Quarter.ofMonth(5), Quarter.Q2);
-        assertEquals(Quarter.ofMonth(6), Quarter.Q2);
-        assertEquals(Quarter.ofMonth(7), Quarter.Q3);
-        assertEquals(Quarter.ofMonth(8), Quarter.Q3);
-        assertEquals(Quarter.ofMonth(9), Quarter.Q3);
-        assertEquals(Quarter.ofMonth(10), Quarter.Q4);
-        assertEquals(Quarter.ofMonth(11), Quarter.Q4);
-        assertEquals(Quarter.ofMonth(12), Quarter.Q4);
+        assertEquals(Quarter.Q1, Quarter.ofMonth(1));
+        assertEquals(Quarter.Q1, Quarter.ofMonth(2));
+        assertEquals(Quarter.Q1, Quarter.ofMonth(3));
+        assertEquals(Quarter.Q2, Quarter.ofMonth(4));
+        assertEquals(Quarter.Q2, Quarter.ofMonth(5));
+        assertEquals(Quarter.Q2, Quarter.ofMonth(6));
+        assertEquals(Quarter.Q3, Quarter.ofMonth(7));
+        assertEquals(Quarter.Q3, Quarter.ofMonth(8));
+        assertEquals(Quarter.Q3, Quarter.ofMonth(9));
+        assertEquals(Quarter.Q4, Quarter.ofMonth(10));
+        assertEquals(Quarter.Q4, Quarter.ofMonth(11));
+        assertEquals(Quarter.Q4, Quarter.ofMonth(12));
     }
 
     @Test(expected = DateTimeException.class)
@@ -158,24 +158,24 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_from_TemporalAccessor() {
-        assertEquals(Quarter.from(LocalDate.of(2011, 6, 6)), Quarter.Q2);
-        assertEquals(Quarter.from(LocalDateTime.of(2012, 2, 3, 12, 30)), Quarter.Q1);
+        assertEquals(Quarter.Q2, Quarter.from(LocalDate.of(2011, 6, 6)));
+        assertEquals(Quarter.Q1, Quarter.from(LocalDateTime.of(2012, 2, 3, 12, 30)));
     }
 
     @Test
     public void test_from_TemporalAccessor_Month() {
-        assertEquals(Quarter.from(Month.JANUARY), Quarter.Q1);
-        assertEquals(Quarter.from(Month.FEBRUARY), Quarter.Q1);
-        assertEquals(Quarter.from(Month.MARCH), Quarter.Q1);
-        assertEquals(Quarter.from(Month.APRIL), Quarter.Q2);
-        assertEquals(Quarter.from(Month.MAY), Quarter.Q2);
-        assertEquals(Quarter.from(Month.JUNE), Quarter.Q2);
-        assertEquals(Quarter.from(Month.JULY), Quarter.Q3);
-        assertEquals(Quarter.from(Month.AUGUST), Quarter.Q3);
-        assertEquals(Quarter.from(Month.SEPTEMBER), Quarter.Q3);
-        assertEquals(Quarter.from(Month.OCTOBER), Quarter.Q4);
-        assertEquals(Quarter.from(Month.NOVEMBER), Quarter.Q4);
-        assertEquals(Quarter.from(Month.DECEMBER), Quarter.Q4);
+        assertEquals(Quarter.Q1, Quarter.from(Month.JANUARY));
+        assertEquals(Quarter.Q1, Quarter.from(Month.FEBRUARY));
+        assertEquals(Quarter.Q1, Quarter.from(Month.MARCH));
+        assertEquals(Quarter.Q2, Quarter.from(Month.APRIL));
+        assertEquals(Quarter.Q2, Quarter.from(Month.MAY));
+        assertEquals(Quarter.Q2, Quarter.from(Month.JUNE));
+        assertEquals(Quarter.Q3, Quarter.from(Month.JULY));
+        assertEquals(Quarter.Q3, Quarter.from(Month.AUGUST));
+        assertEquals(Quarter.Q3, Quarter.from(Month.SEPTEMBER));
+        assertEquals(Quarter.Q4, Quarter.from(Month.OCTOBER));
+        assertEquals(Quarter.Q4, Quarter.from(Month.NOVEMBER));
+        assertEquals(Quarter.Q4, Quarter.from(Month.DECEMBER));
     }
 
     @Test(expected = DateTimeException.class)
@@ -191,7 +191,7 @@ public class TestQuarter {
     @Test
     public void test_from_parse_CharSequence() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("'Q'Q");
-        assertEquals(formatter.parse("Q3", Quarter::from), Q3);
+        assertEquals(Q3, formatter.parse("Q3", Quarter::from));
     }
 
     //-----------------------------------------------------------------------
@@ -199,7 +199,7 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_getDisplayName() {
-        assertEquals(Quarter.Q1.getDisplayName(TextStyle.SHORT, Locale.US), "Q1");
+        assertEquals("Q1", Quarter.Q1.getDisplayName(TextStyle.SHORT, Locale.US));
     }
 
     @Test(expected = NullPointerException.class)
@@ -218,38 +218,38 @@ public class TestQuarter {
     @Test
     public void test_isSupported() {
         Quarter test = Quarter.Q1;
-        assertEquals(test.isSupported(null), false);
-        assertEquals(test.isSupported(NANO_OF_SECOND), false);
-        assertEquals(test.isSupported(NANO_OF_DAY), false);
-        assertEquals(test.isSupported(MICRO_OF_SECOND), false);
-        assertEquals(test.isSupported(MICRO_OF_DAY), false);
-        assertEquals(test.isSupported(MILLI_OF_SECOND), false);
-        assertEquals(test.isSupported(MILLI_OF_DAY), false);
-        assertEquals(test.isSupported(SECOND_OF_MINUTE), false);
-        assertEquals(test.isSupported(SECOND_OF_DAY), false);
-        assertEquals(test.isSupported(MINUTE_OF_HOUR), false);
-        assertEquals(test.isSupported(MINUTE_OF_DAY), false);
-        assertEquals(test.isSupported(HOUR_OF_AMPM), false);
-        assertEquals(test.isSupported(CLOCK_HOUR_OF_AMPM), false);
-        assertEquals(test.isSupported(HOUR_OF_DAY), false);
-        assertEquals(test.isSupported(CLOCK_HOUR_OF_DAY), false);
-        assertEquals(test.isSupported(AMPM_OF_DAY), false);
-        assertEquals(test.isSupported(DAY_OF_WEEK), false);
-        assertEquals(test.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH), false);
-        assertEquals(test.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR), false);
-        assertEquals(test.isSupported(DAY_OF_MONTH), false);
-        assertEquals(test.isSupported(DAY_OF_YEAR), false);
-        assertEquals(test.isSupported(EPOCH_DAY), false);
-        assertEquals(test.isSupported(ALIGNED_WEEK_OF_MONTH), false);
-        assertEquals(test.isSupported(ALIGNED_WEEK_OF_YEAR), false);
-        assertEquals(test.isSupported(MONTH_OF_YEAR), false);
-        assertEquals(test.isSupported(PROLEPTIC_MONTH), false);
-        assertEquals(test.isSupported(YEAR_OF_ERA), false);
-        assertEquals(test.isSupported(YEAR), false);
-        assertEquals(test.isSupported(ERA), false);
-        assertEquals(test.isSupported(INSTANT_SECONDS), false);
-        assertEquals(test.isSupported(OFFSET_SECONDS), false);
-        assertEquals(test.isSupported(QUARTER_OF_YEAR), true);
+        assertEquals(false, test.isSupported(null));
+        assertEquals(false, test.isSupported(NANO_OF_SECOND));
+        assertEquals(false, test.isSupported(NANO_OF_DAY));
+        assertEquals(false, test.isSupported(MICRO_OF_SECOND));
+        assertEquals(false, test.isSupported(MICRO_OF_DAY));
+        assertEquals(false, test.isSupported(MILLI_OF_SECOND));
+        assertEquals(false, test.isSupported(MILLI_OF_DAY));
+        assertEquals(false, test.isSupported(SECOND_OF_MINUTE));
+        assertEquals(false, test.isSupported(SECOND_OF_DAY));
+        assertEquals(false, test.isSupported(MINUTE_OF_HOUR));
+        assertEquals(false, test.isSupported(MINUTE_OF_DAY));
+        assertEquals(false, test.isSupported(HOUR_OF_AMPM));
+        assertEquals(false, test.isSupported(CLOCK_HOUR_OF_AMPM));
+        assertEquals(false, test.isSupported(HOUR_OF_DAY));
+        assertEquals(false, test.isSupported(CLOCK_HOUR_OF_DAY));
+        assertEquals(false, test.isSupported(AMPM_OF_DAY));
+        assertEquals(false, test.isSupported(DAY_OF_WEEK));
+        assertEquals(false, test.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(false, test.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(false, test.isSupported(DAY_OF_MONTH));
+        assertEquals(false, test.isSupported(DAY_OF_YEAR));
+        assertEquals(false, test.isSupported(EPOCH_DAY));
+        assertEquals(false, test.isSupported(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(false, test.isSupported(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(false, test.isSupported(MONTH_OF_YEAR));
+        assertEquals(false, test.isSupported(PROLEPTIC_MONTH));
+        assertEquals(false, test.isSupported(YEAR_OF_ERA));
+        assertEquals(false, test.isSupported(YEAR));
+        assertEquals(false, test.isSupported(ERA));
+        assertEquals(false, test.isSupported(INSTANT_SECONDS));
+        assertEquals(false, test.isSupported(OFFSET_SECONDS));
+        assertEquals(true, test.isSupported(QUARTER_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -257,7 +257,7 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_range() {
-        assertEquals(Quarter.Q1.range(QUARTER_OF_YEAR), QUARTER_OF_YEAR.range());
+        assertEquals(QUARTER_OF_YEAR.range(), Quarter.Q1.range(QUARTER_OF_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -275,10 +275,10 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_get() {
-        assertEquals(Quarter.Q1.get(QUARTER_OF_YEAR), 1);
-        assertEquals(Quarter.Q2.get(QUARTER_OF_YEAR), 2);
-        assertEquals(Quarter.Q3.get(QUARTER_OF_YEAR), 3);
-        assertEquals(Quarter.Q4.get(QUARTER_OF_YEAR), 4);
+        assertEquals(1, Quarter.Q1.get(QUARTER_OF_YEAR));
+        assertEquals(2, Quarter.Q2.get(QUARTER_OF_YEAR));
+        assertEquals(3, Quarter.Q3.get(QUARTER_OF_YEAR));
+        assertEquals(4, Quarter.Q4.get(QUARTER_OF_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -296,10 +296,10 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_getLong() {
-        assertEquals(Quarter.Q1.getLong(QUARTER_OF_YEAR), 1);
-        assertEquals(Quarter.Q2.getLong(QUARTER_OF_YEAR), 2);
-        assertEquals(Quarter.Q3.getLong(QUARTER_OF_YEAR), 3);
-        assertEquals(Quarter.Q4.getLong(QUARTER_OF_YEAR), 4);
+        assertEquals(1, Quarter.Q1.getLong(QUARTER_OF_YEAR));
+        assertEquals(2, Quarter.Q2.getLong(QUARTER_OF_YEAR));
+        assertEquals(3, Quarter.Q3.getLong(QUARTER_OF_YEAR));
+        assertEquals(4, Quarter.Q4.getLong(QUARTER_OF_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -335,7 +335,7 @@ public class TestQuarter {
     @Test
     @UseDataProvider("data_plus")
     public void test_plus_long(int base, long amount, int expected) {
-        assertEquals(Quarter.of(base).plus(amount), Quarter.of(expected));
+        assertEquals(Quarter.of(expected), Quarter.of(base).plus(amount));
     }
 
     //-----------------------------------------------------------------------
@@ -361,7 +361,7 @@ public class TestQuarter {
     @Test
     @UseDataProvider("data_minus")
     public void test_minus_long(int base, long amount, int expected) {
-        assertEquals(Quarter.of(base).minus(amount), Quarter.of(expected));
+        assertEquals(Quarter.of(expected), Quarter.of(base).minus(amount));
     }
 
     //-----------------------------------------------------------------------
@@ -369,14 +369,14 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_length_boolean() {
-        assertEquals(Quarter.Q1.length(true), 91);
-        assertEquals(Quarter.Q1.length(false), 90);
-        assertEquals(Quarter.Q2.length(true), 91);
-        assertEquals(Quarter.Q2.length(false), 91);
-        assertEquals(Quarter.Q3.length(true), 92);
-        assertEquals(Quarter.Q3.length(false), 92);
-        assertEquals(Quarter.Q4.length(true), 92);
-        assertEquals(Quarter.Q4.length(false), 92);
+        assertEquals(91, Quarter.Q1.length(true));
+        assertEquals(90, Quarter.Q1.length(false));
+        assertEquals(91, Quarter.Q2.length(true));
+        assertEquals(91, Quarter.Q2.length(false));
+        assertEquals(92, Quarter.Q3.length(true));
+        assertEquals(92, Quarter.Q3.length(false));
+        assertEquals(92, Quarter.Q4.length(true));
+        assertEquals(92, Quarter.Q4.length(false));
     }
 
     //-----------------------------------------------------------------------
@@ -384,10 +384,10 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_firstMonth() {
-        assertEquals(Quarter.Q1.firstMonth(), Month.JANUARY);
-        assertEquals(Quarter.Q2.firstMonth(), Month.APRIL);
-        assertEquals(Quarter.Q3.firstMonth(), Month.JULY);
-        assertEquals(Quarter.Q4.firstMonth(), Month.OCTOBER);
+        assertEquals(Month.JANUARY, Quarter.Q1.firstMonth());
+        assertEquals(Month.APRIL, Quarter.Q2.firstMonth());
+        assertEquals(Month.JULY, Quarter.Q3.firstMonth());
+        assertEquals(Month.OCTOBER, Quarter.Q4.firstMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -395,13 +395,13 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_query() {
-        assertEquals(Quarter.Q1.query(TemporalQueries.chronology()), IsoChronology.INSTANCE);
-        assertEquals(Quarter.Q1.query(TemporalQueries.localDate()), null);
-        assertEquals(Quarter.Q1.query(TemporalQueries.localTime()), null);
-        assertEquals(Quarter.Q1.query(TemporalQueries.offset()), null);
-        assertEquals(Quarter.Q1.query(TemporalQueries.precision()), QUARTER_YEARS);
-        assertEquals(Quarter.Q1.query(TemporalQueries.zone()), null);
-        assertEquals(Quarter.Q1.query(TemporalQueries.zoneId()), null);
+        assertEquals(IsoChronology.INSTANCE, Quarter.Q1.query(TemporalQueries.chronology()));
+        assertEquals(null, Quarter.Q1.query(TemporalQueries.localDate()));
+        assertEquals(null, Quarter.Q1.query(TemporalQueries.localTime()));
+        assertEquals(null, Quarter.Q1.query(TemporalQueries.offset()));
+        assertEquals(QUARTER_YEARS, Quarter.Q1.query(TemporalQueries.precision()));
+        assertEquals(null, Quarter.Q1.query(TemporalQueries.zone()));
+        assertEquals(null, Quarter.Q1.query(TemporalQueries.zoneId()));
     }
 
     //-----------------------------------------------------------------------
@@ -409,10 +409,10 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_toString() {
-        assertEquals(Quarter.Q1.toString(), "Q1");
-        assertEquals(Quarter.Q2.toString(), "Q2");
-        assertEquals(Quarter.Q3.toString(), "Q3");
-        assertEquals(Quarter.Q4.toString(), "Q4");
+        assertEquals("Q1", Quarter.Q1.toString());
+        assertEquals("Q2", Quarter.Q2.toString());
+        assertEquals("Q3", Quarter.Q3.toString());
+        assertEquals("Q4", Quarter.Q4.toString());
     }
 
     //-----------------------------------------------------------------------
@@ -420,8 +420,8 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_enum() {
-        assertEquals(Quarter.valueOf("Q4"), Quarter.Q4);
-        assertEquals(Quarter.values()[0], Quarter.Q1);
+        assertEquals(Quarter.Q4, Quarter.valueOf("Q4"));
+        assertEquals(Quarter.Q1, Quarter.values()[0]);
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestQuarter.java
+++ b/src/test/java/org/threeten/extra/TestQuarter.java
@@ -64,6 +64,7 @@ import static java.time.temporal.ChronoField.YEAR_OF_ERA;
 import static java.time.temporal.IsoFields.QUARTER_OF_YEAR;
 import static java.time.temporal.IsoFields.QUARTER_YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.threeten.extra.Quarter.Q3;
 
@@ -129,18 +130,18 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_ofMonth_int_singleton() {
-        assertEquals(Quarter.Q1, Quarter.ofMonth(1));
-        assertEquals(Quarter.Q1, Quarter.ofMonth(2));
-        assertEquals(Quarter.Q1, Quarter.ofMonth(3));
-        assertEquals(Quarter.Q2, Quarter.ofMonth(4));
-        assertEquals(Quarter.Q2, Quarter.ofMonth(5));
-        assertEquals(Quarter.Q2, Quarter.ofMonth(6));
-        assertEquals(Quarter.Q3, Quarter.ofMonth(7));
-        assertEquals(Quarter.Q3, Quarter.ofMonth(8));
-        assertEquals(Quarter.Q3, Quarter.ofMonth(9));
-        assertEquals(Quarter.Q4, Quarter.ofMonth(10));
-        assertEquals(Quarter.Q4, Quarter.ofMonth(11));
-        assertEquals(Quarter.Q4, Quarter.ofMonth(12));
+        assertSame(Quarter.Q1, Quarter.ofMonth(1));
+        assertSame(Quarter.Q1, Quarter.ofMonth(2));
+        assertSame(Quarter.Q1, Quarter.ofMonth(3));
+        assertSame(Quarter.Q2, Quarter.ofMonth(4));
+        assertSame(Quarter.Q2, Quarter.ofMonth(5));
+        assertSame(Quarter.Q2, Quarter.ofMonth(6));
+        assertSame(Quarter.Q3, Quarter.ofMonth(7));
+        assertSame(Quarter.Q3, Quarter.ofMonth(8));
+        assertSame(Quarter.Q3, Quarter.ofMonth(9));
+        assertSame(Quarter.Q4, Quarter.ofMonth(10));
+        assertSame(Quarter.Q4, Quarter.ofMonth(11));
+        assertSame(Quarter.Q4, Quarter.ofMonth(12));
     }
 
     @Test(expected = DateTimeException.class)

--- a/src/test/java/org/threeten/extra/TestSeconds.java
+++ b/src/test/java/org/threeten/extra/TestSeconds.java
@@ -72,7 +72,7 @@ public class TestSeconds {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
     
@@ -80,7 +80,7 @@ public class TestSeconds {
     @Test
     public void test_ZERO() {
         assertSame(Seconds.of(0), Seconds.ZERO);
-        assertSame(Seconds.of(0), Seconds.ZERO);
+        assertEquals(Seconds.of(0), Seconds.ZERO);
         assertEquals(0, Seconds.ZERO.getAmount());
     }
     

--- a/src/test/java/org/threeten/extra/TestSeconds.java
+++ b/src/test/java/org/threeten/extra/TestSeconds.java
@@ -81,31 +81,31 @@ public class TestSeconds {
     public void test_ZERO() {
         assertSame(Seconds.of(0), Seconds.ZERO);
         assertSame(Seconds.of(0), Seconds.ZERO);
-        assertEquals(Seconds.ZERO.getAmount(), 0);
+        assertEquals(0, Seconds.ZERO.getAmount());
     }
     
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Seconds.of(0).getAmount(), 0);
-        assertEquals(Seconds.of(1).getAmount(), 1);
-        assertEquals(Seconds.of(2).getAmount(), 2);
-        assertEquals(Seconds.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Seconds.of(-1).getAmount(), -1);
-        assertEquals(Seconds.of(-2).getAmount(), -2);
-        assertEquals(Seconds.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(0, Seconds.of(0).getAmount());
+        assertEquals(1, Seconds.of(1).getAmount());
+        assertEquals(2, Seconds.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Seconds.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Seconds.of(-1).getAmount());
+        assertEquals(-2, Seconds.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Seconds.of(Integer.MIN_VALUE).getAmount());
     }
     
     //-----------------------------------------------------------------------
     @Test
     public void test_ofHours() {
-        assertEquals(Seconds.ofHours(0).getAmount(), 0);
-        assertEquals(Seconds.ofHours(1).getAmount(), 3600);
-        assertEquals(Seconds.ofHours(2).getAmount(), 7200);
-        assertEquals(Seconds.ofHours(Integer.MAX_VALUE / 3600).getAmount(), (Integer.MAX_VALUE / 3600) * 3600);
-        assertEquals(Seconds.ofHours(-1).getAmount(), -3600);
-        assertEquals(Seconds.ofHours(-2).getAmount(), -7200);
-        assertEquals(Seconds.ofHours(Integer.MIN_VALUE / 3600).getAmount(), (Integer.MIN_VALUE / 3600) * 3600);
+        assertEquals(0, Seconds.ofHours(0).getAmount());
+        assertEquals(3600, Seconds.ofHours(1).getAmount());
+        assertEquals(7200, Seconds.ofHours(2).getAmount());
+        assertEquals((Integer.MAX_VALUE / 3600) * 3600, Seconds.ofHours(Integer.MAX_VALUE / 3600).getAmount());
+        assertEquals(-3600, Seconds.ofHours(-1).getAmount());
+        assertEquals(-7200, Seconds.ofHours(-2).getAmount());
+        assertEquals((Integer.MIN_VALUE / 3600) * 3600, Seconds.ofHours(Integer.MIN_VALUE / 3600).getAmount());
     }
     
     @Test(expected = ArithmeticException.class)
@@ -116,13 +116,13 @@ public class TestSeconds {
     //-----------------------------------------------------------------------
     @Test
     public void test_ofMinutes() {
-        assertEquals(Seconds.ofMinutes(0).getAmount(), 0);
-        assertEquals(Seconds.ofMinutes(1).getAmount(), 60);
-        assertEquals(Seconds.ofMinutes(2).getAmount(), 120);
-        assertEquals(Seconds.ofMinutes(Integer.MAX_VALUE / 60).getAmount(), (Integer.MAX_VALUE / 60) * 60);
-        assertEquals(Seconds.ofMinutes(-1).getAmount(), -60);
-        assertEquals(Seconds.ofMinutes(-2).getAmount(), -120);
-        assertEquals(Seconds.ofMinutes(Integer.MIN_VALUE / 60).getAmount(), (Integer.MIN_VALUE / 60) * 60);
+        assertEquals(0, Seconds.ofMinutes(0).getAmount());
+        assertEquals(60, Seconds.ofMinutes(1).getAmount());
+        assertEquals(120, Seconds.ofMinutes(2).getAmount());
+        assertEquals((Integer.MAX_VALUE / 60) * 60, Seconds.ofMinutes(Integer.MAX_VALUE / 60).getAmount());
+        assertEquals(-60, Seconds.ofMinutes(-1).getAmount());
+        assertEquals(-120, Seconds.ofMinutes(-2).getAmount());
+        assertEquals((Integer.MIN_VALUE / 60) * 60, Seconds.ofMinutes(Integer.MIN_VALUE / 60).getAmount());
     }
     
     @Test(expected = ArithmeticException.class)
@@ -194,19 +194,19 @@ public class TestSeconds {
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedSeconds) {
-        assertEquals(Seconds.parse(str), Seconds.of(expectedSeconds));
+        assertEquals(Seconds.of(expectedSeconds), Seconds.parse(str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedSeconds) {
-        assertEquals(Seconds.parse("+" + str), Seconds.of(expectedSeconds));
+        assertEquals(Seconds.of(expectedSeconds), Seconds.parse("+" + str));
     }
 
     @Test
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedSeconds) {
-        assertEquals(Seconds.parse("-" + str), Seconds.of(-expectedSeconds));
+        assertEquals(Seconds.of(-expectedSeconds), Seconds.parse("-" + str));
     }
 
     @DataProvider
@@ -418,23 +418,23 @@ public class TestSeconds {
     @Test
     public void test_addTo() {
         LocalTime base = LocalTime.of(11, 30);
-        assertEquals(Seconds.of(0).addTo(base), LocalTime.of(11, 30));
-        assertEquals(Seconds.of(6).addTo(base), LocalTime.of(11, 30, 6));
+        assertEquals(LocalTime.of(11, 30), Seconds.of(0).addTo(base));
+        assertEquals(LocalTime.of(11, 30, 6), Seconds.of(6).addTo(base));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_subtractFrom() {
         LocalTime base = LocalTime.of(11, 30);
-        assertEquals(Seconds.of(0).subtractFrom(base), LocalTime.of(11, 30));
-        assertEquals(Seconds.of(6).subtractFrom(base), LocalTime.of(11, 29, 54));
+        assertEquals(LocalTime.of(11, 30), Seconds.of(0).subtractFrom(base));
+        assertEquals(LocalTime.of(11, 29, 54), Seconds.of(6).subtractFrom(base));
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_toDuration() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Seconds.of(i).toDuration(), Duration.ofSeconds(i));
+            assertEquals(Duration.ofSeconds(i), Seconds.of(i).toDuration());
         }
     }
     

--- a/src/test/java/org/threeten/extra/TestTemporals.java
+++ b/src/test/java/org/threeten/extra/TestTemporals.java
@@ -100,7 +100,7 @@ public class TestTemporals {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 
@@ -167,7 +167,7 @@ public class TestTemporals {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestTemporals.java
+++ b/src/test/java/org/threeten/extra/TestTemporals.java
@@ -117,7 +117,7 @@ public class TestTemporals {
                 switch (date.getDayOfWeek()) {
                     case FRIDAY:
                     case SATURDAY:
-                        assertEquals(test.getDayOfWeek(), MONDAY);
+                        assertEquals(MONDAY, test.getDayOfWeek());
                         break;
                     default:
                         assertEquals(date.getDayOfWeek().plus(1), test.getDayOfWeek());
@@ -127,18 +127,18 @@ public class TestTemporals {
                     int dayDiff = test.getDayOfYear() - date.getDayOfYear();
                     switch (date.getDayOfWeek()) {
                         case FRIDAY:
-                            assertEquals(dayDiff, 3);
+                            assertEquals(3, dayDiff);
                             break;
                         case SATURDAY:
-                            assertEquals(dayDiff, 2);
+                            assertEquals(2, dayDiff);
                             break;
                         default:
-                            assertEquals(dayDiff, 1);
+                            assertEquals(1, dayDiff);
                     }
                 } else {
-                    assertEquals(test.getYear(), 2008);
-                    assertEquals(test.getMonth(), JANUARY);
-                    assertEquals(test.getDayOfMonth(), 1);
+                    assertEquals(2008, test.getYear());
+                    assertEquals(JANUARY, test.getMonth());
+                    assertEquals(1, test.getDayOfMonth());
                 }
             }
         }
@@ -148,11 +148,11 @@ public class TestTemporals {
     public void test_nextWorkingDay_yearChange() {
         LocalDate friday = LocalDate.of(2010, DECEMBER, 31);
         Temporal test = Temporals.nextWorkingDay().adjustInto(friday);
-        assertEquals(test, LocalDate.of(2011, JANUARY, 3));
+        assertEquals(LocalDate.of(2011, JANUARY, 3), test);
 
         LocalDate saturday = LocalDate.of(2011, DECEMBER, 31);
         test = Temporals.nextWorkingDay().adjustInto(saturday);
-        assertEquals(test, LocalDate.of(2012, JANUARY, 2));
+        assertEquals(LocalDate.of(2012, JANUARY, 2), test);
     }
 
     //-----------------------------------------------------------------------
@@ -184,7 +184,7 @@ public class TestTemporals {
                 switch (date.getDayOfWeek()) {
                     case MONDAY:
                     case SUNDAY:
-                        assertEquals(test.getDayOfWeek(), FRIDAY);
+                        assertEquals(FRIDAY, test.getDayOfWeek());
                         break;
                     default:
                         assertEquals(date.getDayOfWeek().minus(1), test.getDayOfWeek());
@@ -194,18 +194,18 @@ public class TestTemporals {
                     int dayDiff = test.getDayOfYear() - date.getDayOfYear();
                     switch (date.getDayOfWeek()) {
                         case MONDAY:
-                            assertEquals(dayDiff, -3);
+                            assertEquals(-3, dayDiff);
                             break;
                         case SUNDAY:
-                            assertEquals(dayDiff, -2);
+                            assertEquals(-2, dayDiff);
                             break;
                         default:
-                            assertEquals(dayDiff, -1);
+                            assertEquals(-1, dayDiff);
                     }
                 } else {
-                    assertEquals(test.getYear(), 2006);
-                    assertEquals(test.getMonth(), DECEMBER);
-                    assertEquals(test.getDayOfMonth(), 29);
+                    assertEquals(2006, test.getYear());
+                    assertEquals(DECEMBER, test.getMonth());
+                    assertEquals(29, test.getDayOfMonth());
                 }
             }
         }
@@ -215,11 +215,11 @@ public class TestTemporals {
     public void test_previousWorkingDay_yearChange() {
         LocalDate monday = LocalDate.of(2011, JANUARY, 3);
         Temporal test = Temporals.previousWorkingDay().adjustInto(monday);
-        assertEquals(test, LocalDate.of(2010, DECEMBER, 31));
+        assertEquals(LocalDate.of(2010, DECEMBER, 31), test);
 
         LocalDate sunday = LocalDate.of(2011, JANUARY, 2);
         test = Temporals.previousWorkingDay().adjustInto(sunday);
-        assertEquals(test, LocalDate.of(2010, DECEMBER, 31));
+        assertEquals(LocalDate.of(2010, DECEMBER, 31), test);
     }
 
     //-----------------------------------------------------------------------
@@ -236,7 +236,7 @@ public class TestTemporals {
     @Test
     @UseDataProvider("data_parseFirstMatching")
     public void test_parseFirstMatching(String text, DateTimeFormatter fmt1, DateTimeFormatter fmt2) {
-        assertEquals(Temporals.parseFirstMatching(text, LocalDate::from, fmt1, fmt2), LocalDate.of(2016, 9, 6));
+        assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching(text, LocalDate::from, fmt1, fmt2));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -246,7 +246,7 @@ public class TestTemporals {
 
     @Test
     public void test_parseFirstMatching_one() {
-        assertEquals(Temporals.parseFirstMatching("2016-09-06", LocalDate::from, DateTimeFormatter.ISO_LOCAL_DATE), LocalDate.of(2016, 9, 6));
+        assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching("2016-09-06", LocalDate::from, DateTimeFormatter.ISO_LOCAL_DATE));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -273,7 +273,7 @@ public class TestTemporals {
     @Test
     @UseDataProvider("data_timeUnitConversion")
     public void test_timeUnit(ChronoUnit chronoUnit, TimeUnit timeUnit) {
-        assertEquals(Temporals.timeUnit(chronoUnit), timeUnit);
+        assertEquals(timeUnit, Temporals.timeUnit(chronoUnit));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -289,7 +289,7 @@ public class TestTemporals {
     @Test
     @UseDataProvider("data_timeUnitConversion")
     public void test_chronoUnit(ChronoUnit chronoUnit, TimeUnit timeUnit) {
-        assertEquals(Temporals.chronoUnit(timeUnit), chronoUnit);
+        assertEquals(chronoUnit, Temporals.chronoUnit(timeUnit));
     }
 
     @Test(expected = NullPointerException.class)
@@ -453,8 +453,8 @@ public class TestTemporals {
             long fromAmount, TemporalUnit fromUnit, TemporalUnit resultUnit,
             long resultWhole, long resultRemainder) {
         long[] result = Temporals.convertAmount(fromAmount, fromUnit, resultUnit);
-        assertEquals(result[0], resultWhole);
-        assertEquals(result[1], resultRemainder);
+        assertEquals(resultWhole, result[0]);
+        assertEquals(resultRemainder, result[1]);
     }
 
     @Test
@@ -463,8 +463,8 @@ public class TestTemporals {
             long fromAmount, TemporalUnit fromUnit, TemporalUnit resultUnit,
             long resultWhole, long resultRemainder) {
         long[] result = Temporals.convertAmount(-fromAmount, fromUnit, resultUnit);
-        assertEquals(result[0], -resultWhole);
-        assertEquals(result[1], -resultRemainder);
+        assertEquals(-resultWhole, result[0]);
+        assertEquals(-resultRemainder, result[1]);
     }
 
     @Test
@@ -472,8 +472,8 @@ public class TestTemporals {
         for (ChronoUnit unit : ChronoUnit.values()) {
             if (unit != ERAS && unit != FOREVER) {
                 long[] result = Temporals.convertAmount(0, unit, unit);
-                assertEquals(result[0], 0);
-                assertEquals(result[1], 0);
+                assertEquals(0, result[0]);
+                assertEquals(0, result[1]);
             }
         }
     }
@@ -483,8 +483,8 @@ public class TestTemporals {
         for (ChronoUnit unit : ChronoUnit.values()) {
             if (unit != ERAS && unit != FOREVER) {
                 long[] result = Temporals.convertAmount(2, unit, unit);
-                assertEquals(result[0], 2);
-                assertEquals(result[1], 0);
+                assertEquals(2, result[0]);
+                assertEquals(0, result[1]);
             }
         }
     }

--- a/src/test/java/org/threeten/extra/TestWeeks.java
+++ b/src/test/java/org/threeten/extra/TestWeeks.java
@@ -74,7 +74,7 @@ public class TestWeeks {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 
@@ -82,14 +82,14 @@ public class TestWeeks {
     @Test
     public void test_ZERO() {
         assertSame(Weeks.of(0), Weeks.ZERO);
-        assertSame(Weeks.of(0), Weeks.ZERO);
+        assertEquals(Weeks.of(0), Weeks.ZERO);
         assertEquals(0, Weeks.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Weeks.of(1), Weeks.ONE);
-        assertSame(Weeks.of(1), Weeks.ONE);
+        assertEquals(Weeks.of(1), Weeks.ONE);
         assertEquals(1, Weeks.ONE.getAmount());
     }
 

--- a/src/test/java/org/threeten/extra/TestWeeks.java
+++ b/src/test/java/org/threeten/extra/TestWeeks.java
@@ -83,46 +83,46 @@ public class TestWeeks {
     public void test_ZERO() {
         assertSame(Weeks.of(0), Weeks.ZERO);
         assertSame(Weeks.of(0), Weeks.ZERO);
-        assertEquals(Weeks.ZERO.getAmount(), 0);
+        assertEquals(0, Weeks.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Weeks.of(1), Weeks.ONE);
         assertSame(Weeks.of(1), Weeks.ONE);
-        assertEquals(Weeks.ONE.getAmount(), 1);
+        assertEquals(1, Weeks.ONE.getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Weeks.of(1).getAmount(), 1);
-        assertEquals(Weeks.of(2).getAmount(), 2);
-        assertEquals(Weeks.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Weeks.of(-1).getAmount(), -1);
-        assertEquals(Weeks.of(-2).getAmount(), -2);
-        assertEquals(Weeks.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(1, Weeks.of(1).getAmount());
+        assertEquals(2, Weeks.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Weeks.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Weeks.of(-1).getAmount());
+        assertEquals(-2, Weeks.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Weeks.of(Integer.MIN_VALUE).getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_from_P0W() {
-        assertEquals(Weeks.from(Period.ofWeeks(0)), Weeks.of(0));
+        assertEquals(Weeks.of(0), Weeks.from(Period.ofWeeks(0)));
     }
 
     @Test
     public void test_from_P2W() {
-        assertEquals(Weeks.from(Period.ofWeeks(2)), Weeks.of(2));
+        assertEquals(Weeks.of(2), Weeks.from(Period.ofWeeks(2)));
     }
 
     @Test
     public void test_from_P14D() {
-        assertEquals(Weeks.from(Period.ofDays(14)), Weeks.of(2));
+        assertEquals(Weeks.of(2), Weeks.from(Period.ofDays(14)));
     }
 
     @Test
     public void test_from_Duration() {
-        assertEquals(Weeks.from(Duration.ofDays(14)), Weeks.of(2));
+        assertEquals(Weeks.of(2), Weeks.from(Duration.ofDays(14)));
     }
 
     @Test(expected = DateTimeException.class)
@@ -143,13 +143,13 @@ public class TestWeeks {
     //-----------------------------------------------------------------------
     @Test
     public void test_parse_CharSequence() {
-        assertEquals(Weeks.parse("P0W"), Weeks.of(0));
-        assertEquals(Weeks.parse("P1W"), Weeks.of(1));
-        assertEquals(Weeks.parse("P2W"), Weeks.of(2));
-        assertEquals(Weeks.parse("P123456789W"), Weeks.of(123456789));
-        assertEquals(Weeks.parse("P-2W"), Weeks.of(-2));
-        assertEquals(Weeks.parse("-P2W"), Weeks.of(-2));
-        assertEquals(Weeks.parse("-P-2W"), Weeks.of(2));
+        assertEquals(Weeks.of(0), Weeks.parse("P0W"));
+        assertEquals(Weeks.of(1), Weeks.parse("P1W"));
+        assertEquals(Weeks.of(2), Weeks.parse("P2W"));
+        assertEquals(Weeks.of(123456789), Weeks.parse("P123456789W"));
+        assertEquals(Weeks.of(-2), Weeks.parse("P-2W"));
+        assertEquals(Weeks.of(-2), Weeks.parse("-P2W"));
+        assertEquals(Weeks.of(2), Weeks.parse("-P-2W"));
     }
 
     @DataProvider
@@ -398,7 +398,7 @@ public class TestWeeks {
     @Test
     public void test_toPeriod() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Weeks.of(i).toPeriod(), Period.ofWeeks(i));
+            assertEquals(Period.ofWeeks(i), Weeks.of(i).toPeriod());
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestYearQuarter.java
+++ b/src/test/java/org/threeten/extra/TestYearQuarter.java
@@ -135,7 +135,7 @@ public class TestYearQuarter {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -147,9 +147,9 @@ public class TestYearQuarter {
         for (int year = -100; year <= 100; year++) {
             for (Quarter quarter : Quarter.values()) {
                 YearQuarter test = YearQuarter.of(year, quarter);
-                assertEquals(test.getYear(), year);
-                assertEquals(test.getQuarterValue(), quarter.getValue());
-                assertEquals(test.getQuarter(), quarter);
+                assertEquals(year, test.getYear());
+                assertEquals(quarter.getValue(), test.getQuarterValue());
+                assertEquals(quarter, test.getQuarter());
             }
         }
     }
@@ -177,11 +177,11 @@ public class TestYearQuarter {
         for (int year = -100; year <= 100; year++) {
             for (int quarter = 1; quarter <= 4; quarter++) {
                 YearQuarter test = YearQuarter.of(year, quarter);
-                assertEquals(test.getYear(), year);
-                assertEquals(test.getQuarterValue(), quarter);
-                assertEquals(test.getQuarter(), Quarter.of(quarter));
-                assertEquals(YearQuarter.of(year, quarter), test);
-                assertEquals(YearQuarter.of(year, quarter).hashCode(), test.hashCode());
+                assertEquals(year, test.getYear());
+                assertEquals(quarter, test.getQuarterValue());
+                assertEquals(Quarter.of(quarter), test.getQuarter());
+                assertEquals(test, YearQuarter.of(year, quarter));
+                assertEquals(test.hashCode(), YearQuarter.of(year, quarter).hashCode());
             }
         }
     }
@@ -215,7 +215,7 @@ public class TestYearQuarter {
         for (int i = 1; i <= STANDARD_YEAR_LENGTH; i++) {
             YearQuarter test = YearQuarter.from(date);
             int expected = ((date.getMonthValue() - 1) / 3) + 1;
-            assertEquals(test, YearQuarter.of(2007, expected));
+            assertEquals(YearQuarter.of(2007, expected), test);
             date = date.plusDays(1);
         }
     }
@@ -226,7 +226,7 @@ public class TestYearQuarter {
         for (int i = 1; i <= LEAP_YEAR_LENGTH; i++) {
             YearQuarter test = YearQuarter.from(date);
             int expected = ((date.getMonthValue() - 1) / 3) + 1;
-            assertEquals(test, YearQuarter.of(2008, expected));
+            assertEquals(YearQuarter.of(2008, expected), test);
             date = date.plusDays(1);
         }
     }
@@ -246,12 +246,12 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_parse_CharSequence() {
-        assertEquals(YearQuarter.parse("2012-Q3"), YearQuarter.of(2012, Q3));
+        assertEquals(YearQuarter.of(2012, Q3), YearQuarter.parse("2012-Q3"));
     }
 
     @Test
     public void test_parse_CharSequence_caseInsensitive() {
-        assertEquals(YearQuarter.parse("2012-q3"), YearQuarter.of(2012, Q3));
+        assertEquals(YearQuarter.of(2012, Q3), YearQuarter.parse("2012-q3"));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -275,7 +275,7 @@ public class TestYearQuarter {
     @Test
     public void test_parse_CharSequenceDateTimeFormatter() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("'Q'Q uuuu");
-        assertEquals(YearQuarter.parse("Q3 2012", f), YearQuarter.of(2012, Q3));
+        assertEquals(YearQuarter.of(2012, Q3), YearQuarter.parse("Q3 2012", f));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -300,39 +300,39 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_isSupported_TemporalField() {
-        assertEquals(TEST.isSupported((TemporalField) null), false);
-        assertEquals(TEST.isSupported(NANO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(NANO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MICRO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MICRO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MILLI_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MILLI_OF_DAY), false);
-        assertEquals(TEST.isSupported(SECOND_OF_MINUTE), false);
-        assertEquals(TEST.isSupported(SECOND_OF_DAY), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_HOUR), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_DAY), false);
-        assertEquals(TEST.isSupported(HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(AMPM_OF_DAY), false);
-        assertEquals(TEST.isSupported(DAY_OF_WEEK), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR), false);
-        assertEquals(TEST.isSupported(DAY_OF_MONTH), false);
-        assertEquals(TEST.isSupported(DAY_OF_YEAR), false);
-        assertEquals(TEST.isSupported(EPOCH_DAY), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_YEAR), false);
-        assertEquals(TEST.isSupported(MONTH_OF_YEAR), false);
-        assertEquals(TEST.isSupported(PROLEPTIC_MONTH), false);
-        assertEquals(TEST.isSupported(YEAR_OF_ERA), true);
-        assertEquals(TEST.isSupported(YEAR), true);
-        assertEquals(TEST.isSupported(ERA), true);
-        assertEquals(TEST.isSupported(INSTANT_SECONDS), false);
-        assertEquals(TEST.isSupported(OFFSET_SECONDS), false);
-        assertEquals(TEST.isSupported(QUARTER_OF_YEAR), true);
-        assertEquals(TEST.isSupported(DAY_OF_QUARTER), false);
+        assertEquals(false, TEST.isSupported((TemporalField) null));
+        assertEquals(false, TEST.isSupported(NANO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(NANO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MICRO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MICRO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MILLI_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MILLI_OF_DAY));
+        assertEquals(false, TEST.isSupported(SECOND_OF_MINUTE));
+        assertEquals(false, TEST.isSupported(SECOND_OF_DAY));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_HOUR));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_DAY));
+        assertEquals(false, TEST.isSupported(HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(AMPM_OF_DAY));
+        assertEquals(false, TEST.isSupported(DAY_OF_WEEK));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(false, TEST.isSupported(DAY_OF_MONTH));
+        assertEquals(false, TEST.isSupported(DAY_OF_YEAR));
+        assertEquals(false, TEST.isSupported(EPOCH_DAY));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(false, TEST.isSupported(MONTH_OF_YEAR));
+        assertEquals(false, TEST.isSupported(PROLEPTIC_MONTH));
+        assertEquals(true, TEST.isSupported(YEAR_OF_ERA));
+        assertEquals(true, TEST.isSupported(YEAR));
+        assertEquals(true, TEST.isSupported(ERA));
+        assertEquals(false, TEST.isSupported(INSTANT_SECONDS));
+        assertEquals(false, TEST.isSupported(OFFSET_SECONDS));
+        assertEquals(true, TEST.isSupported(QUARTER_OF_YEAR));
+        assertEquals(false, TEST.isSupported(DAY_OF_QUARTER));
     }
 
     //-----------------------------------------------------------------------
@@ -340,23 +340,23 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_isSupported_TemporalUnit() {
-        assertEquals(TEST.isSupported((TemporalUnit) null), false);
-        assertEquals(TEST.isSupported(NANOS), false);
-        assertEquals(TEST.isSupported(MICROS), false);
-        assertEquals(TEST.isSupported(MILLIS), false);
-        assertEquals(TEST.isSupported(SECONDS), false);
-        assertEquals(TEST.isSupported(MINUTES), false);
-        assertEquals(TEST.isSupported(HOURS), false);
-        assertEquals(TEST.isSupported(DAYS), false);
-        assertEquals(TEST.isSupported(WEEKS), false);
-        assertEquals(TEST.isSupported(MONTHS), false);
-        assertEquals(TEST.isSupported(YEARS), true);
-        assertEquals(TEST.isSupported(DECADES), true);
-        assertEquals(TEST.isSupported(CENTURIES), true);
-        assertEquals(TEST.isSupported(MILLENNIA), true);
-        assertEquals(TEST.isSupported(ERA), true);
-        assertEquals(TEST.isSupported(FOREVER), false);
-        assertEquals(TEST.isSupported(QUARTER_YEARS), true);
+        assertEquals(false, TEST.isSupported((TemporalUnit) null));
+        assertEquals(false, TEST.isSupported(NANOS));
+        assertEquals(false, TEST.isSupported(MICROS));
+        assertEquals(false, TEST.isSupported(MILLIS));
+        assertEquals(false, TEST.isSupported(SECONDS));
+        assertEquals(false, TEST.isSupported(MINUTES));
+        assertEquals(false, TEST.isSupported(HOURS));
+        assertEquals(false, TEST.isSupported(DAYS));
+        assertEquals(false, TEST.isSupported(WEEKS));
+        assertEquals(false, TEST.isSupported(MONTHS));
+        assertEquals(true, TEST.isSupported(YEARS));
+        assertEquals(true, TEST.isSupported(DECADES));
+        assertEquals(true, TEST.isSupported(CENTURIES));
+        assertEquals(true, TEST.isSupported(MILLENNIA));
+        assertEquals(true, TEST.isSupported(ERA));
+        assertEquals(false, TEST.isSupported(FOREVER));
+        assertEquals(true, TEST.isSupported(QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -364,10 +364,10 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_range() {
-        assertEquals(TEST.range(QUARTER_OF_YEAR), QUARTER_OF_YEAR.range());
-        assertEquals(TEST.range(YEAR), YEAR.range());
-        assertEquals(TEST.range(YEAR_OF_ERA), ValueRange.of(1, Year.MAX_VALUE));
-        assertEquals(TEST.range(ERA), ERA.range());
+        assertEquals(QUARTER_OF_YEAR.range(), TEST.range(QUARTER_OF_YEAR));
+        assertEquals(YEAR.range(), TEST.range(YEAR));
+        assertEquals(ValueRange.of(1, Year.MAX_VALUE), TEST.range(YEAR_OF_ERA));
+        assertEquals(ERA.range(), TEST.range(ERA));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -385,10 +385,10 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_get() {
-        assertEquals(TEST.get(QUARTER_OF_YEAR), 2);
-        assertEquals(TEST.get(YEAR), 2012);
-        assertEquals(TEST.get(YEAR_OF_ERA), 2012);
-        assertEquals(TEST.get(ERA), 1);
+        assertEquals(2, TEST.get(QUARTER_OF_YEAR));
+        assertEquals(2012, TEST.get(YEAR));
+        assertEquals(2012, TEST.get(YEAR_OF_ERA));
+        assertEquals(1, TEST.get(ERA));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -406,10 +406,10 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_getLong() {
-        assertEquals(TEST.getLong(QUARTER_OF_YEAR), 2L);
-        assertEquals(TEST.getLong(YEAR), 2012L);
-        assertEquals(TEST.getLong(YEAR_OF_ERA), 2012L);
-        assertEquals(TEST.getLong(ERA), 1L);
+        assertEquals(2L, TEST.getLong(QUARTER_OF_YEAR));
+        assertEquals(2012L, TEST.getLong(YEAR));
+        assertEquals(2012L, TEST.getLong(YEAR_OF_ERA));
+        assertEquals(1L, TEST.getLong(ERA));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -430,7 +430,7 @@ public class TestYearQuarter {
         for (int year = -500; year <= 500; year++) {
             for (Quarter quarter : Quarter.values()) {
                 YearQuarter test = YearQuarter.of(year, quarter);
-                assertEquals(test.isLeapYear(), Year.isLeap(year));
+                assertEquals(Year.isLeap(year), test.isLeapYear());
             }
         }
     }
@@ -440,53 +440,53 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_isValidDay_int_nonLeap() {
-        assertEquals(YearQuarter.of(2011, Q1).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2011, Q1).isValidDay(91), false);
-        assertEquals(YearQuarter.of(2011, Q1).isValidDay(92), false);
+        assertEquals(true, YearQuarter.of(2011, Q1).isValidDay(90));
+        assertEquals(false, YearQuarter.of(2011, Q1).isValidDay(91));
+        assertEquals(false, YearQuarter.of(2011, Q1).isValidDay(92));
 
-        assertEquals(YearQuarter.of(2011, Q2).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2011, Q2).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2011, Q2).isValidDay(92), false);
+        assertEquals(true, YearQuarter.of(2011, Q2).isValidDay(90));
+        assertEquals(true, YearQuarter.of(2011, Q2).isValidDay(91));
+        assertEquals(false, YearQuarter.of(2011, Q2).isValidDay(92));
 
-        assertEquals(YearQuarter.of(2011, Q3).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2011, Q3).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2011, Q4).isValidDay(90), true);
+        assertEquals(true, YearQuarter.of(2011, Q3).isValidDay(90));
+        assertEquals(true, YearQuarter.of(2011, Q3).isValidDay(91));
+        assertEquals(true, YearQuarter.of(2011, Q4).isValidDay(90));
 
-        assertEquals(YearQuarter.of(2011, Q3).isValidDay(92), true);
-        assertEquals(YearQuarter.of(2011, Q4).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2011, Q4).isValidDay(92), true);
+        assertEquals(true, YearQuarter.of(2011, Q3).isValidDay(92));
+        assertEquals(true, YearQuarter.of(2011, Q4).isValidDay(91));
+        assertEquals(true, YearQuarter.of(2011, Q4).isValidDay(92));
     }
 
     @Test
     public void test_isValidDay_int_leap() {
-        assertEquals(YearQuarter.of(2012, Q1).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2012, Q1).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2012, Q1).isValidDay(92), false);
+        assertEquals(true, YearQuarter.of(2012, Q1).isValidDay(90));
+        assertEquals(true, YearQuarter.of(2012, Q1).isValidDay(91));
+        assertEquals(false, YearQuarter.of(2012, Q1).isValidDay(92));
 
-        assertEquals(YearQuarter.of(2012, Q2).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2012, Q2).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2012, Q2).isValidDay(92), false);
+        assertEquals(true, YearQuarter.of(2012, Q2).isValidDay(90));
+        assertEquals(true, YearQuarter.of(2012, Q2).isValidDay(91));
+        assertEquals(false, YearQuarter.of(2012, Q2).isValidDay(92));
 
-        assertEquals(YearQuarter.of(2012, Q3).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2012, Q3).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2012, Q3).isValidDay(92), true);
+        assertEquals(true, YearQuarter.of(2012, Q3).isValidDay(90));
+        assertEquals(true, YearQuarter.of(2012, Q3).isValidDay(91));
+        assertEquals(true, YearQuarter.of(2012, Q3).isValidDay(92));
 
-        assertEquals(YearQuarter.of(2012, Q4).isValidDay(90), true);
-        assertEquals(YearQuarter.of(2012, Q4).isValidDay(91), true);
-        assertEquals(YearQuarter.of(2012, Q4).isValidDay(92), true);
+        assertEquals(true, YearQuarter.of(2012, Q4).isValidDay(90));
+        assertEquals(true, YearQuarter.of(2012, Q4).isValidDay(91));
+        assertEquals(true, YearQuarter.of(2012, Q4).isValidDay(92));
     }
 
     @Test
     public void test_isValidDay_int_outOfRange() {
-        assertEquals(YearQuarter.of(2011, Q1).isValidDay(93), false);
-        assertEquals(YearQuarter.of(2011, Q2).isValidDay(93), false);
-        assertEquals(YearQuarter.of(2011, Q3).isValidDay(93), false);
-        assertEquals(YearQuarter.of(2011, Q4).isValidDay(93), false);
+        assertEquals(false, YearQuarter.of(2011, Q1).isValidDay(93));
+        assertEquals(false, YearQuarter.of(2011, Q2).isValidDay(93));
+        assertEquals(false, YearQuarter.of(2011, Q3).isValidDay(93));
+        assertEquals(false, YearQuarter.of(2011, Q4).isValidDay(93));
 
-        assertEquals(YearQuarter.of(2011, Q1).isValidDay(0), false);
-        assertEquals(YearQuarter.of(2011, Q2).isValidDay(0), false);
-        assertEquals(YearQuarter.of(2011, Q3).isValidDay(0), false);
-        assertEquals(YearQuarter.of(2011, Q4).isValidDay(0), false);
+        assertEquals(false, YearQuarter.of(2011, Q1).isValidDay(0));
+        assertEquals(false, YearQuarter.of(2011, Q2).isValidDay(0));
+        assertEquals(false, YearQuarter.of(2011, Q3).isValidDay(0));
+        assertEquals(false, YearQuarter.of(2011, Q4).isValidDay(0));
     }
 
     //-----------------------------------------------------------------------
@@ -495,10 +495,10 @@ public class TestYearQuarter {
     @Test
     public void test_lengthOfQuarter() {
         for (int year = -500; year <= 500; year++) {
-            assertEquals(YearQuarter.of(year, Q1).lengthOfQuarter(), Year.isLeap(year) ? 91 : 90);
-            assertEquals(YearQuarter.of(year, Q2).lengthOfQuarter(), 91);
-            assertEquals(YearQuarter.of(year, Q3).lengthOfQuarter(), 92);
-            assertEquals(YearQuarter.of(year, Q4).lengthOfQuarter(), 92);
+            assertEquals(Year.isLeap(year) ? 91 : 90, YearQuarter.of(year, Q1).lengthOfQuarter());
+            assertEquals(91, YearQuarter.of(year, Q2).lengthOfQuarter());
+            assertEquals(92, YearQuarter.of(year, Q3).lengthOfQuarter());
+            assertEquals(92, YearQuarter.of(year, Q4).lengthOfQuarter());
         }
     }
 
@@ -507,17 +507,17 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_with_TemporalAdjuster_Quarter() {
-        assertEquals(YearQuarter.of(2007, Q2).with(Q1), YearQuarter.of(2007, Q1));
+        assertEquals(YearQuarter.of(2007, Q1), YearQuarter.of(2007, Q2).with(Q1));
     }
 
     @Test
     public void test_with_TemporalAdjuster_Year() {
-        assertEquals(YearQuarter.of(2007, Q2).with(Year.of(2012)), YearQuarter.of(2012, Q2));
+        assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).with(Year.of(2012)));
     }
 
     @Test
     public void test_with_TemporalAdjuster_YearQuarter() {
-        assertEquals(YearQuarter.of(2007, Q2).with(YearQuarter.of(2012, Q3)), YearQuarter.of(2012, Q3));
+        assertEquals(YearQuarter.of(2012, Q3), YearQuarter.of(2007, Q2).with(YearQuarter.of(2012, Q3)));
     }
 
     @Test(expected = DateTimeException.class)
@@ -535,7 +535,7 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_withYear() {
-        assertEquals(YearQuarter.of(2007, Q2).withYear(2012), YearQuarter.of(2012, Q2));
+        assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).withYear(2012));
     }
 
     @Test(expected = DateTimeException.class)
@@ -553,7 +553,7 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_withQuarter_int() {
-        assertEquals(YearQuarter.of(2007, Q2).withQuarter(1), YearQuarter.of(2007, Q1));
+        assertEquals(YearQuarter.of(2007, Q1), YearQuarter.of(2007, Q2).withQuarter(1));
     }
 
     @Test(expected = DateTimeException.class)
@@ -571,12 +571,12 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_longTemporalUnit() {
-        assertEquals(YearQuarter.of(2007, Q2).plus(5, YEARS), YearQuarter.of(2012, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plus(0, YEARS), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plus(-5, YEARS), YearQuarter.of(2002, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plus(5, QUARTER_YEARS), YearQuarter.of(2008, Q3));
-        assertEquals(YearQuarter.of(2007, Q2).plus(0, QUARTER_YEARS), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plus(-5, QUARTER_YEARS), YearQuarter.of(2006, Q1));
+        assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).plus(5, YEARS));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).plus(0, YEARS));
+        assertEquals(YearQuarter.of(2002, Q2), YearQuarter.of(2007, Q2).plus(-5, YEARS));
+        assertEquals(YearQuarter.of(2008, Q3), YearQuarter.of(2007, Q2).plus(5, QUARTER_YEARS));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).plus(0, QUARTER_YEARS));
+        assertEquals(YearQuarter.of(2006, Q1), YearQuarter.of(2007, Q2).plus(-5, QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -584,9 +584,9 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_plusYears() {
-        assertEquals(YearQuarter.of(2007, Q2).plusYears(5), YearQuarter.of(2012, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plusYears(0), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plusYears(-5), YearQuarter.of(2002, Q2));
+        assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).plusYears(5));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).plusYears(0));
+        assertEquals(YearQuarter.of(2002, Q2), YearQuarter.of(2007, Q2).plusYears(-5));
     }
 
     //-----------------------------------------------------------------------
@@ -594,9 +594,9 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_plusQuarters() {
-        assertEquals(YearQuarter.of(2007, Q2).plusQuarters(5), YearQuarter.of(2008, Q3));
-        assertEquals(YearQuarter.of(2007, Q2).plusQuarters(0), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).plusQuarters(-5), YearQuarter.of(2006, Q1));
+        assertEquals(YearQuarter.of(2008, Q3), YearQuarter.of(2007, Q2).plusQuarters(5));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).plusQuarters(0));
+        assertEquals(YearQuarter.of(2006, Q1), YearQuarter.of(2007, Q2).plusQuarters(-5));
     }
 
     //-----------------------------------------------------------------------
@@ -604,12 +604,12 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_minus_longTemporalUnit() {
-        assertEquals(YearQuarter.of(2007, Q2).minus(5, YEARS), YearQuarter.of(2002, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minus(0, YEARS), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minus(-5, YEARS), YearQuarter.of(2012, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minus(5, QUARTER_YEARS), YearQuarter.of(2006, Q1));
-        assertEquals(YearQuarter.of(2007, Q2).minus(0, QUARTER_YEARS), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minus(-5, QUARTER_YEARS), YearQuarter.of(2008, Q3));
+        assertEquals(YearQuarter.of(2002, Q2), YearQuarter.of(2007, Q2).minus(5, YEARS));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).minus(0, YEARS));
+        assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).minus(-5, YEARS));
+        assertEquals(YearQuarter.of(2006, Q1), YearQuarter.of(2007, Q2).minus(5, QUARTER_YEARS));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).minus(0, QUARTER_YEARS));
+        assertEquals(YearQuarter.of(2008, Q3), YearQuarter.of(2007, Q2).minus(-5, QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -617,9 +617,9 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_minusYears() {
-        assertEquals(YearQuarter.of(2007, Q2).minusYears(5), YearQuarter.of(2002, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minusYears(0), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minusYears(-5), YearQuarter.of(2012, Q2));
+        assertEquals(YearQuarter.of(2002, Q2), YearQuarter.of(2007, Q2).minusYears(5));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).minusYears(0));
+        assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).minusYears(-5));
     }
 
     //-----------------------------------------------------------------------
@@ -627,9 +627,9 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_minusQuarters() {
-        assertEquals(YearQuarter.of(2007, Q2).minusQuarters(5), YearQuarter.of(2006, Q1));
-        assertEquals(YearQuarter.of(2007, Q2).minusQuarters(0), YearQuarter.of(2007, Q2));
-        assertEquals(YearQuarter.of(2007, Q2).minusQuarters(-5), YearQuarter.of(2008, Q3));
+        assertEquals(YearQuarter.of(2006, Q1), YearQuarter.of(2007, Q2).minusQuarters(5));
+        assertEquals(YearQuarter.of(2007, Q2), YearQuarter.of(2007, Q2).minusQuarters(0));
+        assertEquals(YearQuarter.of(2008, Q3), YearQuarter.of(2007, Q2).minusQuarters(-5));
     }
 
     //-----------------------------------------------------------------------
@@ -640,7 +640,7 @@ public class TestYearQuarter {
         for (int year = -500; year <= 500; year++) {
             for (Quarter quarter : Quarter.values()) {
                 YearQuarter test = YearQuarter.of(year, quarter);
-                assertEquals(test.lengthOfYear(), Year.isLeap(year) ? 366 : 365);
+                assertEquals(Year.isLeap(year) ? 366 : 365, test.lengthOfYear());
             }
         }
     }
@@ -650,13 +650,13 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_query() {
-        assertEquals(TEST.query(TemporalQueries.chronology()), IsoChronology.INSTANCE);
-        assertEquals(TEST.query(TemporalQueries.localDate()), null);
-        assertEquals(TEST.query(TemporalQueries.localTime()), null);
-        assertEquals(TEST.query(TemporalQueries.offset()), null);
-        assertEquals(TEST.query(TemporalQueries.precision()), QUARTER_YEARS);
-        assertEquals(TEST.query(TemporalQueries.zone()), null);
-        assertEquals(TEST.query(TemporalQueries.zoneId()), null);
+        assertEquals(IsoChronology.INSTANCE, TEST.query(TemporalQueries.chronology()));
+        assertEquals(null, TEST.query(TemporalQueries.localDate()));
+        assertEquals(null, TEST.query(TemporalQueries.localTime()));
+        assertEquals(null, TEST.query(TemporalQueries.offset()));
+        assertEquals(QUARTER_YEARS, TEST.query(TemporalQueries.precision()));
+        assertEquals(null, TEST.query(TemporalQueries.zone()));
+        assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }
 
     //-----------------------------------------------------------------------
@@ -668,7 +668,7 @@ public class TestYearQuarter {
             for (int dom = 1; dom < 28; dom++) {
                 LocalDate base = LocalDate.of(2007, month, dom);
                 LocalDate expected = LocalDate.of(2012, 4 + ((month - 1) % 3), dom);
-                assertEquals(YearQuarter.of(2012, Q2).adjustInto(base), expected);
+                assertEquals(expected, YearQuarter.of(2012, Q2).adjustInto(base));
             }
         }
     }
@@ -677,14 +677,14 @@ public class TestYearQuarter {
     public void test_adjustInto_Temporal_lastValidDay_nonLeap() {
         LocalDate base = LocalDate.of(2007, 5, 31);
         LocalDate expected = LocalDate.of(2011, 2, 28);
-        assertEquals(YearQuarter.of(2011, Q1).adjustInto(base), expected);
+        assertEquals(expected, YearQuarter.of(2011, Q1).adjustInto(base));
     }
 
     @Test
     public void test_adjustInto_Temporal_lastValidDay_leap() {
         LocalDate base = LocalDate.of(2007, 5, 31);
         LocalDate expected = LocalDate.of(2012, 2, 29);
-        assertEquals(YearQuarter.of(2012, Q1).adjustInto(base), expected);
+        assertEquals(expected, YearQuarter.of(2012, Q1).adjustInto(base));
     }
 
     @Test(expected = NullPointerException.class)
@@ -697,35 +697,35 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_until_TemporalTemporalUnit_QUARTER_YEARS() {
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q4), QUARTER_YEARS), -2);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q1), QUARTER_YEARS), -1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q2), QUARTER_YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), QUARTER_YEARS), 1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q4), QUARTER_YEARS), 2);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q1), QUARTER_YEARS), 3);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q2), QUARTER_YEARS), 4);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q3), QUARTER_YEARS), 5);
+        assertEquals(-2, YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q4), QUARTER_YEARS));
+        assertEquals(-1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q1), QUARTER_YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q2), QUARTER_YEARS));
+        assertEquals(1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), QUARTER_YEARS));
+        assertEquals(2, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q4), QUARTER_YEARS));
+        assertEquals(3, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q1), QUARTER_YEARS));
+        assertEquals(4, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q2), QUARTER_YEARS));
+        assertEquals(5, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q3), QUARTER_YEARS));
     }
 
     @Test
     public void test_until_TemporalTemporalUnit_YEARS() {
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2010, Q2), YEARS), -2);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2010, Q3), YEARS), -1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2010, Q4), YEARS), -1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q1), YEARS), -1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q2), YEARS), -1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q3), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q4), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q1), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q2), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q4), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q1), YEARS), 0);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q2), YEARS), 1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q3), YEARS), 1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q4), YEARS), 1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2014, Q1), YEARS), 1);
-        assertEquals(YearQuarter.of(2012, Q2).until(YearQuarter.of(2014, Q2), YEARS), 2);
+        assertEquals(-2, YearQuarter.of(2012, Q2).until(YearQuarter.of(2010, Q2), YEARS));
+        assertEquals(-1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2010, Q3), YEARS));
+        assertEquals(-1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2010, Q4), YEARS));
+        assertEquals(-1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q1), YEARS));
+        assertEquals(-1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q2), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q3), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2011, Q4), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q1), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q2), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q4), YEARS));
+        assertEquals(0, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q1), YEARS));
+        assertEquals(1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q2), YEARS));
+        assertEquals(1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q3), YEARS));
+        assertEquals(1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2013, Q4), YEARS));
+        assertEquals(1, YearQuarter.of(2012, Q2).until(YearQuarter.of(2014, Q1), YEARS));
+        assertEquals(2, YearQuarter.of(2012, Q2).until(YearQuarter.of(2014, Q2), YEARS));
     }
 
     @Test(expected = NullPointerException.class)
@@ -744,7 +744,7 @@ public class TestYearQuarter {
     @Test
     public void test_format() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("'Q'Q uuuu");
-        assertEquals(YearQuarter.of(2012, Q1).format(f), "Q1 2012");
+        assertEquals("Q1 2012", YearQuarter.of(2012, Q1).format(f));
     }
 
     @Test(expected = NullPointerException.class)
@@ -759,25 +759,25 @@ public class TestYearQuarter {
     public void test_atDay() {
         for (int i = 1; i <= 90; i++) {
             LocalDate expected = LocalDate.of(2012, 1, 1).plusDays(i - 1);
-            assertEquals(YearQuarter.of(2012, Q1).atDay(i), expected);
+            assertEquals(expected, YearQuarter.of(2012, Q1).atDay(i));
         }
         for (int i = 1; i <= 91; i++) {
             LocalDate expected = LocalDate.of(2012, 4, 1).plusDays(i - 1);
-            assertEquals(YearQuarter.of(2012, Q2).atDay(i), expected);
+            assertEquals(expected, YearQuarter.of(2012, Q2).atDay(i));
         }
         for (int i = 1; i <= 92; i++) {
             LocalDate expected = LocalDate.of(2012, 7, 1).plusDays(i - 1);
-            assertEquals(YearQuarter.of(2012, Q3).atDay(i), expected);
+            assertEquals(expected, YearQuarter.of(2012, Q3).atDay(i));
         }
         for (int i = 1; i <= 92; i++) {
             LocalDate expected = LocalDate.of(2012, 10, 1).plusDays(i - 1);
-            assertEquals(YearQuarter.of(2012, Q4).atDay(i), expected);
+            assertEquals(expected, YearQuarter.of(2012, Q4).atDay(i));
         }
     }
 
     @Test
     public void test_atDay_Q1_91_leap() {
-        assertEquals(YearQuarter.of(2012, Q1).atDay(91), LocalDate.of(2012, 3, 31));
+        assertEquals(LocalDate.of(2012, 3, 31), YearQuarter.of(2012, Q1).atDay(91));
     }
 
     @Test(expected = DateTimeException.class)
@@ -810,15 +810,15 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_atEndOfQuarter() {
-        assertEquals(YearQuarter.of(2011, Q1).atEndOfQuarter(), LocalDate.of(2011, 3, 31));
-        assertEquals(YearQuarter.of(2011, Q2).atEndOfQuarter(), LocalDate.of(2011, 6, 30));
-        assertEquals(YearQuarter.of(2011, Q3).atEndOfQuarter(), LocalDate.of(2011, 9, 30));
-        assertEquals(YearQuarter.of(2011, Q4).atEndOfQuarter(), LocalDate.of(2011, 12, 31));
+        assertEquals(LocalDate.of(2011, 3, 31), YearQuarter.of(2011, Q1).atEndOfQuarter());
+        assertEquals(LocalDate.of(2011, 6, 30), YearQuarter.of(2011, Q2).atEndOfQuarter());
+        assertEquals(LocalDate.of(2011, 9, 30), YearQuarter.of(2011, Q3).atEndOfQuarter());
+        assertEquals(LocalDate.of(2011, 12, 31), YearQuarter.of(2011, Q4).atEndOfQuarter());
 
-        assertEquals(YearQuarter.of(2012, Q1).atEndOfQuarter(), LocalDate.of(2012, 3, 31));
-        assertEquals(YearQuarter.of(2012, Q2).atEndOfQuarter(), LocalDate.of(2012, 6, 30));
-        assertEquals(YearQuarter.of(2012, Q3).atEndOfQuarter(), LocalDate.of(2012, 9, 30));
-        assertEquals(YearQuarter.of(2012, Q4).atEndOfQuarter(), LocalDate.of(2012, 12, 31));
+        assertEquals(LocalDate.of(2012, 3, 31), YearQuarter.of(2012, Q1).atEndOfQuarter());
+        assertEquals(LocalDate.of(2012, 6, 30), YearQuarter.of(2012, Q2).atEndOfQuarter());
+        assertEquals(LocalDate.of(2012, 9, 30), YearQuarter.of(2012, Q3).atEndOfQuarter());
+        assertEquals(LocalDate.of(2012, 12, 31), YearQuarter.of(2012, Q4).atEndOfQuarter());
     }
 
     //-----------------------------------------------------------------------
@@ -833,41 +833,41 @@ public class TestYearQuarter {
                     for (Quarter quarter2 : Quarter.values()) {
                         YearQuarter b = YearQuarter.of(year2, quarter2);
                         if (year1 < year2) {
-                            assertEquals(a.compareTo(b) < 0, true);
-                            assertEquals(b.compareTo(a) > 0, true);
-                            assertEquals(a.isAfter(b), false);
-                            assertEquals(b.isBefore(a), false);
-                            assertEquals(b.isAfter(a), true);
-                            assertEquals(a.isBefore(b), true);
+                            assertEquals(true, a.compareTo(b) < 0);
+                            assertEquals(true, b.compareTo(a) > 0);
+                            assertEquals(false, a.isAfter(b));
+                            assertEquals(false, b.isBefore(a));
+                            assertEquals(true, b.isAfter(a));
+                            assertEquals(true, a.isBefore(b));
                         } else if (year1 > year2) {
-                            assertEquals(a.compareTo(b) > 0, true);
-                            assertEquals(b.compareTo(a) < 0, true);
-                            assertEquals(a.isAfter(b), true);
-                            assertEquals(b.isBefore(a), true);
-                            assertEquals(b.isAfter(a), false);
-                            assertEquals(a.isBefore(b), false);
+                            assertEquals(true, a.compareTo(b) > 0);
+                            assertEquals(true, b.compareTo(a) < 0);
+                            assertEquals(true, a.isAfter(b));
+                            assertEquals(true, b.isBefore(a));
+                            assertEquals(false, b.isAfter(a));
+                            assertEquals(false, a.isBefore(b));
                         } else {
                             if (quarter1.getValue() < quarter2.getValue()) {
-                                assertEquals(a.compareTo(b) < 0, true);
-                                assertEquals(b.compareTo(a) > 0, true);
-                                assertEquals(a.isAfter(b), false);
-                                assertEquals(b.isBefore(a), false);
-                                assertEquals(b.isAfter(a), true);
-                                assertEquals(a.isBefore(b), true);
+                                assertEquals(true, a.compareTo(b) < 0);
+                                assertEquals(true, b.compareTo(a) > 0);
+                                assertEquals(false, a.isAfter(b));
+                                assertEquals(false, b.isBefore(a));
+                                assertEquals(true, b.isAfter(a));
+                                assertEquals(true, a.isBefore(b));
                             } else if (quarter1.getValue() > quarter2.getValue()) {
-                                assertEquals(a.compareTo(b) > 0, true);
-                                assertEquals(b.compareTo(a) < 0, true);
-                                assertEquals(a.isAfter(b), true);
-                                assertEquals(b.isBefore(a), true);
-                                assertEquals(b.isAfter(a), false);
-                                assertEquals(a.isBefore(b), false);
+                                assertEquals(true, a.compareTo(b) > 0);
+                                assertEquals(true, b.compareTo(a) < 0);
+                                assertEquals(true, a.isAfter(b));
+                                assertEquals(true, b.isBefore(a));
+                                assertEquals(false, b.isAfter(a));
+                                assertEquals(false, a.isBefore(b));
                             } else {
-                                assertEquals(a.compareTo(b), 0);
-                                assertEquals(b.compareTo(a), 0);
-                                assertEquals(a.isAfter(b), false);
-                                assertEquals(b.isBefore(a), false);
-                                assertEquals(b.isAfter(a), false);
-                                assertEquals(a.isBefore(b), false);
+                                assertEquals(0, a.compareTo(b));
+                                assertEquals(0, b.compareTo(a));
+                                assertEquals(false, a.isAfter(b));
+                                assertEquals(false, b.isBefore(a));
+                                assertEquals(false, b.isAfter(a));
+                                assertEquals(false, a.isBefore(b));
                             }
                         }
                     }
@@ -904,12 +904,12 @@ public class TestYearQuarter {
 
     @Test
     public void test_equals_nullYearQuarter() {
-        assertEquals(TEST.equals(null), false);
+        assertEquals(false, TEST.equals(null));
     }
 
     @Test
     public void test_equals_incorrectType() {
-        assertEquals(TEST.equals("Incorrect type"), false);
+        assertEquals(false, TEST.equals("Incorrect type"));
     }
 
     //-----------------------------------------------------------------------
@@ -917,22 +917,22 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_toString() {
-        assertEquals(YearQuarter.of(2012, Q2).toString(), "2012-Q2");
+        assertEquals("2012-Q2", YearQuarter.of(2012, Q2).toString());
     }
 
     @Test
     public void test_toString_bigYear() {
-        assertEquals(YearQuarter.of(10000, Q2).toString(), "+10000-Q2");
+        assertEquals("+10000-Q2", YearQuarter.of(10000, Q2).toString());
     }
 
     @Test
     public void test_toString_negativeYear() {
-        assertEquals(YearQuarter.of(-1, Q2).toString(), "-0001-Q2");
+        assertEquals("-0001-Q2", YearQuarter.of(-1, Q2).toString());
     }
 
     @Test
     public void test_toString_negativeBigYear() {
-        assertEquals(YearQuarter.of(-10000, Q2).toString(), "-10000-Q2");
+        assertEquals("-10000-Q2", YearQuarter.of(-10000, Q2).toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -307,7 +307,7 @@ public class TestYearWeek {
         }
         ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(
                 baos.toByteArray()));
-        assertEquals(ois.readObject(), test);
+        assertEquals(test, ois.readObject());
     }
 
     //-----------------------------------------------------------------------
@@ -324,7 +324,7 @@ public class TestYearWeek {
             expected = YearWeek.now(Clock.systemDefaultZone());
             test = YearWeek.now();
         }
-        assertEquals(test, expected);
+        assertEquals(expected, test);
     }
 
     //-----------------------------------------------------------------------
@@ -347,7 +347,7 @@ public class TestYearWeek {
             expected = YearWeek.now(Clock.system(zone));
             test = YearWeek.now(zone);
         }
-        assertEquals(test, expected);
+        assertEquals(expected, test);
     }
 
     //-----------------------------------------------------------------------
@@ -358,8 +358,8 @@ public class TestYearWeek {
         Instant instant = LocalDateTime.of(2010, 12, 31, 0, 0).toInstant(ZoneOffset.UTC);
         Clock clock = Clock.fixed(instant, ZoneOffset.UTC);
         YearWeek test = YearWeek.now(clock);
-        assertEquals(test.getYear(), 2010);
-        assertEquals(test.getWeek(), 52);
+        assertEquals(2010, test.getYear());
+        assertEquals(52, test.getWeek());
     }
 
     @Test(expected = NullPointerException.class)
@@ -374,8 +374,8 @@ public class TestYearWeek {
     @UseDataProvider("data_sampleYearWeeks")
     public void test_of(int year, int week) {
         YearWeek yearWeek = YearWeek.of(year, week);
-        assertEquals(yearWeek.getYear(), year);
-        assertEquals(yearWeek.getWeek(), week);
+        assertEquals(year, yearWeek.getYear());
+        assertEquals(week, yearWeek.getWeek());
     }
 
     @Test
@@ -408,41 +408,41 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_isSupported_TemporalField() {
-        assertEquals(TEST.isSupported((TemporalField) null), false);
-        assertEquals(TEST.isSupported(NANO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(NANO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MICRO_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MICRO_OF_DAY), false);
-        assertEquals(TEST.isSupported(MILLI_OF_SECOND), false);
-        assertEquals(TEST.isSupported(MILLI_OF_DAY), false);
-        assertEquals(TEST.isSupported(SECOND_OF_MINUTE), false);
-        assertEquals(TEST.isSupported(SECOND_OF_DAY), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_HOUR), false);
-        assertEquals(TEST.isSupported(MINUTE_OF_DAY), false);
-        assertEquals(TEST.isSupported(HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_AMPM), false);
-        assertEquals(TEST.isSupported(HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(CLOCK_HOUR_OF_DAY), false);
-        assertEquals(TEST.isSupported(AMPM_OF_DAY), false);
-        assertEquals(TEST.isSupported(DAY_OF_WEEK), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR), false);
-        assertEquals(TEST.isSupported(DAY_OF_MONTH), false);
-        assertEquals(TEST.isSupported(DAY_OF_YEAR), false);
-        assertEquals(TEST.isSupported(EPOCH_DAY), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_MONTH), false);
-        assertEquals(TEST.isSupported(ALIGNED_WEEK_OF_YEAR), false);
-        assertEquals(TEST.isSupported(MONTH_OF_YEAR), false);
-        assertEquals(TEST.isSupported(PROLEPTIC_MONTH), false);
-        assertEquals(TEST.isSupported(YEAR_OF_ERA), false);
-        assertEquals(TEST.isSupported(YEAR), false);
-        assertEquals(TEST.isSupported(ERA), false);
-        assertEquals(TEST.isSupported(INSTANT_SECONDS), false);
-        assertEquals(TEST.isSupported(OFFSET_SECONDS), false);
-        assertEquals(TEST.isSupported(QUARTER_OF_YEAR), false);
-        assertEquals(TEST.isSupported(DAY_OF_QUARTER), false);
-        assertEquals(TEST.isSupported(WEEK_BASED_YEAR), true);
-        assertEquals(TEST.isSupported(WEEK_OF_WEEK_BASED_YEAR), true);
+        assertEquals(false, TEST.isSupported((TemporalField) null));
+        assertEquals(false, TEST.isSupported(NANO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(NANO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MICRO_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MICRO_OF_DAY));
+        assertEquals(false, TEST.isSupported(MILLI_OF_SECOND));
+        assertEquals(false, TEST.isSupported(MILLI_OF_DAY));
+        assertEquals(false, TEST.isSupported(SECOND_OF_MINUTE));
+        assertEquals(false, TEST.isSupported(SECOND_OF_DAY));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_HOUR));
+        assertEquals(false, TEST.isSupported(MINUTE_OF_DAY));
+        assertEquals(false, TEST.isSupported(HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_AMPM));
+        assertEquals(false, TEST.isSupported(HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(CLOCK_HOUR_OF_DAY));
+        assertEquals(false, TEST.isSupported(AMPM_OF_DAY));
+        assertEquals(false, TEST.isSupported(DAY_OF_WEEK));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(false, TEST.isSupported(DAY_OF_MONTH));
+        assertEquals(false, TEST.isSupported(DAY_OF_YEAR));
+        assertEquals(false, TEST.isSupported(EPOCH_DAY));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(false, TEST.isSupported(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(false, TEST.isSupported(MONTH_OF_YEAR));
+        assertEquals(false, TEST.isSupported(PROLEPTIC_MONTH));
+        assertEquals(false, TEST.isSupported(YEAR_OF_ERA));
+        assertEquals(false, TEST.isSupported(YEAR));
+        assertEquals(false, TEST.isSupported(ERA));
+        assertEquals(false, TEST.isSupported(INSTANT_SECONDS));
+        assertEquals(false, TEST.isSupported(OFFSET_SECONDS));
+        assertEquals(false, TEST.isSupported(QUARTER_OF_YEAR));
+        assertEquals(false, TEST.isSupported(DAY_OF_QUARTER));
+        assertEquals(true, TEST.isSupported(WEEK_BASED_YEAR));
+        assertEquals(true, TEST.isSupported(WEEK_OF_WEEK_BASED_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -454,7 +454,7 @@ public class TestYearWeek {
         YearWeek yearWeek = YearWeek.of(weekBasedYear, weekOfWeekBasedYear);
         LocalDate expected = LocalDate.of(year, month, dayOfMonth);
         LocalDate actual = yearWeek.atDay(dayOfWeek);
-        assertEquals(actual, expected);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -465,7 +465,7 @@ public class TestYearWeek {
             for (int j = 1; j <= 7; j++) {
                 DayOfWeek dow = DayOfWeek.of(j);
                 LocalDate actual = yearWeek.atDay(dow);
-                assertEquals(actual, expected);
+                assertEquals(expected, actual);
                 expected = expected.plusDays(1);
             }
             yearWeek = yearWeek.plusWeeks(1);
@@ -499,41 +499,41 @@ public class TestYearWeek {
                     for (int week2 = 1; week2 < 53; week2++) {
                         YearWeek b = YearWeek.of(year2, week2);
                         if (year1 < year2) {
-                            assertEquals(a.compareTo(b) < 0, true);
-                            assertEquals(b.compareTo(a) > 0, true);
-                            assertEquals(a.isAfter(b), false);
-                            assertEquals(b.isBefore(a), false);
-                            assertEquals(b.isAfter(a), true);
-                            assertEquals(a.isBefore(b), true);
+                            assertEquals(true, a.compareTo(b) < 0);
+                            assertEquals(true, b.compareTo(a) > 0);
+                            assertEquals(false, a.isAfter(b));
+                            assertEquals(false, b.isBefore(a));
+                            assertEquals(true, b.isAfter(a));
+                            assertEquals(true, a.isBefore(b));
                         } else if (year1 > year2) {
-                            assertEquals(a.compareTo(b) > 0, true);
-                            assertEquals(b.compareTo(a) < 0, true);
-                            assertEquals(a.isAfter(b), true);
-                            assertEquals(b.isBefore(a), true);
-                            assertEquals(b.isAfter(a), false);
-                            assertEquals(a.isBefore(b), false);
+                            assertEquals(true, a.compareTo(b) > 0);
+                            assertEquals(true, b.compareTo(a) < 0);
+                            assertEquals(true, a.isAfter(b));
+                            assertEquals(true, b.isBefore(a));
+                            assertEquals(false, b.isAfter(a));
+                            assertEquals(false, a.isBefore(b));
                         } else {
                             if (week1 < week2) {
-                                assertEquals(a.compareTo(b) < 0, true);
-                                assertEquals(b.compareTo(a) > 0, true);
-                                assertEquals(a.isAfter(b), false);
-                                assertEquals(b.isBefore(a), false);
-                                assertEquals(b.isAfter(a), true);
-                                assertEquals(a.isBefore(b), true);
+                                assertEquals(true, a.compareTo(b) < 0);
+                                assertEquals(true, b.compareTo(a) > 0);
+                                assertEquals(false, a.isAfter(b));
+                                assertEquals(false, b.isBefore(a));
+                                assertEquals(true, b.isAfter(a));
+                                assertEquals(true, a.isBefore(b));
                             } else if (week1 > week2) {
-                                assertEquals(a.compareTo(b) > 0, true);
-                                assertEquals(b.compareTo(a) < 0, true);
-                                assertEquals(a.isAfter(b), true);
-                                assertEquals(b.isBefore(a), true);
-                                assertEquals(b.isAfter(a), false);
-                                assertEquals(a.isBefore(b), false);
+                                assertEquals(true, a.compareTo(b) > 0);
+                                assertEquals(true, b.compareTo(a) < 0);
+                                assertEquals(true, a.isAfter(b));
+                                assertEquals(true, b.isBefore(a));
+                                assertEquals(false, b.isAfter(a));
+                                assertEquals(false, a.isBefore(b));
                             } else {
-                                assertEquals(a.compareTo(b), 0);
-                                assertEquals(b.compareTo(a), 0);
-                                assertEquals(a.isAfter(b), false);
-                                assertEquals(b.isBefore(a), false);
-                                assertEquals(b.isAfter(a), false);
-                                assertEquals(a.isBefore(b), false);
+                                assertEquals(0, a.compareTo(b));
+                                assertEquals(0, b.compareTo(a));
+                                assertEquals(false, a.isAfter(b));
+                                assertEquals(false, b.isBefore(a));
+                                assertEquals(false, b.isAfter(a));
+                                assertEquals(false, a.isBefore(b));
                             }
                         }
                     }
@@ -555,9 +555,9 @@ public class TestYearWeek {
     public void test_from(int weekBasedYear, int weekOfWeekBasedYear, DayOfWeek dayOfWeek, int year, int month, int dayOfMonth) {
         YearWeek expected = YearWeek.of(weekBasedYear, weekOfWeekBasedYear);
         LocalDate ld = LocalDate.of(year, month, dayOfMonth);
-        assertEquals(YearWeek.from(ld), expected);
-        assertEquals(YearWeek.from(ThaiBuddhistDate.from(ld)), expected);
-        assertEquals(YearWeek.from(expected), expected);
+        assertEquals(expected, YearWeek.from(ld));
+        assertEquals(expected, YearWeek.from(ThaiBuddhistDate.from(ld)));
+        assertEquals(expected, YearWeek.from(expected));
     }
 
     @Test(expected = DateTimeException.class)
@@ -575,8 +575,8 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_get() {
-        assertEquals(TEST.get(WEEK_BASED_YEAR), 2015);
-        assertEquals(TEST.get(WEEK_OF_WEEK_BASED_YEAR), 1);
+        assertEquals(2015, TEST.get(WEEK_BASED_YEAR));
+        assertEquals(1, TEST.get(WEEK_OF_WEEK_BASED_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -594,8 +594,8 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_getLong() {
-        assertEquals(TEST.getLong(WEEK_BASED_YEAR), 2015L);
-        assertEquals(TEST.getLong(WEEK_OF_WEEK_BASED_YEAR), 1L);
+        assertEquals(2015L, TEST.getLong(WEEK_BASED_YEAR));
+        assertEquals(1L, TEST.getLong(WEEK_OF_WEEK_BASED_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -613,8 +613,8 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_lengthOfYear() {
-        assertEquals(YearWeek.of(2014, 1).lengthOfYear(), 364);
-        assertEquals(YearWeek.of(2015, 1).lengthOfYear(), 371);
+        assertEquals(364, YearWeek.of(2014, 1).lengthOfYear());
+        assertEquals(371, YearWeek.of(2015, 1).lengthOfYear());
     }
 
     //-----------------------------------------------------------------------
@@ -622,7 +622,7 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_toString() {
-        assertEquals(TEST.toString(), "2015-W01");
+        assertEquals("2015-W01", TEST.toString());
     }
 
     //-----------------------------------------------------------------------
@@ -630,7 +630,7 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_parse_CharSequence() {
-        assertEquals(YearWeek.parse("2015-W01"), TEST);
+        assertEquals(TEST, YearWeek.parse("2015-W01"));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -654,7 +654,7 @@ public class TestYearWeek {
     @Test
     public void test_parse_CharSequenceDateTimeFormatter() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("E 'W'w YYYY").withLocale(Locale.ENGLISH);
-        assertEquals(YearWeek.parse("Mon W1 2015", f), TEST);
+        assertEquals(TEST, YearWeek.parse("Mon W1 2015", f));
     }
 
     @Test(expected = DateTimeParseException.class)
@@ -684,7 +684,7 @@ public class TestYearWeek {
                 .appendLiteral('-')
                 .appendValue(WEEK_OF_WEEK_BASED_YEAR, 2)
                 .toFormatter();
-        assertEquals(TEST.format(f), "2015-01");
+        assertEquals("2015-01", TEST.format(f));
     }
 
     //-----------------------------------------------------------------------
@@ -694,7 +694,7 @@ public class TestYearWeek {
     public void test_adjustInto() {
         YearWeek yw = YearWeek.of(2016, 1);
         LocalDate date = LocalDate.of(2015, 6, 20);
-        assertEquals(yw.adjustInto(date), LocalDate.of(2016, 1, 9));
+        assertEquals(LocalDate.of(2016, 1, 9), yw.adjustInto(date));
     }
 
     @Test(expected = DateTimeException.class)
@@ -709,11 +709,11 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_range() {
-        assertEquals(TEST_NON_LEAP.range(WEEK_BASED_YEAR), WEEK_BASED_YEAR.range());
-        assertEquals(TEST.range(WEEK_BASED_YEAR), WEEK_BASED_YEAR.range());
+        assertEquals(WEEK_BASED_YEAR.range(), TEST_NON_LEAP.range(WEEK_BASED_YEAR));
+        assertEquals(WEEK_BASED_YEAR.range(), TEST.range(WEEK_BASED_YEAR));
 
-        assertEquals(TEST_NON_LEAP.range(WEEK_OF_WEEK_BASED_YEAR), ValueRange.of(1, 52));
-        assertEquals(TEST.range(WEEK_OF_WEEK_BASED_YEAR), ValueRange.of(1, 53));
+        assertEquals(ValueRange.of(1, 52), TEST_NON_LEAP.range(WEEK_OF_WEEK_BASED_YEAR));
+        assertEquals(ValueRange.of(1, 53), TEST.range(WEEK_OF_WEEK_BASED_YEAR));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -731,18 +731,18 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_withYear() {
-        assertEquals(YearWeek.of(2015, 1).withYear(2014), YearWeek.of(2014, 1));
-        assertEquals(YearWeek.of(2015, 53).withYear(2009), YearWeek.of(2009, 53));
+        assertEquals(YearWeek.of(2014, 1), YearWeek.of(2015, 1).withYear(2014));
+        assertEquals(YearWeek.of(2009, 53), YearWeek.of(2015, 53).withYear(2009));
     }
 
     @Test
     public void test_withYear_sameYear() {
-        assertEquals(YearWeek.of(2015, 1).withYear(2015), YearWeek.of(2015, 1));
+        assertEquals(YearWeek.of(2015, 1), YearWeek.of(2015, 1).withYear(2015));
     }
 
     @Test
     public void test_withYear_resolve() {
-        assertEquals(YearWeek.of(2015, 53).withYear(2014), YearWeek.of(2014, 52));
+        assertEquals(YearWeek.of(2014, 52), YearWeek.of(2015, 53).withYear(2014));
     }
 
     @Test(expected = DateTimeException.class)
@@ -760,13 +760,13 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_withWeek() {
-        assertEquals(TEST.withWeek(52), YearWeek.of(2015, 52));
-        assertEquals(YearWeek.of(2014, 1).withWeek(53), TEST);
+        assertEquals(YearWeek.of(2015, 52), TEST.withWeek(52));
+        assertEquals(TEST, YearWeek.of(2014, 1).withWeek(53));
     }
 
     @Test
     public void test_withWeek_sameWeek() {
-        assertEquals(YearWeek.of(2014, 2).withWeek(2), YearWeek.of(2014, 2));
+        assertEquals(YearWeek.of(2014, 2), YearWeek.of(2014, 2).withWeek(2));
     }
 
     @Test(expected = DateTimeException.class)
@@ -784,19 +784,19 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_plusYears() {
-        assertEquals(TEST.plusYears(-2), YearWeek.of(2013, 1));
-        assertEquals(TEST.plusYears(-1), YearWeek.of(2014, 1));
-        assertEquals(TEST.plusYears(0), TEST);
-        assertEquals(TEST.plusYears(1), YearWeek.of(2016, 1));
-        assertEquals(TEST.plusYears(2), YearWeek.of(2017, 1));
+        assertEquals(YearWeek.of(2013, 1), TEST.plusYears(-2));
+        assertEquals(YearWeek.of(2014, 1), TEST.plusYears(-1));
+        assertEquals(TEST, TEST.plusYears(0));
+        assertEquals(YearWeek.of(2016, 1), TEST.plusYears(1));
+        assertEquals(YearWeek.of(2017, 1), TEST.plusYears(2));
     }
 
     @Test
     public void test_plusYears_changeWeek() {
-        assertEquals(YearWeek.of(2015, 53).plusYears(-1), YearWeek.of(2014, 52));
-        assertEquals(YearWeek.of(2015, 53).plusYears(0), YearWeek.of(2015, 53));
-        assertEquals(YearWeek.of(2015, 53).plusYears(1), YearWeek.of(2016, 52));
-        assertEquals(YearWeek.of(2015, 53).plusYears(5), YearWeek.of(2020, 53));
+        assertEquals(YearWeek.of(2014, 52), YearWeek.of(2015, 53).plusYears(-1));
+        assertEquals(YearWeek.of(2015, 53), YearWeek.of(2015, 53).plusYears(0));
+        assertEquals(YearWeek.of(2016, 52), YearWeek.of(2015, 53).plusYears(1));
+        assertEquals(YearWeek.of(2020, 53), YearWeek.of(2015, 53).plusYears(5));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -814,24 +814,24 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_plusWeeks() {
-        assertEquals(TEST.plusWeeks(0), TEST);
-        assertEquals(TEST.plusWeeks(1), YearWeek.of(2015, 2));
-        assertEquals(TEST.plusWeeks(2), YearWeek.of(2015, 3));
-        assertEquals(TEST.plusWeeks(51), YearWeek.of(2015, 52));
-        assertEquals(TEST.plusWeeks(52), YearWeek.of(2015, 53));
-        assertEquals(TEST.plusWeeks(53), YearWeek.of(2016, 1));
-        assertEquals(TEST.plusWeeks(314), YearWeek.of(2021, 1));
+        assertEquals(TEST, TEST.plusWeeks(0));
+        assertEquals(YearWeek.of(2015, 2), TEST.plusWeeks(1));
+        assertEquals(YearWeek.of(2015, 3), TEST.plusWeeks(2));
+        assertEquals(YearWeek.of(2015, 52), TEST.plusWeeks(51));
+        assertEquals(YearWeek.of(2015, 53), TEST.plusWeeks(52));
+        assertEquals(YearWeek.of(2016, 1), TEST.plusWeeks(53));
+        assertEquals(YearWeek.of(2021, 1), TEST.plusWeeks(314));
     }
 
     @Test
     public void test_plusWeeks_negative() {
-        assertEquals(TEST.plusWeeks(0), TEST);
-        assertEquals(TEST.plusWeeks(-1), YearWeek.of(2014, 52));
-        assertEquals(TEST.plusWeeks(-2), YearWeek.of(2014, 51));
-        assertEquals(TEST.plusWeeks(-51), YearWeek.of(2014, 2));
-        assertEquals(TEST.plusWeeks(-52), YearWeek.of(2014, 1));
-        assertEquals(TEST.plusWeeks(-53), YearWeek.of(2013, 52));
-        assertEquals(TEST.plusWeeks(-261), YearWeek.of(2009, 53));
+        assertEquals(TEST, TEST.plusWeeks(0));
+        assertEquals(YearWeek.of(2014, 52), TEST.plusWeeks(-1));
+        assertEquals(YearWeek.of(2014, 51), TEST.plusWeeks(-2));
+        assertEquals(YearWeek.of(2014, 2), TEST.plusWeeks(-51));
+        assertEquals(YearWeek.of(2014, 1), TEST.plusWeeks(-52));
+        assertEquals(YearWeek.of(2013, 52), TEST.plusWeeks(-53));
+        assertEquals(YearWeek.of(2009, 53), TEST.plusWeeks(-261));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -849,19 +849,19 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_minusYears() {
-        assertEquals(TEST.minusYears(-2), YearWeek.of(2017, 1));
-        assertEquals(TEST.minusYears(-1), YearWeek.of(2016, 1));
-        assertEquals(TEST.minusYears(0), TEST);
-        assertEquals(TEST.minusYears(1), YearWeek.of(2014, 1));
-        assertEquals(TEST.minusYears(2), YearWeek.of(2013, 1));
+        assertEquals(YearWeek.of(2017, 1), TEST.minusYears(-2));
+        assertEquals(YearWeek.of(2016, 1), TEST.minusYears(-1));
+        assertEquals(TEST, TEST.minusYears(0));
+        assertEquals(YearWeek.of(2014, 1), TEST.minusYears(1));
+        assertEquals(YearWeek.of(2013, 1), TEST.minusYears(2));
     }
 
     @Test
     public void test_minusYears_changeWeek() {
-        assertEquals(YearWeek.of(2015, 53).minusYears(-5), YearWeek.of(2020, 53));
-        assertEquals(YearWeek.of(2015, 53).minusYears(-1), YearWeek.of(2016, 52));
-        assertEquals(YearWeek.of(2015, 53).minusYears(0), YearWeek.of(2015, 53));
-        assertEquals(YearWeek.of(2015, 53).minusYears(1), YearWeek.of(2014, 52));
+        assertEquals(YearWeek.of(2020, 53), YearWeek.of(2015, 53).minusYears(-5));
+        assertEquals(YearWeek.of(2016, 52), YearWeek.of(2015, 53).minusYears(-1));
+        assertEquals(YearWeek.of(2015, 53), YearWeek.of(2015, 53).minusYears(0));
+        assertEquals(YearWeek.of(2014, 52), YearWeek.of(2015, 53).minusYears(1));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -879,24 +879,24 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_minusWeeks() {
-        assertEquals(TEST.minusWeeks(0), TEST);
-        assertEquals(TEST.minusWeeks(1), YearWeek.of(2014, 52));
-        assertEquals(TEST.minusWeeks(2), YearWeek.of(2014, 51));
-        assertEquals(TEST.minusWeeks(51), YearWeek.of(2014, 2));
-        assertEquals(TEST.minusWeeks(52), YearWeek.of(2014, 1));
-        assertEquals(TEST.minusWeeks(53), YearWeek.of(2013, 52));
-        assertEquals(TEST.minusWeeks(261), YearWeek.of(2009, 53));
+        assertEquals(TEST, TEST.minusWeeks(0));
+        assertEquals(YearWeek.of(2014, 52), TEST.minusWeeks(1));
+        assertEquals(YearWeek.of(2014, 51), TEST.minusWeeks(2));
+        assertEquals(YearWeek.of(2014, 2), TEST.minusWeeks(51));
+        assertEquals(YearWeek.of(2014, 1), TEST.minusWeeks(52));
+        assertEquals(YearWeek.of(2013, 52), TEST.minusWeeks(53));
+        assertEquals(YearWeek.of(2009, 53), TEST.minusWeeks(261));
     }
 
     @Test
     public void test_minusWeeks_negative() {
-        assertEquals(TEST.minusWeeks(0), TEST);
-        assertEquals(TEST.minusWeeks(-1), YearWeek.of(2015, 2));
-        assertEquals(TEST.minusWeeks(-2), YearWeek.of(2015, 3));
-        assertEquals(TEST.minusWeeks(-51), YearWeek.of(2015, 52));
-        assertEquals(TEST.minusWeeks(-52), YearWeek.of(2015, 53));
-        assertEquals(TEST.minusWeeks(-53), YearWeek.of(2016, 1));
-        assertEquals(TEST.minusWeeks(-314), YearWeek.of(2021, 1));
+        assertEquals(TEST, TEST.minusWeeks(0));
+        assertEquals(YearWeek.of(2015, 2), TEST.minusWeeks(-1));
+        assertEquals(YearWeek.of(2015, 3), TEST.minusWeeks(-2));
+        assertEquals(YearWeek.of(2015, 52), TEST.minusWeeks(-51));
+        assertEquals(YearWeek.of(2015, 53), TEST.minusWeeks(-52));
+        assertEquals(YearWeek.of(2016, 1), TEST.minusWeeks(-53));
+        assertEquals(YearWeek.of(2021, 1), TEST.minusWeeks(-314));
     }
 
     @Test(expected = ArithmeticException.class)
@@ -914,13 +914,13 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void test_query() {
-        assertEquals(TEST.query(TemporalQueries.chronology()), IsoChronology.INSTANCE);
-        assertEquals(TEST.query(TemporalQueries.localDate()), null);
-        assertEquals(TEST.query(TemporalQueries.localTime()), null);
-        assertEquals(TEST.query(TemporalQueries.offset()), null);
-        assertEquals(TEST.query(TemporalQueries.precision()), null);
-        assertEquals(TEST.query(TemporalQueries.zone()), null);
-        assertEquals(TEST.query(TemporalQueries.zoneId()), null);
+        assertEquals(IsoChronology.INSTANCE, TEST.query(TemporalQueries.chronology()));
+        assertEquals(null, TEST.query(TemporalQueries.localDate()));
+        assertEquals(null, TEST.query(TemporalQueries.localTime()));
+        assertEquals(null, TEST.query(TemporalQueries.offset()));
+        assertEquals(null, TEST.query(TemporalQueries.precision()));
+        assertEquals(null, TEST.query(TemporalQueries.zone()));
+        assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }
 
     //-----------------------------------------------------------------------
@@ -952,7 +952,7 @@ public class TestYearWeek {
     @Test
     public void test_equals_incorrectType() {
         assertTrue(TEST.equals(null) == false);
-        assertEquals(TEST.equals("Incorrect type"), false);
+        assertEquals(false, TEST.equals("Incorrect type"));
     }
 
     //-----------------------------------------------------------------------
@@ -974,7 +974,7 @@ public class TestYearWeek {
     public void test_toString(int year, int week, String expected) {
         YearWeek yearWeek = YearWeek.of(year, week);
         String s = yearWeek.toString();
-        assertEquals(s, expected);
+        assertEquals(expected, s);
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestYears.java
+++ b/src/test/java/org/threeten/extra/TestYears.java
@@ -74,7 +74,7 @@ public class TestYears {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 
@@ -82,14 +82,14 @@ public class TestYears {
     @Test
     public void test_ZERO() {
         assertSame(Years.of(0), Years.ZERO);
-        assertSame(Years.of(0), Years.ZERO);
+        assertEquals(Years.of(0), Years.ZERO);
         assertEquals(0, Years.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Years.of(1), Years.ONE);
-        assertSame(Years.of(1), Years.ONE);
+        assertEquals(Years.of(1), Years.ONE);
         assertEquals(1, Years.ONE.getAmount());
     }
 

--- a/src/test/java/org/threeten/extra/TestYears.java
+++ b/src/test/java/org/threeten/extra/TestYears.java
@@ -83,51 +83,51 @@ public class TestYears {
     public void test_ZERO() {
         assertSame(Years.of(0), Years.ZERO);
         assertSame(Years.of(0), Years.ZERO);
-        assertEquals(Years.ZERO.getAmount(), 0);
+        assertEquals(0, Years.ZERO.getAmount());
     }
 
     @Test
     public void test_ONE() {
         assertSame(Years.of(1), Years.ONE);
         assertSame(Years.of(1), Years.ONE);
-        assertEquals(Years.ONE.getAmount(), 1);
+        assertEquals(1, Years.ONE.getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
-        assertEquals(Years.of(1).getAmount(), 1);
-        assertEquals(Years.of(2).getAmount(), 2);
-        assertEquals(Years.of(Integer.MAX_VALUE).getAmount(), Integer.MAX_VALUE);
-        assertEquals(Years.of(-1).getAmount(), -1);
-        assertEquals(Years.of(-2).getAmount(), -2);
-        assertEquals(Years.of(Integer.MIN_VALUE).getAmount(), Integer.MIN_VALUE);
+        assertEquals(1, Years.of(1).getAmount());
+        assertEquals(2, Years.of(2).getAmount());
+        assertEquals(Integer.MAX_VALUE, Years.of(Integer.MAX_VALUE).getAmount());
+        assertEquals(-1, Years.of(-1).getAmount());
+        assertEquals(-2, Years.of(-2).getAmount());
+        assertEquals(Integer.MIN_VALUE, Years.of(Integer.MIN_VALUE).getAmount());
     }
 
     //-----------------------------------------------------------------------
     @Test
     public void test_from_P0Y() {
-        assertEquals(Years.from(Period.ofYears(0)), Years.of(0));
+        assertEquals(Years.of(0), Years.from(Period.ofYears(0)));
     }
 
     @Test
     public void test_from_P2Y() {
-        assertEquals(Years.from(Period.ofYears(2)), Years.of(2));
+        assertEquals(Years.of(2), Years.from(Period.ofYears(2)));
     }
 
     @Test
     public void test_from_P24M() {
-        assertEquals(Years.from(Period.ofMonths(24)), Years.of(2));
+        assertEquals(Years.of(2), Years.from(Period.ofMonths(24)));
     }
 
     @Test
     public void test_from_yearsAndMonths() {
-        assertEquals(Years.from(Period.of(3, 24, 0)), Years.of(5));
+        assertEquals(Years.of(5), Years.from(Period.of(3, 24, 0)));
     }
 
     @Test
     public void test_from_decadesAndMonths() {
-        assertEquals(Years.from(new MockDecadesMonths(2, -12)), Years.of(19));
+        assertEquals(Years.of(19), Years.from(new MockDecadesMonths(2, -12)));
     }
 
     @Test(expected = DateTimeException.class)
@@ -148,13 +148,13 @@ public class TestYears {
     //-----------------------------------------------------------------------
     @Test
     public void test_parse_CharSequence() {
-        assertEquals(Years.parse("P0Y"), Years.of(0));
-        assertEquals(Years.parse("P1Y"), Years.of(1));
-        assertEquals(Years.parse("P2Y"), Years.of(2));
-        assertEquals(Years.parse("P123456789Y"), Years.of(123456789));
-        assertEquals(Years.parse("P-2Y"), Years.of(-2));
-        assertEquals(Years.parse("-P2Y"), Years.of(-2));
-        assertEquals(Years.parse("-P-2Y"), Years.of(2));
+        assertEquals(Years.of(0), Years.parse("P0Y"));
+        assertEquals(Years.of(1), Years.parse("P1Y"));
+        assertEquals(Years.of(2), Years.parse("P2Y"));
+        assertEquals(Years.of(123456789), Years.parse("P123456789Y"));
+        assertEquals(Years.of(-2), Years.parse("P-2Y"));
+        assertEquals(Years.of(-2), Years.parse("-P2Y"));
+        assertEquals(Years.of(2), Years.parse("-P-2Y"));
     }
 
     @DataProvider
@@ -403,7 +403,7 @@ public class TestYears {
     @Test
     public void test_toPeriod() {
         for (int i = -20; i < 20; i++) {
-            assertEquals(Years.of(i).toPeriod(), Period.ofYears(i));
+            assertEquals(Period.ofYears(i), Years.of(i).toPeriod());
         }
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
@@ -54,6 +54,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
@@ -94,12 +95,12 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_chronology_of_name() {
-        Assert.assertEquals(INSTANCE.getId(), "Accounting");
+        Assert.assertEquals("Accounting", INSTANCE.getId());
     }
 
     @Test
     public void test_chronology_of_name_id() {
-        Assert.assertEquals(INSTANCE.getCalendarType(), null);
+        Assert.assertEquals(null, INSTANCE.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -144,78 +145,78 @@ public class TestAccountingChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_AccountingDate(AccountingDate accounting, LocalDate iso) {
-        assertEquals(LocalDate.from(accounting), iso);
+        assertEquals(iso, LocalDate.from(accounting));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_AccountingDate_from_LocalDate(AccountingDate accounting, LocalDate iso) {
-        assertEquals(AccountingDate.from(INSTANCE, iso), accounting);
+        assertEquals(accounting, AccountingDate.from(INSTANCE, iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_AccountingDate_chronology_dateEpochDay(AccountingDate accounting, LocalDate iso) {
-        assertEquals(INSTANCE.dateEpochDay(iso.toEpochDay()), accounting);
+        assertEquals(accounting, INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_AccountingDate_toEpochDay(AccountingDate accounting, LocalDate iso) {
-        assertEquals(accounting.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), accounting.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_AccountingDate_until_CoptiDate(AccountingDate accounting, LocalDate iso) {
-        assertEquals(accounting.until(accounting), INSTANCE.period(0, 0, 0));
+        assertEquals(INSTANCE.period(0, 0, 0), accounting.until(accounting));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_AccountingDate_until_LocalDate(AccountingDate accounting, LocalDate iso) {
-        assertEquals(accounting.until(iso), INSTANCE.period(0, 0, 0));
+        assertEquals(INSTANCE.period(0, 0, 0), accounting.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_CoptiDate(AccountingDate accounting, LocalDate iso) {
-        assertEquals(iso.until(accounting), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(accounting));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(AccountingDate accounting, LocalDate iso) {
-        assertEquals(INSTANCE.date(iso), accounting);
+        assertEquals(accounting, INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(AccountingDate accounting, LocalDate iso) {
-        assertEquals(LocalDate.from(accounting.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(accounting.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(accounting.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(accounting.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(accounting.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(accounting.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(accounting.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(accounting.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(accounting.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(accounting.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(AccountingDate accounting, LocalDate iso) {
-        assertEquals(LocalDate.from(accounting.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(accounting.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(accounting.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(accounting.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(accounting.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(accounting.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(accounting.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(accounting.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(accounting.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(accounting.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(AccountingDate accounting, LocalDate iso) {
-        assertEquals(accounting.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(accounting.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(accounting.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(accounting.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, accounting.until(iso.plusDays(0), DAYS));
+        assertEquals(1, accounting.until(iso.plusDays(1), DAYS));
+        assertEquals(35, accounting.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, accounting.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -314,28 +315,28 @@ public class TestAccountingChronology {
         };
         for (int year = -200; year < 200; year++) {
             AccountingDate base = INSTANCE.date(year, 1, 1);
-            assertEquals(base.isLeapYear(), isLeapYear.test(year));
-            assertEquals(INSTANCE.isLeapYear(year), isLeapYear.test(year));
+            assertEquals(isLeapYear.test(year), base.isLeapYear());
+            assertEquals(isLeapYear.test(year), INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(INSTANCE.isLeapYear(8), false);
-        assertEquals(INSTANCE.isLeapYear(7), false);
-        assertEquals(INSTANCE.isLeapYear(6), true);
-        assertEquals(INSTANCE.isLeapYear(5), false);
-        assertEquals(INSTANCE.isLeapYear(4), false);
-        assertEquals(INSTANCE.isLeapYear(3), false);
-        assertEquals(INSTANCE.isLeapYear(2), false);
-        assertEquals(INSTANCE.isLeapYear(1), false);
-        assertEquals(INSTANCE.isLeapYear(0), true);
-        assertEquals(INSTANCE.isLeapYear(-1), false);
-        assertEquals(INSTANCE.isLeapYear(-2), false);
-        assertEquals(INSTANCE.isLeapYear(-3), false);
-        assertEquals(INSTANCE.isLeapYear(-4), false);
-        assertEquals(INSTANCE.isLeapYear(-5), true);
-        assertEquals(INSTANCE.isLeapYear(-6), false);
+        assertEquals(false, INSTANCE.isLeapYear(8));
+        assertEquals(false, INSTANCE.isLeapYear(7));
+        assertEquals(true, INSTANCE.isLeapYear(6));
+        assertEquals(false, INSTANCE.isLeapYear(5));
+        assertEquals(false, INSTANCE.isLeapYear(4));
+        assertEquals(false, INSTANCE.isLeapYear(3));
+        assertEquals(false, INSTANCE.isLeapYear(2));
+        assertEquals(false, INSTANCE.isLeapYear(1));
+        assertEquals(true, INSTANCE.isLeapYear(0));
+        assertEquals(false, INSTANCE.isLeapYear(-1));
+        assertEquals(false, INSTANCE.isLeapYear(-2));
+        assertEquals(false, INSTANCE.isLeapYear(-3));
+        assertEquals(false, INSTANCE.isLeapYear(-4));
+        assertEquals(true, INSTANCE.isLeapYear(-5));
+        assertEquals(false, INSTANCE.isLeapYear(-6));
     }
 
     @DataProvider
@@ -365,7 +366,7 @@ public class TestAccountingChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(INSTANCE.date(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, INSTANCE.date(year, month, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -381,7 +382,7 @@ public class TestAccountingChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             AccountingDate eraBased = INSTANCE.date(era, yoe, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -395,20 +396,20 @@ public class TestAccountingChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             AccountingDate eraBased = INSTANCE.dateYearDay(era, yoe, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.CE, 4), 4);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.CE, 3), 3);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.CE, 2), 2);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.CE, 1), 1);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.BCE, 1), 0);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.BCE, 2), -1);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.BCE, 3), -2);
-        assertEquals(INSTANCE.prolepticYear(AccountingEra.BCE, 4), -3);
+        assertEquals(4, INSTANCE.prolepticYear(AccountingEra.CE, 4));
+        assertEquals(3, INSTANCE.prolepticYear(AccountingEra.CE, 3));
+        assertEquals(2, INSTANCE.prolepticYear(AccountingEra.CE, 2));
+        assertEquals(1, INSTANCE.prolepticYear(AccountingEra.CE, 1));
+        assertEquals(0, INSTANCE.prolepticYear(AccountingEra.BCE, 1));
+        assertEquals(-1, INSTANCE.prolepticYear(AccountingEra.BCE, 2));
+        assertEquals(-2, INSTANCE.prolepticYear(AccountingEra.BCE, 3));
+        assertEquals(-3, INSTANCE.prolepticYear(AccountingEra.BCE, 4));
     }
 
     @Test(expected = ClassCastException.class)
@@ -418,8 +419,8 @@ public class TestAccountingChronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(INSTANCE.eraOf(1), AccountingEra.CE);
-        assertEquals(INSTANCE.eraOf(0), AccountingEra.BCE);
+        assertEquals(AccountingEra.CE, INSTANCE.eraOf(1));
+        assertEquals(AccountingEra.BCE, INSTANCE.eraOf(0));
     }
 
     @Test(expected = DateTimeException.class)
@@ -430,9 +431,9 @@ public class TestAccountingChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = INSTANCE.eras();
-        assertEquals(eras.size(), 2);
-        assertEquals(eras.contains(AccountingEra.BCE), true);
-        assertEquals(eras.contains(AccountingEra.CE), true);
+        assertEquals(2, eras.size());
+        assertEquals(true, eras.contains(AccountingEra.BCE));
+        assertEquals(true, eras.contains(AccountingEra.CE));
     }
 
     //-----------------------------------------------------------------------
@@ -440,11 +441,11 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 28, 35));
-        assertEquals(INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 364, 371));
-        assertEquals(INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
-        assertEquals(INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(1, 52, 53));
+        assertEquals(ValueRange.of(1, 7), INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 28, 35), INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 364, 371), INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 13), INSTANCE.range(MONTH_OF_YEAR));
+        assertEquals(ValueRange.of(1, 52, 53), INSTANCE.range(ALIGNED_WEEK_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -480,7 +481,7 @@ public class TestAccountingChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(INSTANCE.date(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), INSTANCE.date(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -515,7 +516,7 @@ public class TestAccountingChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(INSTANCE.date(year, month, dom).getLong(field), expected);
+        assertEquals(expected, INSTANCE.date(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -569,7 +570,7 @@ public class TestAccountingChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(INSTANCE.date(year, month, dom).with(field, value), INSTANCE.date(expectedYear, expectedMonth, expectedDom));
+        assertEquals(INSTANCE.date(expectedYear, expectedMonth, expectedDom), INSTANCE.date(year, month, dom).with(field, value));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -584,14 +585,14 @@ public class TestAccountingChronology {
     public void test_adjust1() {
         AccountingDate base = INSTANCE.date(2012, 6, 23);
         AccountingDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, INSTANCE.date(2012, 6, 28));
+        assertEquals(INSTANCE.date(2012, 6, 28), test);
     }
 
     @Test
     public void test_adjust2() {
         AccountingDate base = INSTANCE.date(2012, 13, 23);
         AccountingDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, INSTANCE.date(2012, 13, 35));
+        assertEquals(INSTANCE.date(2012, 13, 35), test);
     }
 
     //-----------------------------------------------------------------------
@@ -601,7 +602,7 @@ public class TestAccountingChronology {
     public void test_adjust_toLocalDate() {
         AccountingDate accounting = INSTANCE.date(2000, 1, 4);
         AccountingDate test = accounting.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, INSTANCE.date(2012, 12, 5));
+        assertEquals(INSTANCE.date(2012, 12, 5), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -617,14 +618,14 @@ public class TestAccountingChronology {
     public void test_LocalDate_adjustToAccountingDate() {
         AccountingDate accounting = INSTANCE.date(2012, 6, 23);
         LocalDate test = LocalDate.MIN.with(accounting);
-        assertEquals(test, LocalDate.of(2012, 2, 7));
+        assertEquals(LocalDate.of(2012, 2, 7), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToAccountingDate() {
         AccountingDate accounting = INSTANCE.date(2012, 6, 23);
         LocalDateTime test = LocalDateTime.MIN.with(accounting);
-        assertEquals(test, LocalDateTime.of(2012, 2, 7, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 2, 7, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -663,7 +664,7 @@ public class TestAccountingChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(INSTANCE.date(year, month, dom).plus(amount, unit), INSTANCE.date(expectedYear, expectedMonth, expectedDom));
+        assertEquals(INSTANCE.date(expectedYear, expectedMonth, expectedDom), INSTANCE.date(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -672,7 +673,7 @@ public class TestAccountingChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(INSTANCE.date(year, month, dom).minus(amount, unit), INSTANCE.date(expectedYear, expectedMonth, expectedDom));
+        assertEquals(INSTANCE.date(expectedYear, expectedMonth, expectedDom), INSTANCE.date(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -720,7 +721,7 @@ public class TestAccountingChronology {
             TemporalUnit unit, long expected) {
         AccountingDate start = INSTANCE.date(year1, month1, dom1);
         AccountingDate end = INSTANCE.date(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -733,22 +734,22 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(INSTANCE.date(2014, 5, 26).plus(INSTANCE.period(0, 2, 3)), INSTANCE.date(2014, 8, 1));
+        assertEquals(INSTANCE.date(2014, 8, 1), INSTANCE.date(2014, 5, 26).plus(INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(INSTANCE.date(2014, 5, 26).plus(Period.ofMonths(2)), INSTANCE.date(2014, 7, 26));
+        assertEquals(INSTANCE.date(2014, 7, 26), INSTANCE.date(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(INSTANCE.date(2014, 5, 26).minus(INSTANCE.period(0, 2, 3)), INSTANCE.date(2014, 3, 23));
+        assertEquals(INSTANCE.date(2014, 3, 23), INSTANCE.date(2014, 5, 26).minus(INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(INSTANCE.date(2014, 5, 26).minus(Period.ofMonths(2)), INSTANCE.date(2014, 3, 26));
+        assertEquals(INSTANCE.date(2014, 3, 26), INSTANCE.date(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -767,18 +768,18 @@ public class TestAccountingChronology {
                 .withDivision(AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS)
                 .toChronology().date(2000, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
-        assertEquals(a1.getChronology().equals(other.getChronology()), false);
-        assertEquals(a1.equals(other), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
+        assertEquals(false, a1.getChronology().equals(other.getChronology()));
+        assertEquals(false, a1.equals(other));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a1.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -795,7 +796,7 @@ public class TestAccountingChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(AccountingDate accounting, String expected) {
-        assertEquals(accounting.toString(), expected);
+        assertEquals(expected, accounting.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
@@ -102,7 +102,7 @@ public class TestAccountingChronologyBuilder {
         };
 
         for (int year = -200; year < 600; year++) {
-            assertEquals(chronology.isLeapYear(year), isLeapYear.test(year));
+            assertEquals(isLeapYear.test(year), chronology.isLeapYear(year));
         }
     }
 
@@ -123,7 +123,7 @@ public class TestAccountingChronologyBuilder {
         };
 
         for (int year = -200; year < 600; year++) {
-            assertEquals(chronology.isLeapYear(year), isLeapYear.test(year));
+            assertEquals(isLeapYear.test(year), chronology.isLeapYear(year));
         }
     }
 
@@ -147,13 +147,13 @@ public class TestAccountingChronologyBuilder {
             if (year != 1 && isLeapYear.test(year - 1)) {
                 leapYears++;
             }
-            assertEquals(chronology.previousLeapYears(year), leapYears);
+            assertEquals(leapYears, chronology.previousLeapYears(year));
         }
         for (int year = 1, leapYears = 0; year >= -200; year--) {
             if (year != 1 && isLeapYear.test(year)) {
                 leapYears--;
             }
-            assertEquals(chronology.previousLeapYears(year), leapYears);
+            assertEquals(leapYears, chronology.previousLeapYears(year));
         }
     }
 
@@ -177,13 +177,13 @@ public class TestAccountingChronologyBuilder {
             if (year != 1 && isLeapYear.test(year - 1)) {
                 leapYears++;
             }
-            assertEquals(chronology.previousLeapYears(year), leapYears);
+            assertEquals(leapYears, chronology.previousLeapYears(year));
         }
         for (int year = 1, leapYears = 0; year >= -200; year--) {
             if (year != 1 && isLeapYear.test(year)) {
                 leapYears--;
             }
-            assertEquals(chronology.previousLeapYears(year), leapYears);
+            assertEquals(leapYears, chronology.previousLeapYears(year));
         }
     }
 
@@ -199,7 +199,7 @@ public class TestAccountingChronologyBuilder {
         };
 
         for (int year = -200; year < 600; year++) {
-            assertEquals(chronology.date(year, 1, 1).toEpochDay(), getYearEnd.apply(year - 1).plusDays(1).toEpochDay());
+            assertEquals(getYearEnd.apply(year - 1).plusDays(1).toEpochDay(), chronology.date(year, 1, 1).toEpochDay());
         }
     }
 
@@ -215,7 +215,7 @@ public class TestAccountingChronologyBuilder {
         };
 
         for (int year = -200; year < 600; year++) {
-            assertEquals(chronology.date(year, 1, 1).toEpochDay(), getYearEnd.apply(year - 1).plusDays(1).toEpochDay());
+            assertEquals(getYearEnd.apply(year - 1).plusDays(1).toEpochDay(), chronology.date(year, 1, 1).toEpochDay());
         }
     }
 
@@ -277,11 +277,11 @@ public class TestAccountingChronologyBuilder {
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
                 .toChronology();
 
-        assertEquals(chronology.range(ChronoField.ALIGNED_WEEK_OF_MONTH), expectedWeekOfMonthRange);
-        assertEquals(chronology.range(ChronoField.DAY_OF_MONTH), expectedDayOfMonthRange);
-        assertEquals(chronology.range(ChronoField.DAY_OF_YEAR), ValueRange.of(1, 364, 371));
-        assertEquals(chronology.range(ChronoField.MONTH_OF_YEAR), expectedMonthRange);
-        assertEquals(chronology.range(ChronoField.PROLEPTIC_MONTH), expectedProlepticMonthRange);
+        assertEquals(expectedWeekOfMonthRange, chronology.range(ChronoField.ALIGNED_WEEK_OF_MONTH));
+        assertEquals(expectedDayOfMonthRange, chronology.range(ChronoField.DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 364, 371), chronology.range(ChronoField.DAY_OF_YEAR));
+        assertEquals(expectedMonthRange, chronology.range(ChronoField.MONTH_OF_YEAR));
+        assertEquals(expectedProlepticMonthRange, chronology.range(ChronoField.PROLEPTIC_MONTH));
     }
 
     @Test
@@ -292,10 +292,10 @@ public class TestAccountingChronologyBuilder {
                 .toChronology();
 
         for (int month = 1; month <= weeksInMonth.length; month++) {
-            assertEquals(AccountingDate.of(chronology, 2011, month, 15).range(ChronoField.DAY_OF_MONTH), ValueRange.of(1, weeksInMonth[month - 1] * 7));
-            assertEquals(AccountingDate.of(chronology, 2012, month, 15).range(ChronoField.DAY_OF_MONTH), ValueRange.of(1, weeksInMonth[month - 1] * 7 + (month == leapWeekInMonth ? 7 : 0)));
-            assertEquals(AccountingDate.of(chronology, 2011, month, 15).range(ChronoField.ALIGNED_WEEK_OF_MONTH), ValueRange.of(1, weeksInMonth[month - 1]));
-            assertEquals(AccountingDate.of(chronology, 2012, month, 15).range(ChronoField.ALIGNED_WEEK_OF_MONTH), ValueRange.of(1, weeksInMonth[month - 1] + (month == leapWeekInMonth ? 1 : 0)));
+            assertEquals(ValueRange.of(1, weeksInMonth[month - 1] * 7), AccountingDate.of(chronology, 2011, month, 15).range(ChronoField.DAY_OF_MONTH));
+            assertEquals(ValueRange.of(1, weeksInMonth[month - 1] * 7 + (month == leapWeekInMonth ? 7 : 0)), AccountingDate.of(chronology, 2012, month, 15).range(ChronoField.DAY_OF_MONTH));
+            assertEquals(ValueRange.of(1, weeksInMonth[month - 1]), AccountingDate.of(chronology, 2011, month, 15).range(ChronoField.ALIGNED_WEEK_OF_MONTH));
+            assertEquals(ValueRange.of(1, weeksInMonth[month - 1] + (month == leapWeekInMonth ? 1 : 0)), AccountingDate.of(chronology, 2012, month, 15).range(ChronoField.ALIGNED_WEEK_OF_MONTH));
         }
     }
 
@@ -316,7 +316,7 @@ public class TestAccountingChronologyBuilder {
         };
 
         for (int year = 2007; year < 2015; year++) {
-            assertEquals(AccountingDate.of(chronology, year, 3, 5).range(ChronoField.DAY_OF_YEAR), ValueRange.of(1, isLeapYear.test(year) ? 371 : 364));
+            assertEquals(ValueRange.of(1, isLeapYear.test(year) ? 371 : 364), AccountingDate.of(chronology, year, 3, 5).range(ChronoField.DAY_OF_YEAR));
         }
     }
 
@@ -337,7 +337,7 @@ public class TestAccountingChronologyBuilder {
         };
 
         for (int year = 2007; year < 2015; year++) {
-            assertEquals(AccountingDate.of(chronology, year, 3, 5).range(ChronoField.DAY_OF_YEAR), ValueRange.of(1, isLeapYear.test(year) ? 371 : 364));
+            assertEquals(ValueRange.of(1, isLeapYear.test(year) ? 371 : 364), AccountingDate.of(chronology, year, 3, 5).range(ChronoField.DAY_OF_YEAR));
         }
     }
 
@@ -381,8 +381,8 @@ public class TestAccountingChronologyBuilder {
                 .toChronology();
 
         for (int month = 1; month <= weeksInMonth.length; month++) {
-            assertEquals(chronology.getDivision().getWeeksInMonth(month), weeksInMonth[month - 1]);
-            assertEquals(chronology.getDivision().getWeeksInMonth(month, leapWeekInMonth), weeksInMonth[month - 1] + (month == leapWeekInMonth ? 1 : 0));
+            assertEquals(weeksInMonth[month - 1], chronology.getDivision().getWeeksInMonth(month));
+            assertEquals(weeksInMonth[month - 1] + (month == leapWeekInMonth ? 1 : 0), chronology.getDivision().getWeeksInMonth(month, leapWeekInMonth));
         }
     }
 
@@ -394,8 +394,8 @@ public class TestAccountingChronologyBuilder {
                 .toChronology();
 
         for (int month = 1, elapsedWeeks = 0; month <= weeksInMonth.length; elapsedWeeks += weeksInMonth[month - 1], month++) {
-            assertEquals(chronology.getDivision().getWeeksAtStartOfMonth(month), elapsedWeeks);
-            assertEquals(chronology.getDivision().getWeeksAtStartOfMonth(month, leapWeekInMonth), elapsedWeeks + (month > leapWeekInMonth ? 1 : 0));
+            assertEquals(elapsedWeeks, chronology.getDivision().getWeeksAtStartOfMonth(month));
+            assertEquals(elapsedWeeks + (month > leapWeekInMonth ? 1 : 0), chronology.getDivision().getWeeksAtStartOfMonth(month, leapWeekInMonth));
         }
     }
 
@@ -408,10 +408,10 @@ public class TestAccountingChronologyBuilder {
 
         for (int month = 1, elapsedWeeks = 0; month <= weeksInMonth.length; elapsedWeeks += weeksInMonth[month - 1], month++) {
             for (int i = 0; i < weeksInMonth[month - 1]; i++) {
-                assertEquals(chronology.getDivision().getMonthFromElapsedWeeks(elapsedWeeks + i), month);
-                assertEquals(chronology.getDivision().getMonthFromElapsedWeeks(elapsedWeeks + i + (month > leapWeekInMonth ? 1 : 0), leapWeekInMonth), month);
+                assertEquals(month, chronology.getDivision().getMonthFromElapsedWeeks(elapsedWeeks + i));
+                assertEquals(month, chronology.getDivision().getMonthFromElapsedWeeks(elapsedWeeks + i + (month > leapWeekInMonth ? 1 : 0), leapWeekInMonth));
                 if (month == leapWeekInMonth && i == weeksInMonth[month - 1] - 1) {
-                    assertEquals(chronology.getDivision().getMonthFromElapsedWeeks(elapsedWeeks + i + 1, leapWeekInMonth), month);
+                    assertEquals(month, chronology.getDivision().getMonthFromElapsedWeeks(elapsedWeeks + i + 1, leapWeekInMonth));
                 }
             }
         }
@@ -420,7 +420,7 @@ public class TestAccountingChronologyBuilder {
     @Test(expected = DateTimeException.class)
     @UseDataProvider("data_weeksInMonth")
     public void test_negativeWeeks_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
-        assertEquals(division.getMonthFromElapsedWeeks(0), 1);
+        assertEquals(1, division.getMonthFromElapsedWeeks(0));
         division.getMonthFromElapsedWeeks(-1);
     }
 
@@ -431,7 +431,7 @@ public class TestAccountingChronologyBuilder {
         for (int month = 1; month <= weeksInMonth.length; month++) {
             elapsedWeeks += weeksInMonth[month - 1];
         }
-        assertEquals(division.getMonthFromElapsedWeeks(elapsedWeeks), weeksInMonth.length);
+        assertEquals(weeksInMonth.length, division.getMonthFromElapsedWeeks(elapsedWeeks));
         division.getMonthFromElapsedWeeks(elapsedWeeks + 1);
     }
 
@@ -442,7 +442,7 @@ public class TestAccountingChronologyBuilder {
         for (int month = 1; month <= weeksInMonth.length; month++) {
             elapsedWeeks += weeksInMonth[month - 1];
         }
-        assertEquals(division.getMonthFromElapsedWeeks(elapsedWeeks, leapWeekInMonth), weeksInMonth.length);
+        assertEquals(weeksInMonth.length, division.getMonthFromElapsedWeeks(elapsedWeeks, leapWeekInMonth));
         division.getMonthFromElapsedWeeks(elapsedWeeks + 1, leapWeekInMonth);
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
@@ -54,6 +54,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -102,9 +103,9 @@ public class TestBritishCutoverChronology {
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("BritishCutover");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, BritishCutoverChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "BritishCutover");
-        Assert.assertEquals(chrono.getCalendarType(), null);
+        Assert.assertEquals(BritishCutoverChronology.INSTANCE, chrono);
+        Assert.assertEquals("BritishCutover", chrono.getId());
+        Assert.assertEquals(null, chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -158,78 +159,78 @@ public class TestBritishCutoverChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(LocalDate.from(cutover), iso);
+        assertEquals(iso, LocalDate.from(cutover));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_from_LocalDate(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(BritishCutoverDate.from(iso), cutover);
+        assertEquals(cutover, BritishCutoverDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_chronology_dateEpochDay(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(BritishCutoverChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), cutover);
+        assertEquals(cutover, BritishCutoverChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_toEpochDay(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(cutover.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), cutover.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_until_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(cutover.until(cutover), BritishCutoverChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(BritishCutoverChronology.INSTANCE.period(0, 0, 0), cutover.until(cutover));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_until_LocalDate(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(cutover.until(iso), BritishCutoverChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(BritishCutoverChronology.INSTANCE.period(0, 0, 0), cutover.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(iso.until(cutover), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(cutover));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(BritishCutoverChronology.INSTANCE.date(iso), cutover);
+        assertEquals(cutover, BritishCutoverChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(LocalDate.from(cutover.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(cutover.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(cutover.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(cutover.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(cutover.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(cutover.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(cutover.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(cutover.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(cutover.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(cutover.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(LocalDate.from(cutover.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(cutover.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(cutover.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(cutover.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(cutover.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(cutover.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(cutover.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(cutover.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(cutover.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(cutover.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(BritishCutoverDate cutover, LocalDate iso) {
-        assertEquals(cutover.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(cutover.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(cutover.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(cutover.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, cutover.until(iso.plusDays(0), DAYS));
+        assertEquals(1, cutover.until(iso.plusDays(1), DAYS));
+        assertEquals(35, cutover.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, cutover.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -293,28 +294,28 @@ public class TestBritishCutoverChronology {
     public void test_Chronology_isLeapYear_loop() {
         for (int year = -200; year < 200; year++) {
             BritishCutoverDate base = BritishCutoverDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), (year % 4) == 0);
-            assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(year), (year % 4) == 0);
+            assertEquals((year % 4) == 0, base.isLeapYear());
+            assertEquals((year % 4) == 0, BritishCutoverChronology.INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_Chronology_isLeapYear_specific() {
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(8), true);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(7), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(6), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(5), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(4), true);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(3), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(2), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(1), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(0), true);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(-1), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(-2), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(-3), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(-4), true);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(-5), false);
-        assertEquals(BritishCutoverChronology.INSTANCE.isLeapYear(-6), false);
+        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(8));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(7));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(6));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(5));
+        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(4));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(3));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(2));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(1));
+        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(0));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-1));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-2));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-3));
+        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(-4));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-5));
+        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-6));
     }
 
     //-----------------------------------------------------------------------
@@ -322,7 +323,7 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_getCutover() {
-        assertEquals(BritishCutoverChronology.INSTANCE.getCutover(), LocalDate.of(1752, 9, 14));
+        assertEquals(LocalDate.of(1752, 9, 14), BritishCutoverChronology.INSTANCE.getCutover());
     }
 
     //-----------------------------------------------------------------------
@@ -400,7 +401,7 @@ public class TestBritishCutoverChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(BritishCutoverDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, BritishCutoverDate.of(year, month, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -441,13 +442,13 @@ public class TestBritishCutoverChronology {
     @Test
     @UseDataProvider("data_lengthOfYear")
     public void test_lengthOfYear_atStart(int year, int length) {
-        assertEquals(BritishCutoverDate.of(year, 1, 1).lengthOfYear(), length);
+        assertEquals(length, BritishCutoverDate.of(year, 1, 1).lengthOfYear());
     }
 
     @Test
     @UseDataProvider("data_lengthOfYear")
     public void test_lengthOfYear_atEnd(int year, int length) {
-        assertEquals(BritishCutoverDate.of(year, 12, 31).lengthOfYear(), length);
+        assertEquals(length, BritishCutoverDate.of(year, 12, 31).lengthOfYear());
     }
 
     //-----------------------------------------------------------------------
@@ -463,7 +464,7 @@ public class TestBritishCutoverChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             BritishCutoverDate eraBased = BritishCutoverChronology.INSTANCE.date(era, yoe, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -477,32 +478,32 @@ public class TestBritishCutoverChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             BritishCutoverDate eraBased = BritishCutoverChronology.INSTANCE.dateYearDay(era, yoe, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_era_yearDay() {
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 1), BritishCutoverDate.of(1752, 1, 1));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 244), BritishCutoverDate.of(1752, 8, 31));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 246), BritishCutoverDate.of(1752, 9, 2));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 247), BritishCutoverDate.of(1752, 9, 14));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 257), BritishCutoverDate.of(1752, 9, 24));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 258), BritishCutoverDate.of(1752, 9, 25));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(1752, 355), BritishCutoverDate.of(1752, 12, 31));
-        assertEquals(BritishCutoverChronology.INSTANCE.dateYearDay(2014, 1), BritishCutoverDate.of(2014, 1, 1));
+        assertEquals(BritishCutoverDate.of(1752, 1, 1), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 1));
+        assertEquals(BritishCutoverDate.of(1752, 8, 31), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 244));
+        assertEquals(BritishCutoverDate.of(1752, 9, 2), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 246));
+        assertEquals(BritishCutoverDate.of(1752, 9, 14), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 247));
+        assertEquals(BritishCutoverDate.of(1752, 9, 24), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 257));
+        assertEquals(BritishCutoverDate.of(1752, 9, 25), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 258));
+        assertEquals(BritishCutoverDate.of(1752, 12, 31), BritishCutoverChronology.INSTANCE.dateYearDay(1752, 355));
+        assertEquals(BritishCutoverDate.of(2014, 1, 1), BritishCutoverChronology.INSTANCE.dateYearDay(2014, 1));
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 4), 4);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 3), 3);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 2), 2);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 1), 1);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 1), 0);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 2), -1);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 3), -2);
-        assertEquals(BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 4), -3);
+        assertEquals(4, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 4));
+        assertEquals(3, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 3));
+        assertEquals(2, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 2));
+        assertEquals(1, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.AD, 1));
+        assertEquals(0, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 1));
+        assertEquals(-1, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 2));
+        assertEquals(-2, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 3));
+        assertEquals(-3, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 4));
     }
 
     @Test(expected = ClassCastException.class)
@@ -512,8 +513,8 @@ public class TestBritishCutoverChronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(BritishCutoverChronology.INSTANCE.eraOf(1), JulianEra.AD);
-        assertEquals(BritishCutoverChronology.INSTANCE.eraOf(0), JulianEra.BC);
+        assertEquals(JulianEra.AD, BritishCutoverChronology.INSTANCE.eraOf(1));
+        assertEquals(JulianEra.BC, BritishCutoverChronology.INSTANCE.eraOf(0));
     }
 
     @Test(expected = DateTimeException.class)
@@ -524,9 +525,9 @@ public class TestBritishCutoverChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = BritishCutoverChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
-        assertEquals(eras.contains(JulianEra.BC), true);
-        assertEquals(eras.contains(JulianEra.AD), true);
+        assertEquals(2, eras.size());
+        assertEquals(true, eras.contains(JulianEra.BC));
+        assertEquals(true, eras.contains(JulianEra.AD));
     }
 
     //-----------------------------------------------------------------------
@@ -534,12 +535,12 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(BritishCutoverChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(BritishCutoverChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 28, 31));
-        assertEquals(BritishCutoverChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 355, 366));
-        assertEquals(BritishCutoverChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 12));
-        assertEquals(BritishCutoverChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH), ValueRange.of(1, 3, 5));
-        assertEquals(BritishCutoverChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(1, 51, 53));
+        assertEquals(ValueRange.of(1, 7), BritishCutoverChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 28, 31), BritishCutoverChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 355, 366), BritishCutoverChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 12), BritishCutoverChronology.INSTANCE.range(MONTH_OF_YEAR));
+        assertEquals(ValueRange.of(1, 3, 5), BritishCutoverChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(ValueRange.of(1, 51, 53), BritishCutoverChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -634,7 +635,7 @@ public class TestBritishCutoverChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(BritishCutoverDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), BritishCutoverDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -696,7 +697,7 @@ public class TestBritishCutoverChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(BritishCutoverDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, BritishCutoverDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -810,7 +811,7 @@ public class TestBritishCutoverChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(BritishCutoverDate.of(year, month, dom).with(field, value), BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom), BritishCutoverDate.of(year, month, dom).with(field, value));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -837,7 +838,7 @@ public class TestBritishCutoverChronology {
     @UseDataProvider("data_lastDayOfMonth")
     public void test_adjust_lastDayOfMonth(BritishCutoverDate input, BritishCutoverDate expected) {
         BritishCutoverDate test = input.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, expected);
+        assertEquals(expected, test);
     }
 
     //-----------------------------------------------------------------------
@@ -858,7 +859,7 @@ public class TestBritishCutoverChronology {
     @UseDataProvider("data_withLocalDate")
     public void test_adjust_LocalDate(BritishCutoverDate input, LocalDate local, BritishCutoverDate expected) {
         BritishCutoverDate test = input.with(local);
-        assertEquals(test, expected);
+        assertEquals(expected, test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -874,14 +875,14 @@ public class TestBritishCutoverChronology {
     public void test_LocalDate_withBritishCutoverDate() {
         BritishCutoverDate cutover = BritishCutoverDate.of(2012, 6, 23);
         LocalDate test = LocalDate.MIN.with(cutover);
-        assertEquals(test, LocalDate.of(2012, 6, 23));
+        assertEquals(LocalDate.of(2012, 6, 23), test);
     }
 
     @Test
     public void test_LocalDateTime_withBritishCutoverDate() {
         BritishCutoverDate cutover = BritishCutoverDate.of(2012, 6, 23);
         LocalDateTime test = LocalDateTime.MIN.with(cutover);
-        assertEquals(test, LocalDateTime.of(2012, 6, 23, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 6, 23, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -944,7 +945,7 @@ public class TestBritishCutoverChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom, boolean bidi) {
-        assertEquals(BritishCutoverDate.of(year, month, dom).plus(amount, unit), BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom), BritishCutoverDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -954,7 +955,7 @@ public class TestBritishCutoverChronology {
             long amount, TemporalUnit unit,
             int year, int month, int dom, boolean bidi) {
         if (bidi) {
-            assertEquals(BritishCutoverDate.of(year, month, dom).minus(amount, unit), BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom));
+            assertEquals(BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom), BritishCutoverDate.of(year, month, dom).minus(amount, unit));
         }
     }
 
@@ -1027,7 +1028,7 @@ public class TestBritishCutoverChronology {
             TemporalUnit unit, long expected) {
         BritishCutoverDate start = BritishCutoverDate.of(year1, month1, dom1);
         BritishCutoverDate end = BritishCutoverDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -1041,38 +1042,38 @@ public class TestBritishCutoverChronology {
     @Test
     public void test_plus_Period() {
         assertEquals(
-            BritishCutoverDate.of(1752, 9, 2).plus(BritishCutoverChronology.INSTANCE.period(0, 1, 3)),
-            BritishCutoverDate.of(1752, 10, 5));
+            BritishCutoverDate.of(1752, 10, 5),
+            BritishCutoverDate.of(1752, 9, 2).plus(BritishCutoverChronology.INSTANCE.period(0, 1, 3)));
         assertEquals(
-            BritishCutoverDate.of(1752, 8, 12).plus(BritishCutoverChronology.INSTANCE.period(0, 1, 0)),
-            BritishCutoverDate.of(1752, 9, 23));
+            BritishCutoverDate.of(1752, 9, 23),
+            BritishCutoverDate.of(1752, 8, 12).plus(BritishCutoverChronology.INSTANCE.period(0, 1, 0)));
         assertEquals(
-            BritishCutoverDate.of(2014, 5, 26).plus(BritishCutoverChronology.INSTANCE.period(0, 2, 3)),
-            BritishCutoverDate.of(2014, 7, 29));
+            BritishCutoverDate.of(2014, 7, 29),
+            BritishCutoverDate.of(2014, 5, 26).plus(BritishCutoverChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
         assertEquals(
-            BritishCutoverDate.of(2014, 5, 26).plus(Period.ofMonths(2)),
-            BritishCutoverDate.of(2014, 7, 26));
+            BritishCutoverDate.of(2014, 7, 26),
+            BritishCutoverDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
         assertEquals(
-            BritishCutoverDate.of(1752, 10, 12).minus(BritishCutoverChronology.INSTANCE.period(0, 1, 0)),
-            BritishCutoverDate.of(1752, 9, 23));
+            BritishCutoverDate.of(1752, 9, 23),
+            BritishCutoverDate.of(1752, 10, 12).minus(BritishCutoverChronology.INSTANCE.period(0, 1, 0)));
         assertEquals(
-            BritishCutoverDate.of(2014, 5, 26).minus(BritishCutoverChronology.INSTANCE.period(0, 2, 3)),
-            BritishCutoverDate.of(2014, 3, 23));
+            BritishCutoverDate.of(2014, 3, 23),
+            BritishCutoverDate.of(2014, 5, 26).minus(BritishCutoverChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
         assertEquals(
-            BritishCutoverDate.of(2014, 5, 26).minus(Period.ofMonths(2)),
-            BritishCutoverDate.of(2014, 3, 26));
+            BritishCutoverDate.of(2014, 3, 26),
+            BritishCutoverDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -1232,8 +1233,8 @@ public class TestBritishCutoverChronology {
         BritishCutoverDate b = BritishCutoverDate.of(year2, month2, dom2);
         ChronoPeriod c = a.until(b);
         assertEquals(
-            c,
-            BritishCutoverChronology.INSTANCE.period(expectedYears, expectedMonths, expectedDays));
+            BritishCutoverChronology.INSTANCE.period(expectedYears, expectedMonths, expectedDays),
+            c);
     }
 
     @Test
@@ -1245,7 +1246,7 @@ public class TestBritishCutoverChronology {
         BritishCutoverDate a = BritishCutoverDate.of(year1, month1, dom1);
         BritishCutoverDate b = BritishCutoverDate.of(year2, month2, dom2);
         ChronoPeriod c = a.until(b);
-        assertEquals(a.plus(c), b);
+        assertEquals(b, a.plus(c));
     }
 
     //-------------------------------------------------------------------------
@@ -1255,11 +1256,11 @@ public class TestBritishCutoverChronology {
     public void test_atTime() {
         BritishCutoverDate date = BritishCutoverDate.of(2014, 10, 12);
         ChronoLocalDateTime<BritishCutoverDate> test = date.atTime(LocalTime.of(12, 30));
-        assertEquals(test.toLocalDate(), date);
-        assertEquals(test.toLocalTime(), LocalTime.of(12, 30));
+        assertEquals(date, test.toLocalDate());
+        assertEquals(LocalTime.of(12, 30), test.toLocalTime());
         ChronoLocalDateTime<BritishCutoverDate> test2 =
             BritishCutoverChronology.INSTANCE.localDateTime(LocalDateTime.from(test));
-        assertEquals(test2, test);
+        assertEquals(test, test2);
     }
 
     @Test(expected = NullPointerException.class)
@@ -1280,10 +1281,10 @@ public class TestBritishCutoverChronology {
         gcal.clear();
         gcal.set(1700, Calendar.JANUARY, 1);
         while (test.isBefore(end)) {
-            assertEquals(test.get(YEAR_OF_ERA), gcal.get(Calendar.YEAR));
-            assertEquals(test.get(MONTH_OF_YEAR), gcal.get(Calendar.MONTH) + 1);
-            assertEquals(test.get(DAY_OF_MONTH), gcal.get(Calendar.DAY_OF_MONTH));
-            assertEquals(LocalDate.from(test), gcal.toZonedDateTime().toLocalDate());
+            assertEquals(gcal.get(Calendar.YEAR), test.get(YEAR_OF_ERA));
+            assertEquals(gcal.get(Calendar.MONTH) + 1, test.get(MONTH_OF_YEAR));
+            assertEquals(gcal.get(Calendar.DAY_OF_MONTH), test.get(DAY_OF_MONTH));
+            assertEquals(gcal.toZonedDateTime().toLocalDate(), LocalDate.from(test));
             gcal.add(Calendar.DAY_OF_MONTH, 1);
             test = test.plus(1, DAYS);
         }
@@ -1300,16 +1301,16 @@ public class TestBritishCutoverChronology {
         BritishCutoverDate c = BritishCutoverDate.of(2000, 2, 3);
         BritishCutoverDate d = BritishCutoverDate.of(2001, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -1326,7 +1327,7 @@ public class TestBritishCutoverChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(BritishCutoverDate cutover, String expected) {
-        assertEquals(cutover.toString(), expected);
+        assertEquals(expected, cutover.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
@@ -54,6 +54,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -91,18 +92,18 @@ public class TestCopticChronology {
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Coptic");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, CopticChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Coptic");
-        Assert.assertEquals(chrono.getCalendarType(), "coptic");
+        Assert.assertEquals(CopticChronology.INSTANCE, chrono);
+        Assert.assertEquals("Coptic", chrono.getId());
+        Assert.assertEquals("coptic", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("coptic");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, CopticChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Coptic");
-        Assert.assertEquals(chrono.getCalendarType(), "coptic");
+        Assert.assertEquals(CopticChronology.INSTANCE, chrono);
+        Assert.assertEquals("Coptic", chrono.getId());
+        Assert.assertEquals("coptic", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -139,78 +140,78 @@ public class TestCopticChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_CopticDate(CopticDate coptic, LocalDate iso) {
-        assertEquals(LocalDate.from(coptic), iso);
+        assertEquals(iso, LocalDate.from(coptic));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_CopticDate_from_LocalDate(CopticDate coptic, LocalDate iso) {
-        assertEquals(CopticDate.from(iso), coptic);
+        assertEquals(coptic, CopticDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_CopticDate_chronology_dateEpochDay(CopticDate coptic, LocalDate iso) {
-        assertEquals(CopticChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), coptic);
+        assertEquals(coptic, CopticChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_CopticDate_toEpochDay(CopticDate coptic, LocalDate iso) {
-        assertEquals(coptic.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), coptic.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_CopticDate_until_CopticDate(CopticDate coptic, LocalDate iso) {
-        assertEquals(coptic.until(coptic), CopticChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(CopticChronology.INSTANCE.period(0, 0, 0), coptic.until(coptic));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_CopticDate_until_LocalDate(CopticDate coptic, LocalDate iso) {
-        assertEquals(coptic.until(iso), CopticChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(CopticChronology.INSTANCE.period(0, 0, 0), coptic.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_CopticDate(CopticDate coptic, LocalDate iso) {
-        assertEquals(iso.until(coptic), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(coptic));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(CopticDate coptic, LocalDate iso) {
-        assertEquals(CopticChronology.INSTANCE.date(iso), coptic);
+        assertEquals(coptic, CopticChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(CopticDate coptic, LocalDate iso) {
-        assertEquals(LocalDate.from(coptic.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(coptic.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(coptic.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(coptic.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(coptic.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(coptic.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(coptic.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(coptic.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(coptic.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(coptic.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(CopticDate coptic, LocalDate iso) {
-        assertEquals(LocalDate.from(coptic.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(coptic.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(coptic.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(coptic.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(coptic.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(coptic.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(coptic.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(coptic.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(coptic.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(coptic.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(CopticDate coptic, LocalDate iso) {
-        assertEquals(coptic.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(coptic.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(coptic.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(coptic.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, coptic.until(iso.plusDays(0), DAYS));
+        assertEquals(1, coptic.until(iso.plusDays(1), DAYS));
+        assertEquals(35, coptic.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, coptic.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -263,28 +264,28 @@ public class TestCopticChronology {
     public void test_isLeapYear_loop() {
         for (int year = -200; year < 200; year++) {
             CopticDate base = CopticDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), ((year - 3) % 4) == 0);
-            assertEquals(CopticChronology.INSTANCE.isLeapYear(year), ((year + 400 - 3) % 4) == 0);
+            assertEquals(((year - 3) % 4) == 0, base.isLeapYear());
+            assertEquals(((year + 400 - 3) % 4) == 0, CopticChronology.INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(8), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(7), true);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(6), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(5), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(4), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(3), true);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(2), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(1), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(0), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(-1), true);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(-2), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(-3), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(-4), false);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(-5), true);
-        assertEquals(CopticChronology.INSTANCE.isLeapYear(-6), false);
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(8));
+        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(7));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(6));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(5));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(4));
+        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(3));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(2));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(1));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(0));
+        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(-1));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-2));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-3));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-4));
+        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(-5));
+        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-6));
     }
 
     @DataProvider
@@ -310,7 +311,7 @@ public class TestCopticChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(CopticDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, CopticDate.of(year, month, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -326,7 +327,7 @@ public class TestCopticChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             CopticDate eraBased = CopticChronology.INSTANCE.date(era, yoe, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -340,26 +341,26 @@ public class TestCopticChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             CopticDate eraBased = CopticChronology.INSTANCE.dateYearDay(era, yoe, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 4), 4);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 3), 3);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 2), 2);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 1), 1);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 1), 0);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 2), -1);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 3), -2);
-        assertEquals(CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 4), -3);
+        assertEquals(4, CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 4));
+        assertEquals(3, CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 3));
+        assertEquals(2, CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 2));
+        assertEquals(1, CopticChronology.INSTANCE.prolepticYear(CopticEra.AM, 1));
+        assertEquals(0, CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 1));
+        assertEquals(-1, CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 2));
+        assertEquals(-2, CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 3));
+        assertEquals(-3, CopticChronology.INSTANCE.prolepticYear(CopticEra.BEFORE_AM, 4));
     }
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(CopticChronology.INSTANCE.eraOf(1), CopticEra.AM);
-        assertEquals(CopticChronology.INSTANCE.eraOf(0), CopticEra.BEFORE_AM);
+        assertEquals(CopticEra.AM, CopticChronology.INSTANCE.eraOf(1));
+        assertEquals(CopticEra.BEFORE_AM, CopticChronology.INSTANCE.eraOf(0));
     }
 
     @Test(expected = DateTimeException.class)
@@ -370,9 +371,9 @@ public class TestCopticChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = CopticChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
-        assertEquals(eras.contains(CopticEra.BEFORE_AM), true);
-        assertEquals(eras.contains(CopticEra.AM), true);
+        assertEquals(2, eras.size());
+        assertEquals(true, eras.contains(CopticEra.BEFORE_AM));
+        assertEquals(true, eras.contains(CopticEra.AM));
     }
 
     //-----------------------------------------------------------------------
@@ -380,10 +381,10 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(CopticChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(CopticChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 5, 30));
-        assertEquals(CopticChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
-        assertEquals(CopticChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
+        assertEquals(ValueRange.of(1, 7), CopticChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 5, 30), CopticChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 365, 366), CopticChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 13), CopticChronology.INSTANCE.range(MONTH_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -421,7 +422,7 @@ public class TestCopticChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(CopticDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), CopticDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -456,7 +457,7 @@ public class TestCopticChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(CopticDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, CopticDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -508,7 +509,7 @@ public class TestCopticChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(CopticDate.of(year, month, dom).with(field, value), CopticDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(CopticDate.of(expectedYear, expectedMonth, expectedDom), CopticDate.of(year, month, dom).with(field, value));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -523,14 +524,14 @@ public class TestCopticChronology {
     public void test_adjust1() {
         CopticDate base = CopticDate.of(1728, 10, 29);
         CopticDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, CopticDate.of(1728, 10, 30));
+        assertEquals(CopticDate.of(1728, 10, 30), test);
     }
 
     @Test
     public void test_adjust2() {
         CopticDate base = CopticDate.of(1728, 13, 2);
         CopticDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, CopticDate.of(1728, 13, 5));
+        assertEquals(CopticDate.of(1728, 13, 5), test);
     }
 
     //-----------------------------------------------------------------------
@@ -540,7 +541,7 @@ public class TestCopticChronology {
     public void test_adjust_toLocalDate() {
         CopticDate coptic = CopticDate.of(1726, 1, 4);
         CopticDate test = coptic.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, CopticDate.of(1728, 10, 29));
+        assertEquals(CopticDate.of(1728, 10, 29), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -556,14 +557,14 @@ public class TestCopticChronology {
     public void test_LocalDate_adjustToCopticDate() {
         CopticDate coptic = CopticDate.of(1728, 10, 29);
         LocalDate test = LocalDate.MIN.with(coptic);
-        assertEquals(test, LocalDate.of(2012, 7, 6));
+        assertEquals(LocalDate.of(2012, 7, 6), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToCopticDate() {
         CopticDate coptic = CopticDate.of(1728, 10, 29);
         LocalDateTime test = LocalDateTime.MIN.with(coptic);
-        assertEquals(test, LocalDateTime.of(2012, 7, 6, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 7, 6, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -602,7 +603,7 @@ public class TestCopticChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(CopticDate.of(year, month, dom).plus(amount, unit), CopticDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(CopticDate.of(expectedYear, expectedMonth, expectedDom), CopticDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -611,7 +612,7 @@ public class TestCopticChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(CopticDate.of(year, month, dom).minus(amount, unit), CopticDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(CopticDate.of(expectedYear, expectedMonth, expectedDom), CopticDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -622,22 +623,22 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(CopticDate.of(1727, 5, 26).plus(CopticChronology.INSTANCE.period(0, 2, 3)), CopticDate.of(1727, 7, 29));
+        assertEquals(CopticDate.of(1727, 7, 29), CopticDate.of(1727, 5, 26).plus(CopticChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(CopticDate.of(1727, 5, 26).plus(Period.ofMonths(2)), CopticDate.of(1727, 7, 26));
+        assertEquals(CopticDate.of(1727, 7, 26), CopticDate.of(1727, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(CopticDate.of(1727, 5, 26).minus(CopticChronology.INSTANCE.period(0, 2, 3)), CopticDate.of(1727, 3, 23));
+        assertEquals(CopticDate.of(1727, 3, 23), CopticDate.of(1727, 5, 26).minus(CopticChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(CopticDate.of(1727, 5, 26).minus(Period.ofMonths(2)), CopticDate.of(1727, 3, 26));
+        assertEquals(CopticDate.of(1727, 3, 26), CopticDate.of(1727, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -678,7 +679,7 @@ public class TestCopticChronology {
             TemporalUnit unit, long expected) {
         CopticDate start = CopticDate.of(year1, month1, dom1);
         CopticDate end = CopticDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -699,16 +700,16 @@ public class TestCopticChronology {
         CopticDate c = CopticDate.of(1728, 2, 3);
         CopticDate d = CopticDate.of(1729, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -728,7 +729,7 @@ public class TestCopticChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(CopticDate coptic, String expected) {
-        assertEquals(coptic.toString(), expected);
+        assertEquals(expected, coptic.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
@@ -55,6 +55,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -94,18 +95,18 @@ public class TestDiscordianChronology {
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Discordian");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, DiscordianChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Discordian");
-        Assert.assertEquals(chrono.getCalendarType(), "discordian");
+        Assert.assertEquals(DiscordianChronology.INSTANCE, chrono);
+        Assert.assertEquals("Discordian", chrono.getId());
+        Assert.assertEquals("discordian", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("discordian");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, DiscordianChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Discordian");
-        Assert.assertEquals(chrono.getCalendarType(), "discordian");
+        Assert.assertEquals(DiscordianChronology.INSTANCE, chrono);
+        Assert.assertEquals("Discordian", chrono.getId());
+        Assert.assertEquals("discordian", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -155,78 +156,78 @@ public class TestDiscordianChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(LocalDate.from(discordian), iso);
+        assertEquals(iso, LocalDate.from(discordian));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_from_LocalDate(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(DiscordianDate.from(iso), discordian);
+        assertEquals(discordian, DiscordianDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_chronology_dateEpochDay(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(DiscordianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), discordian);
+        assertEquals(discordian, DiscordianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_toEpochDay(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(discordian.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), discordian.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_until_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(discordian.until(discordian), DiscordianChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(DiscordianChronology.INSTANCE.period(0, 0, 0), discordian.until(discordian));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_until_LocalDate(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(discordian.until(iso), DiscordianChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(DiscordianChronology.INSTANCE.period(0, 0, 0), discordian.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(iso.until(discordian), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(discordian));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(DiscordianChronology.INSTANCE.date(iso), discordian);
+        assertEquals(discordian, DiscordianChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(LocalDate.from(discordian.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(discordian.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(discordian.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(discordian.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(discordian.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(discordian.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(discordian.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(discordian.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(discordian.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(discordian.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(LocalDate.from(discordian.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(discordian.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(discordian.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(discordian.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(discordian.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(discordian.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(discordian.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(discordian.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(discordian.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(discordian.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(DiscordianDate discordian, LocalDate iso) {
-        assertEquals(discordian.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(discordian.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(discordian.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(discordian.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, discordian.until(iso.plusDays(0), DAYS));
+        assertEquals(1, discordian.until(iso.plusDays(1), DAYS));
+        assertEquals(35, discordian.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, discordian.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -277,28 +278,28 @@ public class TestDiscordianChronology {
         };
         for (int year = 1066; year < 1567; year++) {
             DiscordianDate base = DiscordianDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), isLeapYear.test(year));
-            assertEquals(DiscordianChronology.INSTANCE.isLeapYear(year), isLeapYear.test(year));
+            assertEquals(isLeapYear.test(year), base.isLeapYear());
+            assertEquals(isLeapYear.test(year), DiscordianChronology.INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1174), true);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1173), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1172), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1171), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1170), true);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1169), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1168), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1167), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1166), true);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1165), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1164), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1163), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1162), true);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1161), false);
-        assertEquals(DiscordianChronology.INSTANCE.isLeapYear(1160), false);
+        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1174));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1173));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1172));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1171));
+        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1170));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1169));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1168));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1167));
+        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1166));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1165));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1164));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1163));
+        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1162));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1161));
+        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1160));
     }
 
     @DataProvider
@@ -322,14 +323,14 @@ public class TestDiscordianChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(DiscordianDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, DiscordianDate.of(year, month, 1).lengthOfMonth());
     }
 
     @Test
     public void test_lengthOfMonth_specific() {
-        assertEquals(DiscordianDate.of(3178, 0, 0).lengthOfMonth(), 1);
-        assertEquals(DiscordianDate.of(3178, 1, 1).lengthOfMonth(), 73);
-        assertEquals(DiscordianDate.of(3178, 1, 73).lengthOfMonth(), 73);
+        assertEquals(1, DiscordianDate.of(3178, 0, 0).lengthOfMonth());
+        assertEquals(73, DiscordianDate.of(3178, 1, 1).lengthOfMonth());
+        assertEquals(73, DiscordianDate.of(3178, 1, 73).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -343,7 +344,7 @@ public class TestDiscordianChronology {
             assertEquals(DiscordianEra.YOLD, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             DiscordianDate eraBased = DiscordianChronology.INSTANCE.date(DiscordianEra.YOLD, year, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -355,16 +356,16 @@ public class TestDiscordianChronology {
             assertEquals(DiscordianEra.YOLD, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             DiscordianDate eraBased = DiscordianChronology.INSTANCE.dateYearDay(DiscordianEra.YOLD, year, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 4), 4);
-        assertEquals(DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 3), 3);
-        assertEquals(DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 2), 2);
-        assertEquals(DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 1), 1);
+        assertEquals(4, DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 4));
+        assertEquals(3, DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 3));
+        assertEquals(2, DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 2));
+        assertEquals(1, DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 1));
     }
 
     @Test(expected = ClassCastException.class)
@@ -374,7 +375,7 @@ public class TestDiscordianChronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(DiscordianChronology.INSTANCE.eraOf(1), DiscordianEra.YOLD);
+        assertEquals(DiscordianEra.YOLD, DiscordianChronology.INSTANCE.eraOf(1));
     }
 
     @Test(expected = DateTimeException.class)
@@ -386,8 +387,8 @@ public class TestDiscordianChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = DiscordianChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 1);
-        assertEquals(eras.contains(DiscordianEra.YOLD), true);
+        assertEquals(1, eras.size());
+        assertEquals(true, eras.contains(DiscordianEra.YOLD));
     }
 
     //-----------------------------------------------------------------------
@@ -395,19 +396,19 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(DiscordianChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH), ValueRange.of(0, 1, 0, 5));
-        assertEquals(DiscordianChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR), ValueRange.of(0, 1, 5, 5));
-        assertEquals(DiscordianChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH), ValueRange.of(0, 1, 0, 15));
-        assertEquals(DiscordianChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(0, 1, 73, 73));
-        assertEquals(DiscordianChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(0, 1, 0, 5));
-        assertEquals(DiscordianChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(0, 1, 0, 73));
-        assertEquals(DiscordianChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
-        assertEquals(DiscordianChronology.INSTANCE.range(EPOCH_DAY), ValueRange.of(-1_145_400, 999_999 * 365L + 242_499));
-        assertEquals(DiscordianChronology.INSTANCE.range(ERA), ValueRange.of(1, 1));
-        assertEquals(DiscordianChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(0, 1, 5, 5));
-        assertEquals(DiscordianChronology.INSTANCE.range(PROLEPTIC_MONTH), ValueRange.of(0, 999_999 * 5L + 5 - 1));
-        assertEquals(DiscordianChronology.INSTANCE.range(YEAR), ValueRange.of(1, 999_999));
-        assertEquals(DiscordianChronology.INSTANCE.range(YEAR_OF_ERA), ValueRange.of(1, 999_999));
+        assertEquals(ValueRange.of(0, 1, 0, 5), DiscordianChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(ValueRange.of(0, 1, 5, 5), DiscordianChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(ValueRange.of(0, 1, 0, 15), DiscordianChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(ValueRange.of(0, 1, 73, 73), DiscordianChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(ValueRange.of(0, 1, 0, 5), DiscordianChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(0, 1, 0, 73), DiscordianChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 365, 366), DiscordianChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(-1_145_400, 999_999 * 365L + 242_499), DiscordianChronology.INSTANCE.range(EPOCH_DAY));
+        assertEquals(ValueRange.of(1, 1), DiscordianChronology.INSTANCE.range(ERA));
+        assertEquals(ValueRange.of(0, 1, 5, 5), DiscordianChronology.INSTANCE.range(MONTH_OF_YEAR));
+        assertEquals(ValueRange.of(0, 999_999 * 5L + 5 - 1), DiscordianChronology.INSTANCE.range(PROLEPTIC_MONTH));
+        assertEquals(ValueRange.of(1, 999_999), DiscordianChronology.INSTANCE.range(YEAR));
+        assertEquals(ValueRange.of(1, 999_999), DiscordianChronology.INSTANCE.range(YEAR_OF_ERA));
     }
 
     //-----------------------------------------------------------------------
@@ -458,7 +459,7 @@ public class TestDiscordianChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(DiscordianDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), DiscordianDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -512,7 +513,7 @@ public class TestDiscordianChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(DiscordianDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, DiscordianDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -603,7 +604,7 @@ public class TestDiscordianChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(DiscordianDate.of(year, month, dom).with(field, value), DiscordianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).with(field, value));
     }
 
     @DataProvider
@@ -649,14 +650,14 @@ public class TestDiscordianChronology {
     public void test_adjust1() {
         DiscordianDate base = DiscordianDate.of(2014, 0, 0);
         DiscordianDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, DiscordianDate.of(2014, 0, 0));
+        assertEquals(DiscordianDate.of(2014, 0, 0), test);
     }
 
     @Test
     public void test_adjust2() {
         DiscordianDate base = DiscordianDate.of(2012, 2, 23);
         DiscordianDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, DiscordianDate.of(2012, 2, 73));
+        assertEquals(DiscordianDate.of(2012, 2, 73), test);
     }
 
     //-----------------------------------------------------------------------
@@ -666,7 +667,7 @@ public class TestDiscordianChronology {
     public void test_adjust_toLocalDate() {
         DiscordianDate discordian = DiscordianDate.of(2000, 1, 4);
         DiscordianDate test = discordian.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, DiscordianDate.of(3178, 3, 41));
+        assertEquals(DiscordianDate.of(3178, 3, 41), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -682,14 +683,14 @@ public class TestDiscordianChronology {
     public void test_LocalDate_adjustToDiscordianDate() {
         DiscordianDate discordian = DiscordianDate.of(3178, 3, 41);
         LocalDate test = LocalDate.MIN.with(discordian);
-        assertEquals(test, LocalDate.of(2012, 7, 6));
+        assertEquals(LocalDate.of(2012, 7, 6), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToDiscordianDate() {
         DiscordianDate discordian = DiscordianDate.of(3178, 3, 41);
         LocalDateTime test = LocalDateTime.MIN.with(discordian);
-        assertEquals(test, LocalDateTime.of(2012, 7, 6, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 7, 6, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -769,7 +770,7 @@ public class TestDiscordianChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(DiscordianDate.of(year, month, dom).plus(amount, unit), DiscordianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -777,7 +778,7 @@ public class TestDiscordianChronology {
     public void test_plus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(DiscordianDate.of(year, month, dom).plus(amount, unit), DiscordianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -786,7 +787,7 @@ public class TestDiscordianChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(DiscordianDate.of(year, month, dom).minus(amount, unit), DiscordianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test
@@ -795,7 +796,7 @@ public class TestDiscordianChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(DiscordianDate.of(year, month, dom).minus(amount, unit), DiscordianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -926,7 +927,7 @@ public class TestDiscordianChronology {
             TemporalUnit unit, long expected) {
         DiscordianDate start = DiscordianDate.of(year1, month1, dom1);
         DiscordianDate end = DiscordianDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test
@@ -938,7 +939,7 @@ public class TestDiscordianChronology {
         DiscordianDate start = DiscordianDate.of(year1, month1, dom1);
         DiscordianDate end = DiscordianDate.of(year2, month2, dom2);
         ChronoPeriod period = DiscordianChronology.INSTANCE.period(yearPeriod, monthPeriod, domPeriod);
-        assertEquals(start.until(end), period);
+        assertEquals(period, start.until(end));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -951,22 +952,22 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(DiscordianDate.of(2014, 5, 26).plus(DiscordianChronology.INSTANCE.period(0, 2, 3)), DiscordianDate.of(2015, 2, 29));
+        assertEquals(DiscordianDate.of(2015, 2, 29), DiscordianDate.of(2014, 5, 26).plus(DiscordianChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(DiscordianDate.of(2014, 5, 26).plus(Period.ofMonths(2)), DiscordianDate.of(2015, 2, 26));
+        assertEquals(DiscordianDate.of(2015, 2, 26), DiscordianDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(DiscordianDate.of(2014, 5, 26).minus(DiscordianChronology.INSTANCE.period(0, 2, 3)), DiscordianDate.of(2014, 3, 23));
+        assertEquals(DiscordianDate.of(2014, 3, 23), DiscordianDate.of(2014, 5, 26).minus(DiscordianChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(DiscordianDate.of(2014, 5, 26).minus(Period.ofMonths(2)), DiscordianDate.of(2014, 3, 26));
+        assertEquals(DiscordianDate.of(2014, 3, 26), DiscordianDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -980,16 +981,16 @@ public class TestDiscordianChronology {
         DiscordianDate c = DiscordianDate.of(2000, 2, 3);
         DiscordianDate d = DiscordianDate.of(2001, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -1007,7 +1008,7 @@ public class TestDiscordianChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(DiscordianDate discordian, String expected) {
-        assertEquals(discordian.toString(), expected);
+        assertEquals(expected, discordian.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
@@ -54,6 +54,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -91,18 +92,18 @@ public class TestEthiopicChronology {
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Ethiopic");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, EthiopicChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Ethiopic");
-        Assert.assertEquals(chrono.getCalendarType(), "ethiopic");
+        Assert.assertEquals(EthiopicChronology.INSTANCE, chrono);
+        Assert.assertEquals("Ethiopic", chrono.getId());
+        Assert.assertEquals("ethiopic", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("ethiopic");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, EthiopicChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Ethiopic");
-        Assert.assertEquals(chrono.getCalendarType(), "ethiopic");
+        Assert.assertEquals(EthiopicChronology.INSTANCE, chrono);
+        Assert.assertEquals("Ethiopic", chrono.getId());
+        Assert.assertEquals("ethiopic", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -140,78 +141,78 @@ public class TestEthiopicChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(LocalDate.from(ethiopic), iso);
+        assertEquals(iso, LocalDate.from(ethiopic));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_from_LocalDate(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(EthiopicDate.from(iso), ethiopic);
+        assertEquals(ethiopic, EthiopicDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_chronology_dateEpochDay(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(EthiopicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), ethiopic);
+        assertEquals(ethiopic, EthiopicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_toEpochDay(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(ethiopic.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), ethiopic.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_until_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(ethiopic.until(ethiopic), EthiopicChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(EthiopicChronology.INSTANCE.period(0, 0, 0), ethiopic.until(ethiopic));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_until_LocalDate(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(ethiopic.until(iso), EthiopicChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(EthiopicChronology.INSTANCE.period(0, 0, 0), ethiopic.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(iso.until(ethiopic), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(ethiopic));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(EthiopicChronology.INSTANCE.date(iso), ethiopic);
+        assertEquals(ethiopic, EthiopicChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(LocalDate.from(ethiopic.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(ethiopic.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(ethiopic.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(ethiopic.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(ethiopic.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(ethiopic.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(ethiopic.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(ethiopic.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(ethiopic.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(ethiopic.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(LocalDate.from(ethiopic.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(ethiopic.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(ethiopic.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(ethiopic.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(ethiopic.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(ethiopic.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(ethiopic.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(ethiopic.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(ethiopic.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(ethiopic.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(EthiopicDate ethiopic, LocalDate iso) {
-        assertEquals(ethiopic.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(ethiopic.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(ethiopic.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(ethiopic.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, ethiopic.until(iso.plusDays(0), DAYS));
+        assertEquals(1, ethiopic.until(iso.plusDays(1), DAYS));
+        assertEquals(35, ethiopic.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, ethiopic.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -264,28 +265,28 @@ public class TestEthiopicChronology {
     public void test_isLeapYear_loop() {
         for (int year = -200; year < 200; year++) {
             EthiopicDate base = EthiopicDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), ((year - 3) % 4) == 0);
-            assertEquals(EthiopicChronology.INSTANCE.isLeapYear(year), ((year + 400 - 3) % 4) == 0);
+            assertEquals(((year - 3) % 4) == 0, base.isLeapYear());
+            assertEquals(((year + 400 - 3) % 4) == 0, EthiopicChronology.INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(8), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(7), true);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(6), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(5), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(4), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(3), true);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(2), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(1), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(0), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(-1), true);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(-2), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(-3), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(-4), false);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(-5), true);
-        assertEquals(EthiopicChronology.INSTANCE.isLeapYear(-6), false);
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(8));
+        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(7));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(6));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(5));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(4));
+        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(3));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(2));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(1));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(0));
+        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(-1));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-2));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-3));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-4));
+        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(-5));
+        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-6));
     }
 
     @DataProvider
@@ -311,7 +312,7 @@ public class TestEthiopicChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(EthiopicDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, EthiopicDate.of(year, month, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -327,7 +328,7 @@ public class TestEthiopicChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             EthiopicDate eraBased = EthiopicChronology.INSTANCE.date(era, yoe, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -341,26 +342,26 @@ public class TestEthiopicChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             EthiopicDate eraBased = EthiopicChronology.INSTANCE.dateYearDay(era, yoe, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 4), 4);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 3), 3);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 2), 2);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 1), 1);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 1), 0);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 2), -1);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 3), -2);
-        assertEquals(EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 4), -3);
+        assertEquals(4, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 4));
+        assertEquals(3, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 3));
+        assertEquals(2, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 2));
+        assertEquals(1, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.INCARNATION, 1));
+        assertEquals(0, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 1));
+        assertEquals(-1, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 2));
+        assertEquals(-2, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 3));
+        assertEquals(-3, EthiopicChronology.INSTANCE.prolepticYear(EthiopicEra.BEFORE_INCARNATION, 4));
     }
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(EthiopicChronology.INSTANCE.eraOf(1), EthiopicEra.INCARNATION);
-        assertEquals(EthiopicChronology.INSTANCE.eraOf(0), EthiopicEra.BEFORE_INCARNATION);
+        assertEquals(EthiopicEra.INCARNATION, EthiopicChronology.INSTANCE.eraOf(1));
+        assertEquals(EthiopicEra.BEFORE_INCARNATION, EthiopicChronology.INSTANCE.eraOf(0));
     }
 
     @Test(expected = DateTimeException.class)
@@ -371,9 +372,9 @@ public class TestEthiopicChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = EthiopicChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
-        assertEquals(eras.contains(EthiopicEra.BEFORE_INCARNATION), true);
-        assertEquals(eras.contains(EthiopicEra.INCARNATION), true);
+        assertEquals(2, eras.size());
+        assertEquals(true, eras.contains(EthiopicEra.BEFORE_INCARNATION));
+        assertEquals(true, eras.contains(EthiopicEra.INCARNATION));
     }
 
     //-----------------------------------------------------------------------
@@ -381,10 +382,10 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(EthiopicChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(EthiopicChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 5, 30));
-        assertEquals(EthiopicChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
-        assertEquals(EthiopicChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
+        assertEquals(ValueRange.of(1, 7), EthiopicChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 5, 30), EthiopicChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 365, 366), EthiopicChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 13), EthiopicChronology.INSTANCE.range(MONTH_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -422,7 +423,7 @@ public class TestEthiopicChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(EthiopicDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), EthiopicDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -457,7 +458,7 @@ public class TestEthiopicChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(EthiopicDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, EthiopicDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -512,7 +513,7 @@ public class TestEthiopicChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(EthiopicDate.of(year, month, dom).with(field, value), EthiopicDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(EthiopicDate.of(expectedYear, expectedMonth, expectedDom), EthiopicDate.of(year, month, dom).with(field, value));
     }
 
     @DataProvider
@@ -548,14 +549,14 @@ public class TestEthiopicChronology {
     public void test_adjust1() {
         EthiopicDate base = EthiopicDate.of(2005, 10, 29);
         EthiopicDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, EthiopicDate.of(2005, 10, 30));
+        assertEquals(EthiopicDate.of(2005, 10, 30), test);
     }
 
     @Test
     public void test_adjust2() {
         EthiopicDate base = EthiopicDate.of(2005, 13, 2);
         EthiopicDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, EthiopicDate.of(2005, 13, 5));
+        assertEquals(EthiopicDate.of(2005, 13, 5), test);
     }
 
     //-----------------------------------------------------------------------
@@ -565,7 +566,7 @@ public class TestEthiopicChronology {
     public void test_adjust_toLocalDate() {
         EthiopicDate ethiopic = EthiopicDate.of(2001, 1, 4);
         EthiopicDate test = ethiopic.with(LocalDate.of(2011, 10, 16));
-        assertEquals(test, EthiopicDate.of(2004, 2, 5));
+        assertEquals(EthiopicDate.of(2004, 2, 5), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -581,14 +582,14 @@ public class TestEthiopicChronology {
     public void test_LocalDate_adjustToEthiopicDate() {
         EthiopicDate ethiopic = EthiopicDate.of(2004, 2, 5);
         LocalDate test = LocalDate.MIN.with(ethiopic);
-        assertEquals(test, LocalDate.of(2011, 10, 16));
+        assertEquals(LocalDate.of(2011, 10, 16), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToEthiopicDate() {
         EthiopicDate ethiopic = EthiopicDate.of(2004, 2, 5);
         LocalDateTime test = LocalDateTime.MIN.with(ethiopic);
-        assertEquals(test, LocalDateTime.of(2011, 10, 16, 0, 0));
+        assertEquals(LocalDateTime.of(2011, 10, 16, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -627,7 +628,7 @@ public class TestEthiopicChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(EthiopicDate.of(year, month, dom).plus(amount, unit), EthiopicDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(EthiopicDate.of(expectedYear, expectedMonth, expectedDom), EthiopicDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -636,7 +637,7 @@ public class TestEthiopicChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(EthiopicDate.of(year, month, dom).minus(amount, unit), EthiopicDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(EthiopicDate.of(expectedYear, expectedMonth, expectedDom), EthiopicDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -647,22 +648,22 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(EthiopicDate.of(2006, 5, 26).plus(EthiopicChronology.INSTANCE.period(0, 2, 3)), EthiopicDate.of(2006, 7, 29));
+        assertEquals(EthiopicDate.of(2006, 7, 29), EthiopicDate.of(2006, 5, 26).plus(EthiopicChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(EthiopicDate.of(2006, 5, 26).plus(Period.ofMonths(2)), EthiopicDate.of(2006, 7, 26));
+        assertEquals(EthiopicDate.of(2006, 7, 26), EthiopicDate.of(2006, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(EthiopicDate.of(2006, 5, 26).minus(EthiopicChronology.INSTANCE.period(0, 2, 3)), EthiopicDate.of(2006, 3, 23));
+        assertEquals(EthiopicDate.of(2006, 3, 23), EthiopicDate.of(2006, 5, 26).minus(EthiopicChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(EthiopicDate.of(2006, 5, 26).minus(Period.ofMonths(2)), EthiopicDate.of(2006, 3, 26));
+        assertEquals(EthiopicDate.of(2006, 3, 26), EthiopicDate.of(2006, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -703,7 +704,7 @@ public class TestEthiopicChronology {
             TemporalUnit unit, long expected) {
         EthiopicDate start = EthiopicDate.of(year1, month1, dom1);
         EthiopicDate end = EthiopicDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -724,16 +725,16 @@ public class TestEthiopicChronology {
         EthiopicDate c = EthiopicDate.of(2004, 2, 3);
         EthiopicDate d = EthiopicDate.of(2005, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -753,7 +754,7 @@ public class TestEthiopicChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(EthiopicDate ethiopic, String expected) {
-        assertEquals(ethiopic.toString(), expected);
+        assertEquals(expected, ethiopic.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -97,9 +97,9 @@ public class TestInternationalFixedChronology {
     public void test_chronology() {
         Chronology chrono = Chronology.of("Ifc");
         assertNotNull(chrono);
-        assertEquals(chrono, InternationalFixedChronology.INSTANCE);
-        assertEquals(chrono.getId(), "Ifc");
-        assertEquals(chrono.getCalendarType(), null);
+        assertEquals(InternationalFixedChronology.INSTANCE, chrono);
+        assertEquals("Ifc", chrono.getId());
+        assertEquals(null, chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -155,84 +155,84 @@ public class TestInternationalFixedChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(LocalDate.from(fixed), iso);
+        assertEquals(iso, LocalDate.from(fixed));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_from_LocalDate(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(InternationalFixedDate.from(iso), fixed);
+        assertEquals(fixed, InternationalFixedDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_chronology_dateEpochDay(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(InternationalFixedChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), fixed);
+        assertEquals(fixed, InternationalFixedChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_toEpochDay(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(fixed.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), fixed.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_until_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(fixed.until(fixed), InternationalFixedChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(InternationalFixedChronology.INSTANCE.period(0, 0, 0), fixed.until(fixed));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_until_LocalDate(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(fixed.until(iso), InternationalFixedChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(InternationalFixedChronology.INSTANCE.period(0, 0, 0), fixed.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(iso.until(fixed), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(fixed));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(InternationalFixedChronology.INSTANCE.date(iso), fixed);
+        assertEquals(fixed, InternationalFixedChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(LocalDate.from(fixed.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(fixed.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(fixed.plus(35, DAYS)), iso.plusDays(35));
+        assertEquals(iso, LocalDate.from(fixed.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(fixed.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(fixed.plus(35, DAYS)));
         if (LocalDate.ofYearDay(1, 60).isBefore(iso)) {
-            assertEquals(LocalDate.from(fixed.plus(-1, DAYS)), iso.plusDays(-1));
-            assertEquals(LocalDate.from(fixed.plus(-60, DAYS)), iso.plusDays(-60));
+            assertEquals(iso.plusDays(-1), LocalDate.from(fixed.plus(-1, DAYS)));
+            assertEquals(iso.plusDays(-60), LocalDate.from(fixed.plus(-60, DAYS)));
         }
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(LocalDate.from(fixed.minus(0, DAYS)), iso);
+        assertEquals(iso, LocalDate.from(fixed.minus(0, DAYS)));
         if (LocalDate.ofYearDay(1, 35).isBefore(iso)) {
-            assertEquals(LocalDate.from(fixed.minus(1, DAYS)), iso.minusDays(1));
-            assertEquals(LocalDate.from(fixed.minus(35, DAYS)), iso.minusDays(35));
+            assertEquals(iso.minusDays(1), LocalDate.from(fixed.minus(1, DAYS)));
+            assertEquals(iso.minusDays(35), LocalDate.from(fixed.minus(35, DAYS)));
         }
-        assertEquals(LocalDate.from(fixed.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(fixed.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso.minusDays(-1), LocalDate.from(fixed.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(fixed.minus(-60, DAYS)));
     }
 
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(InternationalFixedDate fixed, LocalDate iso) {
-        assertEquals(fixed.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(fixed.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(fixed.until(iso.plusDays(35), DAYS), 35);
+        assertEquals(0, fixed.until(iso.plusDays(0), DAYS));
+        assertEquals(1, fixed.until(iso.plusDays(1), DAYS));
+        assertEquals(35, fixed.until(iso.plusDays(35), DAYS));
         if (LocalDate.ofYearDay(1, 40).isBefore(iso)) {
-            assertEquals(fixed.until(iso.minusDays(40), DAYS), -40);
+            assertEquals(-40, fixed.until(iso.minusDays(40), DAYS));
         }
     }
 
@@ -316,9 +316,9 @@ public class TestInternationalFixedChronology {
 
         for (int year = 1; year < 500; year++) {
             InternationalFixedDate base = InternationalFixedDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), isLeapYear.test(year));
-            assertEquals(base.lengthOfYear(), isLeapYear.test(year) ? 366 : 365);
-            assertEquals(InternationalFixedChronology.INSTANCE.isLeapYear(year), isLeapYear.test(year));
+            assertEquals(isLeapYear.test(year), base.isLeapYear());
+            assertEquals(isLeapYear.test(year) ? 366 : 365, base.lengthOfYear());
+            assertEquals(isLeapYear.test(year), InternationalFixedChronology.INSTANCE.isLeapYear(year));
         }
     }
 
@@ -358,20 +358,20 @@ public class TestInternationalFixedChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
-        assertEquals(InternationalFixedDate.of(year, month, day).lengthOfMonth(), length);
+        assertEquals(length, InternationalFixedDate.of(year, month, day).lengthOfMonth());
     }
 
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
-        assertEquals(InternationalFixedDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, InternationalFixedDate.of(year, month, 1).lengthOfMonth());
     }
 
     @Test
     public void test_lengthOfMonth_specific() {
-        assertEquals(InternationalFixedDate.of(1900, 13, 29).lengthOfMonth(), 29);
-        assertEquals(InternationalFixedDate.of(2000, 13, 29).lengthOfMonth(), 29);
-        assertEquals(InternationalFixedDate.of(2000, 6, 29).lengthOfMonth(), 29);
+        assertEquals(29, InternationalFixedDate.of(1900, 13, 29).lengthOfMonth());
+        assertEquals(29, InternationalFixedDate.of(2000, 13, 29).lengthOfMonth());
+        assertEquals(29, InternationalFixedDate.of(2000, 6, 29).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -386,7 +386,7 @@ public class TestInternationalFixedChronology {
             assertEquals(era, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             InternationalFixedDate eraBased = InternationalFixedChronology.INSTANCE.date(era, year, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -399,18 +399,18 @@ public class TestInternationalFixedChronology {
             assertEquals(era, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             InternationalFixedDate eraBased = InternationalFixedChronology.INSTANCE.dateYearDay(era, year, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 4), 4);
-        assertEquals(InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 3), 3);
-        assertEquals(InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 2), 2);
-        assertEquals(InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 1), 1);
-        assertEquals(InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 2000), 2000);
-        assertEquals(InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 1582), 1582);
+        assertEquals(4, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 4));
+        assertEquals(3, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 3));
+        assertEquals(2, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 2));
+        assertEquals(1, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 1));
+        assertEquals(2000, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 2000));
+        assertEquals(1582, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 1582));
     }
 
     @DataProvider
@@ -435,7 +435,7 @@ public class TestInternationalFixedChronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(InternationalFixedChronology.INSTANCE.eraOf(1), InternationalFixedEra.CE);
+        assertEquals(InternationalFixedEra.CE, InternationalFixedChronology.INSTANCE.eraOf(1));
     }
 
     @Test(expected = DateTimeException.class)
@@ -446,7 +446,7 @@ public class TestInternationalFixedChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = InternationalFixedChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 1);
+        assertEquals(1, eras.size());
         assertTrue(eras.contains(InternationalFixedEra.CE));
     }
 
@@ -455,19 +455,19 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(InternationalFixedChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH), ValueRange.of(0, 1, 0, 7));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR), ValueRange.of(0, 1, 0, 7));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH), ValueRange.of(0, 1, 0, 4));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(0, 1, 0, 52));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(0, 1, 0, 7));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 29));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(ERA), ValueRange.of(1, 1));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(EPOCH_DAY), ValueRange.of(-719_528, 1_000_000 * 365L + 242_499 - 719_528));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(PROLEPTIC_MONTH), ValueRange.of(13, 1_000_000 * 13L - 1));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(YEAR), ValueRange.of(1, 1_000_000));
-        assertEquals(InternationalFixedChronology.INSTANCE.range(YEAR_OF_ERA), ValueRange.of(1, 1_000_000));
+        assertEquals(ValueRange.of(0, 1, 0, 7), InternationalFixedChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(ValueRange.of(0, 1, 0, 7), InternationalFixedChronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(ValueRange.of(0, 1, 0, 4), InternationalFixedChronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(ValueRange.of(0, 1, 0, 52), InternationalFixedChronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(ValueRange.of(0, 1, 0, 7), InternationalFixedChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 29), InternationalFixedChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 365, 366), InternationalFixedChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 1), InternationalFixedChronology.INSTANCE.range(ERA));
+        assertEquals(ValueRange.of(-719_528, 1_000_000 * 365L + 242_499 - 719_528), InternationalFixedChronology.INSTANCE.range(EPOCH_DAY));
+        assertEquals(ValueRange.of(1, 13), InternationalFixedChronology.INSTANCE.range(MONTH_OF_YEAR));
+        assertEquals(ValueRange.of(13, 1_000_000 * 13L - 1), InternationalFixedChronology.INSTANCE.range(PROLEPTIC_MONTH));
+        assertEquals(ValueRange.of(1, 1_000_000), InternationalFixedChronology.INSTANCE.range(YEAR));
+        assertEquals(ValueRange.of(1, 1_000_000), InternationalFixedChronology.INSTANCE.range(YEAR_OF_ERA));
     }
 
     //-----------------------------------------------------------------------
@@ -536,7 +536,7 @@ public class TestInternationalFixedChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).range(field), range);
+        assertEquals(range, InternationalFixedDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -618,7 +618,7 @@ public class TestInternationalFixedChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, InternationalFixedDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -768,7 +768,7 @@ public class TestInternationalFixedChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).with(field, value), InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).with(field, value));
     }
 
     @DataProvider
@@ -861,7 +861,7 @@ public class TestInternationalFixedChronology {
         InternationalFixedDate base = InternationalFixedDate.of(year, month, day);
         InternationalFixedDate expected = InternationalFixedDate.of(expectedYear, expectedMonth, expectedDay);
         InternationalFixedDate actual = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(actual, expected);
+        assertEquals(expected, actual);
     }
 
     //-----------------------------------------------------------------------
@@ -871,7 +871,7 @@ public class TestInternationalFixedChronology {
     public void test_adjust_toLocalDate() {
         InternationalFixedDate fixed = InternationalFixedDate.of(2000, 1, 4);
         InternationalFixedDate test = fixed.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, InternationalFixedDate.of(2012, 7, 19));
+        assertEquals(InternationalFixedDate.of(2012, 7, 19), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -887,14 +887,14 @@ public class TestInternationalFixedChronology {
     public void test_LocalDate_adjustToInternationalFixedDate() {
         InternationalFixedDate fixed = InternationalFixedDate.of(2012, 7, 19);
         LocalDate test = LocalDate.MIN.with(fixed);
-        assertEquals(test, LocalDate.of(2012, 7, 6));
+        assertEquals(LocalDate.of(2012, 7, 6), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToInternationalFixedDate() {
         InternationalFixedDate fixed = InternationalFixedDate.of(2012, 7, 19);
         LocalDateTime test = LocalDateTime.MIN.with(fixed);
-        assertEquals(test, LocalDateTime.of(2012, 7, 6, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 7, 6, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -1027,7 +1027,7 @@ public class TestInternationalFixedChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).plus(amount, unit), InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -1035,7 +1035,7 @@ public class TestInternationalFixedChronology {
     public void test_plus_leap_and_year_day_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).plus(amount, unit), InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -1044,7 +1044,7 @@ public class TestInternationalFixedChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).minus(amount, unit), InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test
@@ -1053,7 +1053,7 @@ public class TestInternationalFixedChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(InternationalFixedDate.of(year, month, dom).minus(amount, unit), InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -1280,7 +1280,7 @@ public class TestInternationalFixedChronology {
             TemporalUnit unit, long expected) {
         InternationalFixedDate start = InternationalFixedDate.of(year1, month1, dom1);
         InternationalFixedDate end = InternationalFixedDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test
@@ -1292,7 +1292,7 @@ public class TestInternationalFixedChronology {
         InternationalFixedDate start = InternationalFixedDate.of(year1, month1, dom1);
         InternationalFixedDate end = InternationalFixedDate.of(year2, month2, dom2);
         ChronoPeriod period = InternationalFixedChronology.INSTANCE.period(yearPeriod, monthPeriod, dayPeriod);
-        assertEquals(start.until(end), period);
+        assertEquals(period, start.until(end));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -1307,22 +1307,22 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(InternationalFixedDate.of(2014, 5, 26).plus(InternationalFixedChronology.INSTANCE.period(0, 2, 3)), InternationalFixedDate.of(2014, 8, 1));
+        assertEquals(InternationalFixedDate.of(2014, 8, 1), InternationalFixedDate.of(2014, 5, 26).plus(InternationalFixedChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(InternationalFixedDate.of(2014, 5, 26).plus(Period.ofMonths(2)), InternationalFixedDate.of(2014, 7, 26));
+        assertEquals(InternationalFixedDate.of(2014, 7, 26), InternationalFixedDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(InternationalFixedDate.of(2014, 5, 26).minus(InternationalFixedChronology.INSTANCE.period(0, 2, 3)), InternationalFixedDate.of(2014, 3, 23));
+        assertEquals(InternationalFixedDate.of(2014, 3, 23), InternationalFixedDate.of(2014, 5, 26).minus(InternationalFixedChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(InternationalFixedDate.of(2014, 5, 26).minus(Period.ofMonths(2)), InternationalFixedDate.of(2014, 3, 26));
+        assertEquals(InternationalFixedDate.of(2014, 3, 26), InternationalFixedDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -1371,6 +1371,6 @@ public class TestInternationalFixedChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(InternationalFixedDate date, String expected) {
-        assertEquals(date.toString(), expected);
+        assertEquals(expected, date.toString());
     }
 }

--- a/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
@@ -54,6 +54,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -92,18 +93,18 @@ public class TestJulianChronology {
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Julian");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, JulianChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Julian");
-        Assert.assertEquals(chrono.getCalendarType(), "julian");
+        Assert.assertEquals(JulianChronology.INSTANCE, chrono);
+        Assert.assertEquals("Julian", chrono.getId());
+        Assert.assertEquals("julian", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("julian");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, JulianChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Julian");
-        Assert.assertEquals(chrono.getCalendarType(), "julian");
+        Assert.assertEquals(JulianChronology.INSTANCE, chrono);
+        Assert.assertEquals("Julian", chrono.getId());
+        Assert.assertEquals("julian", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -148,78 +149,78 @@ public class TestJulianChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_JulianDate(JulianDate julian, LocalDate iso) {
-        assertEquals(LocalDate.from(julian), iso);
+        assertEquals(iso, LocalDate.from(julian));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_JulianDate_from_LocalDate(JulianDate julian, LocalDate iso) {
-        assertEquals(JulianDate.from(iso), julian);
+        assertEquals(julian, JulianDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_JulianDate_chronology_dateEpochDay(JulianDate julian, LocalDate iso) {
-        assertEquals(JulianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), julian);
+        assertEquals(julian, JulianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_JulianDate_toEpochDay(JulianDate julian, LocalDate iso) {
-        assertEquals(julian.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), julian.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_JulianDate_until_JulianDate(JulianDate julian, LocalDate iso) {
-        assertEquals(julian.until(julian), JulianChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(JulianChronology.INSTANCE.period(0, 0, 0), julian.until(julian));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_JulianDate_until_LocalDate(JulianDate julian, LocalDate iso) {
-        assertEquals(julian.until(iso), JulianChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(JulianChronology.INSTANCE.period(0, 0, 0), julian.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_JulianDate(JulianDate julian, LocalDate iso) {
-        assertEquals(iso.until(julian), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(julian));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(JulianDate julian, LocalDate iso) {
-        assertEquals(JulianChronology.INSTANCE.date(iso), julian);
+        assertEquals(julian, JulianChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(JulianDate julian, LocalDate iso) {
-        assertEquals(LocalDate.from(julian.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(julian.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(julian.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(julian.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(julian.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(julian.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(julian.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(julian.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(julian.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(julian.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(JulianDate julian, LocalDate iso) {
-        assertEquals(LocalDate.from(julian.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(julian.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(julian.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(julian.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(julian.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(julian.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(julian.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(julian.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(julian.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(julian.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(JulianDate julian, LocalDate iso) {
-        assertEquals(julian.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(julian.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(julian.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(julian.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, julian.until(iso.plusDays(0), DAYS));
+        assertEquals(1, julian.until(iso.plusDays(1), DAYS));
+        assertEquals(35, julian.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, julian.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -283,28 +284,28 @@ public class TestJulianChronology {
     public void test_isLeapYear_loop() {
         for (int year = -200; year < 200; year++) {
             JulianDate base = JulianDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), (year % 4) == 0);
-            assertEquals(JulianChronology.INSTANCE.isLeapYear(year), (year % 4) == 0);
+            assertEquals((year % 4) == 0, base.isLeapYear());
+            assertEquals((year % 4) == 0, JulianChronology.INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(8), true);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(7), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(6), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(5), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(4), true);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(3), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(2), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(1), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(0), true);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(-1), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(-2), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(-3), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(-4), true);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(-5), false);
-        assertEquals(JulianChronology.INSTANCE.isLeapYear(-6), false);
+        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(8));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(7));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(6));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(5));
+        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(4));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(3));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(2));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(1));
+        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(0));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-1));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-2));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-3));
+        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(-4));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-5));
+        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-6));
     }
 
     @DataProvider
@@ -335,7 +336,7 @@ public class TestJulianChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(JulianDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, JulianDate.of(year, month, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -351,7 +352,7 @@ public class TestJulianChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             JulianDate eraBased = JulianChronology.INSTANCE.date(era, yoe, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -365,20 +366,20 @@ public class TestJulianChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             JulianDate eraBased = JulianChronology.INSTANCE.dateYearDay(era, yoe, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 4), 4);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 3), 3);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 2), 2);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 1), 1);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 1), 0);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 2), -1);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 3), -2);
-        assertEquals(JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 4), -3);
+        assertEquals(4, JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 4));
+        assertEquals(3, JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 3));
+        assertEquals(2, JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 2));
+        assertEquals(1, JulianChronology.INSTANCE.prolepticYear(JulianEra.AD, 1));
+        assertEquals(0, JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 1));
+        assertEquals(-1, JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 2));
+        assertEquals(-2, JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 3));
+        assertEquals(-3, JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 4));
     }
 
     @Test(expected = ClassCastException.class)
@@ -388,8 +389,8 @@ public class TestJulianChronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(JulianChronology.INSTANCE.eraOf(1), JulianEra.AD);
-        assertEquals(JulianChronology.INSTANCE.eraOf(0), JulianEra.BC);
+        assertEquals(JulianEra.AD, JulianChronology.INSTANCE.eraOf(1));
+        assertEquals(JulianEra.BC, JulianChronology.INSTANCE.eraOf(0));
     }
 
     @Test(expected = DateTimeException.class)
@@ -400,9 +401,9 @@ public class TestJulianChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = JulianChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
-        assertEquals(eras.contains(JulianEra.BC), true);
-        assertEquals(eras.contains(JulianEra.AD), true);
+        assertEquals(2, eras.size());
+        assertEquals(true, eras.contains(JulianEra.BC));
+        assertEquals(true, eras.contains(JulianEra.AD));
     }
 
     //-----------------------------------------------------------------------
@@ -410,10 +411,10 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(JulianChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(JulianChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 28, 31));
-        assertEquals(JulianChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 365, 366));
-        assertEquals(JulianChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 12));
+        assertEquals(ValueRange.of(1, 7), JulianChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 28, 31), JulianChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 365, 366), JulianChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 12), JulianChronology.INSTANCE.range(MONTH_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -448,7 +449,7 @@ public class TestJulianChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(JulianDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), JulianDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -483,7 +484,7 @@ public class TestJulianChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(JulianDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, JulianDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -536,7 +537,7 @@ public class TestJulianChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(JulianDate.of(year, month, dom).with(field, value), JulianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(JulianDate.of(expectedYear, expectedMonth, expectedDom), JulianDate.of(year, month, dom).with(field, value));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -551,14 +552,14 @@ public class TestJulianChronology {
     public void test_adjust1() {
         JulianDate base = JulianDate.of(2012, 6, 23);
         JulianDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, JulianDate.of(2012, 6, 30));
+        assertEquals(JulianDate.of(2012, 6, 30), test);
     }
 
     @Test
     public void test_adjust2() {
         JulianDate base = JulianDate.of(2012, 2, 23);
         JulianDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, JulianDate.of(2012, 2, 29));
+        assertEquals(JulianDate.of(2012, 2, 29), test);
     }
 
     //-----------------------------------------------------------------------
@@ -568,7 +569,7 @@ public class TestJulianChronology {
     public void test_adjust_toLocalDate() {
         JulianDate julian = JulianDate.of(2000, 1, 4);
         JulianDate test = julian.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, JulianDate.of(2012, 6, 23));
+        assertEquals(JulianDate.of(2012, 6, 23), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -584,14 +585,14 @@ public class TestJulianChronology {
     public void test_LocalDate_adjustToJulianDate() {
         JulianDate julian = JulianDate.of(2012, 6, 23);
         LocalDate test = LocalDate.MIN.with(julian);
-        assertEquals(test, LocalDate.of(2012, 7, 6));
+        assertEquals(LocalDate.of(2012, 7, 6), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToJulianDate() {
         JulianDate julian = JulianDate.of(2012, 6, 23);
         LocalDateTime test = LocalDateTime.MIN.with(julian);
-        assertEquals(test, LocalDateTime.of(2012, 7, 6, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 7, 6, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -630,7 +631,7 @@ public class TestJulianChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(JulianDate.of(year, month, dom).plus(amount, unit), JulianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(JulianDate.of(expectedYear, expectedMonth, expectedDom), JulianDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -639,7 +640,7 @@ public class TestJulianChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(JulianDate.of(year, month, dom).minus(amount, unit), JulianDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(JulianDate.of(expectedYear, expectedMonth, expectedDom), JulianDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -687,7 +688,7 @@ public class TestJulianChronology {
             TemporalUnit unit, long expected) {
         JulianDate start = JulianDate.of(year1, month1, dom1);
         JulianDate end = JulianDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -700,22 +701,22 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(JulianDate.of(2014, 5, 26).plus(JulianChronology.INSTANCE.period(0, 2, 3)), JulianDate.of(2014, 7, 29));
+        assertEquals(JulianDate.of(2014, 7, 29), JulianDate.of(2014, 5, 26).plus(JulianChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(JulianDate.of(2014, 5, 26).plus(Period.ofMonths(2)), JulianDate.of(2014, 7, 26));
+        assertEquals(JulianDate.of(2014, 7, 26), JulianDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(JulianDate.of(2014, 5, 26).minus(JulianChronology.INSTANCE.period(0, 2, 3)), JulianDate.of(2014, 3, 23));
+        assertEquals(JulianDate.of(2014, 3, 23), JulianDate.of(2014, 5, 26).minus(JulianChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(JulianDate.of(2014, 5, 26).minus(Period.ofMonths(2)), JulianDate.of(2014, 3, 26));
+        assertEquals(JulianDate.of(2014, 3, 26), JulianDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -729,16 +730,16 @@ public class TestJulianChronology {
         JulianDate c = JulianDate.of(2000, 2, 3);
         JulianDate d = JulianDate.of(2001, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -755,7 +756,7 @@ public class TestJulianChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(JulianDate julian, String expected) {
-        assertEquals(julian.toString(), expected);
+        assertEquals(expected, julian.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
@@ -54,6 +54,7 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -95,18 +96,18 @@ public class TestPaxChronology {
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Pax");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, PaxChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Pax");
-        Assert.assertEquals(chrono.getCalendarType(), "pax");
+        Assert.assertEquals(PaxChronology.INSTANCE, chrono);
+        Assert.assertEquals("Pax", chrono.getId());
+        Assert.assertEquals("pax", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("pax");
         Assert.assertNotNull(chrono);
-        Assert.assertEquals(chrono, PaxChronology.INSTANCE);
-        Assert.assertEquals(chrono.getId(), "Pax");
-        Assert.assertEquals(chrono.getCalendarType(), "pax");
+        Assert.assertEquals(PaxChronology.INSTANCE, chrono);
+        Assert.assertEquals("Pax", chrono.getId());
+        Assert.assertEquals("pax", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -180,78 +181,78 @@ public class TestPaxChronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_PaxDate(PaxDate pax, LocalDate iso) {
-        assertEquals(LocalDate.from(pax), iso);
+        assertEquals(iso, LocalDate.from(pax));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_PaxDate_from_LocalDate(PaxDate pax, LocalDate iso) {
-        assertEquals(PaxDate.from(iso), pax);
+        assertEquals(pax, PaxDate.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_PaxDate_chronology_dateEpochDay(PaxDate pax, LocalDate iso) {
-        assertEquals(PaxChronology.INSTANCE.dateEpochDay(iso.toEpochDay()), pax);
+        assertEquals(pax, PaxChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_PaxDate_toEpochDay(PaxDate pax, LocalDate iso) {
-        assertEquals(pax.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), pax.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_PaxDate_until_PaxDate(PaxDate pax, LocalDate iso) {
-        assertEquals(pax.until(pax), PaxChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(PaxChronology.INSTANCE.period(0, 0, 0), pax.until(pax));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_PaxDate_until_LocalDate(PaxDate pax, LocalDate iso) {
-        assertEquals(pax.until(iso), PaxChronology.INSTANCE.period(0, 0, 0));
+        assertEquals(PaxChronology.INSTANCE.period(0, 0, 0), pax.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_PaxDate(PaxDate pax, LocalDate iso) {
-        assertEquals(iso.until(pax), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(pax));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(PaxDate pax, LocalDate iso) {
-        assertEquals(PaxChronology.INSTANCE.date(iso), pax);
+        assertEquals(pax, PaxChronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(PaxDate pax, LocalDate iso) {
-        assertEquals(LocalDate.from(pax.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(pax.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(pax.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(pax.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(pax.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(pax.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(pax.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(pax.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(pax.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(pax.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(PaxDate pax, LocalDate iso) {
-        assertEquals(LocalDate.from(pax.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(pax.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(pax.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(pax.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(pax.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(pax.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(pax.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(pax.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(pax.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(pax.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(PaxDate pax, LocalDate iso) {
-        assertEquals(pax.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(pax.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(pax.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(pax.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, pax.until(iso.plusDays(0), DAYS));
+        assertEquals(1, pax.until(iso.plusDays(1), DAYS));
+        assertEquals(35, pax.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, pax.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -323,33 +324,33 @@ public class TestPaxChronology {
         };
         for (int year = -500; year < 500; year++) {
             PaxDate base = PaxDate.of(year, 1, 1);
-            assertEquals(base.isLeapYear(), isLeapYear.test(year));
-            assertEquals(PaxChronology.INSTANCE.isLeapYear(year), isLeapYear.test(year));
+            assertEquals(isLeapYear.test(year), base.isLeapYear());
+            assertEquals(isLeapYear.test(year), PaxChronology.INSTANCE.isLeapYear(year));
         }
     }
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(400), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(100), true);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(99), true);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(7), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(6), true);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(5), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(4), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(3), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(2), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(1), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(0), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-1), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-2), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-3), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-4), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-5), false);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-6), true);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-99), true);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-100), true);
-        assertEquals(PaxChronology.INSTANCE.isLeapYear(-400), false);
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(400));
+        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(100));
+        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(99));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(7));
+        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(6));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(5));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(4));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(3));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(2));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(1));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(0));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-1));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-2));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-3));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-4));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-5));
+        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(-6));
+        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(-99));
+        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(-100));
+        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-400));
     }
 
     @DataProvider
@@ -384,7 +385,7 @@ public class TestPaxChronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
-        assertEquals(PaxDate.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, PaxDate.of(year, month, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -400,7 +401,7 @@ public class TestPaxChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             PaxDate eraBased = PaxChronology.INSTANCE.date(era, yoe, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -414,20 +415,20 @@ public class TestPaxChronology {
             int yoe = (year <= 0 ? 1 - year : year);
             assertEquals(yoe, base.get(YEAR_OF_ERA));
             PaxDate eraBased = PaxChronology.INSTANCE.dateYearDay(era, yoe, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 4), 4);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 3), 3);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 2), 2);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 1), 1);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 1), 0);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 2), -1);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 3), -2);
-        assertEquals(PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 4), -3);
+        assertEquals(4, PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 4));
+        assertEquals(3, PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 3));
+        assertEquals(2, PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 2));
+        assertEquals(1, PaxChronology.INSTANCE.prolepticYear(PaxEra.CE, 1));
+        assertEquals(0, PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 1));
+        assertEquals(-1, PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 2));
+        assertEquals(-2, PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 3));
+        assertEquals(-3, PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 4));
     }
 
     @Test(expected = ClassCastException.class)
@@ -437,8 +438,8 @@ public class TestPaxChronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(PaxChronology.INSTANCE.eraOf(1), PaxEra.CE);
-        assertEquals(PaxChronology.INSTANCE.eraOf(0), PaxEra.BCE);
+        assertEquals(PaxEra.CE, PaxChronology.INSTANCE.eraOf(1));
+        assertEquals(PaxEra.BCE, PaxChronology.INSTANCE.eraOf(0));
     }
 
     @Test(expected = DateTimeException.class)
@@ -449,9 +450,9 @@ public class TestPaxChronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = PaxChronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
-        assertEquals(eras.contains(PaxEra.BCE), true);
-        assertEquals(eras.contains(PaxEra.CE), true);
+        assertEquals(2, eras.size());
+        assertEquals(true, eras.contains(PaxEra.BCE));
+        assertEquals(true, eras.contains(PaxEra.CE));
     }
 
     //-----------------------------------------------------------------------
@@ -459,10 +460,10 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(PaxChronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(PaxChronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 7, 28));
-        assertEquals(PaxChronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 364, 371));
-        assertEquals(PaxChronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 13, 14));
+        assertEquals(ValueRange.of(1, 7), PaxChronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 7, 28), PaxChronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 364, 371), PaxChronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(1, 13, 14), PaxChronology.INSTANCE.range(MONTH_OF_YEAR));
     }
 
     //-----------------------------------------------------------------------
@@ -503,7 +504,7 @@ public class TestPaxChronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
-        assertEquals(PaxDate.of(year, month, dom).range(field), ValueRange.of(expectedMin, expectedMax));
+        assertEquals(ValueRange.of(expectedMin, expectedMax), PaxDate.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -538,7 +539,7 @@ public class TestPaxChronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(PaxDate.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, PaxDate.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -591,7 +592,7 @@ public class TestPaxChronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(PaxDate.of(year, month, dom).with(field, value), PaxDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(PaxDate.of(expectedYear, expectedMonth, expectedDom), PaxDate.of(year, month, dom).with(field, value));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -606,14 +607,14 @@ public class TestPaxChronology {
     public void test_adjust1() {
         PaxDate base = PaxDate.of(2012, 6, 23);
         PaxDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, PaxDate.of(2012, 6, 28));
+        assertEquals(PaxDate.of(2012, 6, 28), test);
     }
 
     @Test
     public void test_adjust2() {
         PaxDate base = PaxDate.of(2012, 13, 2);
         PaxDate test = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(test, PaxDate.of(2012, 13, 7));
+        assertEquals(PaxDate.of(2012, 13, 7), test);
     }
 
     //-----------------------------------------------------------------------
@@ -623,7 +624,7 @@ public class TestPaxChronology {
     public void test_adjust_toLocalDate() {
         PaxDate pax = PaxDate.of(2000, 1, 4);
         PaxDate test = pax.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, PaxDate.of(2012, 7, 27));
+        assertEquals(PaxDate.of(2012, 7, 27), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -639,14 +640,14 @@ public class TestPaxChronology {
     public void test_LocalDate_adjustToPaxDate() {
         PaxDate pax = PaxDate.of(2012, 6, 23);
         LocalDate test = LocalDate.MIN.with(pax);
-        assertEquals(test, LocalDate.of(2012, 6, 4));
+        assertEquals(LocalDate.of(2012, 6, 4), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToPaxDate() {
         PaxDate pax = PaxDate.of(2012, 6, 23);
         LocalDateTime test = LocalDateTime.MIN.with(pax);
-        assertEquals(test, LocalDateTime.of(2012, 6, 4, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 6, 4, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -713,7 +714,7 @@ public class TestPaxChronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(PaxDate.of(year, month, dom).plus(amount, unit), PaxDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(PaxDate.of(expectedYear, expectedMonth, expectedDom), PaxDate.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -730,7 +731,7 @@ public class TestPaxChronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(PaxDate.of(year, month, dom).minus(amount, unit), PaxDate.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(PaxDate.of(expectedYear, expectedMonth, expectedDom), PaxDate.of(year, month, dom).minus(amount, unit));
     }
 
     @Test
@@ -827,7 +828,7 @@ public class TestPaxChronology {
             TemporalUnit unit, long expected) {
         PaxDate start = PaxDate.of(year1, month1, dom1);
         PaxDate end = PaxDate.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test
@@ -839,7 +840,7 @@ public class TestPaxChronology {
         PaxDate start = PaxDate.of(year1, month1, dom1);
         PaxDate end = PaxDate.of(year2, month2, dom2);
         ChronoPeriod period = PaxChronology.INSTANCE.period(yearPeriod, monthPeriod, dayPeriod);
-        assertEquals(start.until(end), period);
+        assertEquals(period, start.until(end));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -852,22 +853,22 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(PaxDate.of(2014, 5, 26).plus(PaxChronology.INSTANCE.period(0, 2, 2)), PaxDate.of(2014, 7, 28));
+        assertEquals(PaxDate.of(2014, 7, 28), PaxDate.of(2014, 5, 26).plus(PaxChronology.INSTANCE.period(0, 2, 2)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(PaxDate.of(2014, 5, 26).plus(Period.ofMonths(2)), PaxDate.of(2014, 7, 26));
+        assertEquals(PaxDate.of(2014, 7, 26), PaxDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(PaxDate.of(2014, 5, 26).minus(PaxChronology.INSTANCE.period(0, 2, 3)), PaxDate.of(2014, 3, 23));
+        assertEquals(PaxDate.of(2014, 3, 23), PaxDate.of(2014, 5, 26).minus(PaxChronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(PaxDate.of(2014, 5, 26).minus(Period.ofMonths(2)), PaxDate.of(2014, 3, 26));
+        assertEquals(PaxDate.of(2014, 3, 26), PaxDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -881,16 +882,16 @@ public class TestPaxChronology {
         PaxDate c = PaxDate.of(2000, 2, 3);
         PaxDate d = PaxDate.of(2001, 1, 3);
 
-        assertEquals(a1.equals(a1), true);
-        assertEquals(a1.equals(a2), true);
-        assertEquals(a1.equals(b), false);
-        assertEquals(a1.equals(c), false);
-        assertEquals(a1.equals(d), false);
+        assertEquals(true, a1.equals(a1));
+        assertEquals(true, a1.equals(a2));
+        assertEquals(false, a1.equals(b));
+        assertEquals(false, a1.equals(c));
+        assertEquals(false, a1.equals(d));
 
-        assertEquals(a1.equals(null), false);
-        assertEquals(a1.equals(""), false);
+        assertEquals(false, a1.equals(null));
+        assertEquals(false, a1.equals(""));
 
-        assertEquals(a1.hashCode(), a2.hashCode());
+        assertTrue(a1.hashCode() == a2.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -907,7 +908,7 @@ public class TestPaxChronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(PaxDate pax, String expected) {
-        assertEquals(pax.toString(), expected);
+        assertEquals(expected, pax.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
@@ -101,9 +101,9 @@ public class TestSymmetry010Chronology {
     public void test_chronology() {
         Chronology chrono = Chronology.of("Sym010");
         assertNotNull(chrono);
-        assertEquals(chrono, Symmetry010Chronology.INSTANCE);
-        assertEquals(chrono.getId(), "Sym010");
-        assertEquals(chrono.getCalendarType(), null);
+        assertEquals(Symmetry010Chronology.INSTANCE, chrono);
+        assertEquals("Sym010", chrono.getId());
+        assertEquals(null, chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -149,78 +149,78 @@ public class TestSymmetry010Chronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(LocalDate.from(sym010), iso);
+        assertEquals(iso, LocalDate.from(sym010));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_from_LocalDate(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(Symmetry010Date.from(iso), sym010);
+        assertEquals(sym010, Symmetry010Date.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_chronology_dateEpochDay(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(Symmetry010Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()), sym010);
+        assertEquals(sym010, Symmetry010Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_toEpochDay(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(sym010.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), sym010.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_until_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(sym010.until(sym010), Symmetry010Chronology.INSTANCE.period(0, 0, 0));
+        assertEquals(Symmetry010Chronology.INSTANCE.period(0, 0, 0), sym010.until(sym010));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_until_LocalDate(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(sym010.until(iso), Symmetry010Chronology.INSTANCE.period(0, 0, 0));
+        assertEquals(Symmetry010Chronology.INSTANCE.period(0, 0, 0), sym010.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(Symmetry010Chronology.INSTANCE.date(iso), sym010);
+        assertEquals(sym010, Symmetry010Chronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(iso.until(sym010), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(sym010));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(LocalDate.from(sym010.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(sym010.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(sym010.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(sym010.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(sym010.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(sym010.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(sym010.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(sym010.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(sym010.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(sym010.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(LocalDate.from(sym010.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(sym010.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(sym010.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(sym010.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(sym010.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(sym010.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(sym010.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(sym010.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(sym010.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(sym010.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(Symmetry010Date sym010, LocalDate iso) {
-        assertEquals(sym010.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(sym010.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(sym010.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(sym010.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, sym010.until(iso.plusDays(0), DAYS));
+        assertEquals(1, sym010.until(iso.plusDays(1), DAYS));
+        assertEquals(35, sym010.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, sym010.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -329,19 +329,19 @@ public class TestSymmetry010Chronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
-        assertEquals(Symmetry010Date.of(year, month, day).lengthOfMonth(), length);
+        assertEquals(length, Symmetry010Date.of(year, month, day).lengthOfMonth());
     }
 
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
-        assertEquals(Symmetry010Date.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, Symmetry010Date.of(year, month, 1).lengthOfMonth());
     }
 
     @Test
     public void test_lengthOfMonth_specific() {
-        assertEquals(Symmetry010Date.of(2000, 12, 1).lengthOfMonth(), 30);
-        assertEquals(Symmetry010Date.of(2004, 12, 1).lengthOfMonth(), 37);
+        assertEquals(30, Symmetry010Date.of(2000, 12, 1).lengthOfMonth());
+        assertEquals(37, Symmetry010Date.of(2004, 12, 1).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -358,7 +358,7 @@ public class TestSymmetry010Chronology {
             assertEquals(era, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             Symmetry010Date eraBased = Symmetry010Chronology.INSTANCE.date(era, year, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
 
         for (int year = -200; year < 0; year++) {
@@ -368,7 +368,7 @@ public class TestSymmetry010Chronology {
             assertEquals(era, base.getEra());
             assertEquals(1 - year, base.get(YEAR_OF_ERA));
             Symmetry010Date eraBased = Symmetry010Chronology.INSTANCE.date(era, year, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -381,18 +381,18 @@ public class TestSymmetry010Chronology {
             assertEquals(era, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             Symmetry010Date eraBased = Symmetry010Chronology.INSTANCE.dateYearDay(era, year, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 4), 4);
-        assertEquals(Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 3), 3);
-        assertEquals(Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2), 2);
-        assertEquals(Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1), 1);
-        assertEquals(Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2000), 2000);
-        assertEquals(Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1582), 1582);
+        assertEquals(4, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
+        assertEquals(3, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 3));
+        assertEquals(2, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2));
+        assertEquals(1, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1));
+        assertEquals(2000, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2000));
+        assertEquals(1582, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1582));
     }
 
     @DataProvider
@@ -430,8 +430,8 @@ public class TestSymmetry010Chronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(Symmetry010Chronology.INSTANCE.eraOf(0), IsoEra.BCE);
-        assertEquals(Symmetry010Chronology.INSTANCE.eraOf(1), IsoEra.CE);
+        assertEquals(IsoEra.BCE, Symmetry010Chronology.INSTANCE.eraOf(0));
+        assertEquals(IsoEra.CE, Symmetry010Chronology.INSTANCE.eraOf(1));
     }
 
     @Test(expected = DateTimeException.class)
@@ -442,7 +442,7 @@ public class TestSymmetry010Chronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = Symmetry010Chronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
+        assertEquals(2, eras.size());
         assertTrue(eras.contains(IsoEra.BCE));
         assertTrue(eras.contains(IsoEra.CE));
     }
@@ -452,19 +452,19 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(Symmetry010Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH), ValueRange.of(1, 7));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR), ValueRange.of(1, 7));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH), ValueRange.of(1, 4, 5));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(1, 52, 53));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 30, 37));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 364, 371));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(ERA), ValueRange.of(0, 1));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(EPOCH_DAY), ValueRange.of(-1_000_000 * 364L - 177_474 * 7 - 719_162, 1_000_000 * 364L + 177_474 * 7 - 719_162));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 12));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(PROLEPTIC_MONTH), ValueRange.of(-12_000_000L, 11_999_999L));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(YEAR), ValueRange.of(-1_000_000L, 1_000_000));
-        assertEquals(Symmetry010Chronology.INSTANCE.range(YEAR_OF_ERA), ValueRange.of(-1_000_000, 1_000_000));
+        assertEquals(ValueRange.of(1, 7), Symmetry010Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(ValueRange.of(1, 7), Symmetry010Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(ValueRange.of(1, 4, 5), Symmetry010Chronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(ValueRange.of(1, 52, 53), Symmetry010Chronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(ValueRange.of(1, 7), Symmetry010Chronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 30, 37), Symmetry010Chronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 364, 371), Symmetry010Chronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(0, 1), Symmetry010Chronology.INSTANCE.range(ERA));
+        assertEquals(ValueRange.of(-1_000_000 * 364L - 177_474 * 7 - 719_162, 1_000_000 * 364L + 177_474 * 7 - 719_162), Symmetry010Chronology.INSTANCE.range(EPOCH_DAY));
+        assertEquals(ValueRange.of(1, 12), Symmetry010Chronology.INSTANCE.range(MONTH_OF_YEAR));
+        assertEquals(ValueRange.of(-12_000_000L, 11_999_999L), Symmetry010Chronology.INSTANCE.range(PROLEPTIC_MONTH));
+        assertEquals(ValueRange.of(-1_000_000L, 1_000_000), Symmetry010Chronology.INSTANCE.range(YEAR));
+        assertEquals(ValueRange.of(-1_000_000, 1_000_000), Symmetry010Chronology.INSTANCE.range(YEAR_OF_ERA));
     }
 
     //-----------------------------------------------------------------------
@@ -519,7 +519,7 @@ public class TestSymmetry010Chronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
-        assertEquals(Symmetry010Date.of(year, month, dom).range(field), range);
+        assertEquals(range, Symmetry010Date.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -568,7 +568,7 @@ public class TestSymmetry010Chronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(Symmetry010Date.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, Symmetry010Date.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -660,7 +660,7 @@ public class TestSymmetry010Chronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(Symmetry010Date.of(year, month, dom).with(field, value), Symmetry010Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).with(field, value));
     }
 
     @DataProvider
@@ -741,7 +741,7 @@ public class TestSymmetry010Chronology {
         Symmetry010Date base = Symmetry010Date.of(year, month, day);
         Symmetry010Date expected = Symmetry010Date.of(expectedYear, expectedMonth, expectedDay);
         Symmetry010Date actual = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(actual, expected);
+        assertEquals(expected, actual);
     }
 
     //-----------------------------------------------------------------------
@@ -751,7 +751,7 @@ public class TestSymmetry010Chronology {
     public void test_adjust_toLocalDate() {
         Symmetry010Date sym010 = Symmetry010Date.of(2000, 1, 4);
         Symmetry010Date test = sym010.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, Symmetry010Date.of(2012, 7, 5));
+        assertEquals(Symmetry010Date.of(2012, 7, 5), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -767,14 +767,14 @@ public class TestSymmetry010Chronology {
     public void test_LocalDate_adjustToSymmetry010Date() {
         Symmetry010Date sym010 = Symmetry010Date.of(2012, 7, 19);
         LocalDate test = LocalDate.MIN.with(sym010);
-        assertEquals(test, LocalDate.of(2012, 7, 20));
+        assertEquals(LocalDate.of(2012, 7, 20), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToSymmetry010Date() {
         Symmetry010Date sym010 = Symmetry010Date.of(2012, 7, 19);
         LocalDateTime test = LocalDateTime.MIN.with(sym010);
-        assertEquals(test, LocalDateTime.of(2012, 7, 20, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 7, 20, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -842,7 +842,7 @@ public class TestSymmetry010Chronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(Symmetry010Date.of(year, month, dom).plus(amount, unit), Symmetry010Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -850,7 +850,7 @@ public class TestSymmetry010Chronology {
     public void test_plus_leapWeek_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(Symmetry010Date.of(year, month, dom).plus(amount, unit), Symmetry010Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -859,7 +859,7 @@ public class TestSymmetry010Chronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(Symmetry010Date.of(year, month, dom).minus(amount, unit), Symmetry010Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).minus(amount, unit));
     }
 
     @Test
@@ -868,7 +868,7 @@ public class TestSymmetry010Chronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(Symmetry010Date.of(year, month, dom).minus(amount, unit), Symmetry010Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -930,7 +930,7 @@ public class TestSymmetry010Chronology {
             TemporalUnit unit, long expected) {
         Symmetry010Date start = Symmetry010Date.of(year1, month1, dom1);
         Symmetry010Date end = Symmetry010Date.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test
@@ -942,7 +942,7 @@ public class TestSymmetry010Chronology {
         Symmetry010Date start = Symmetry010Date.of(year1, month1, dom1);
         Symmetry010Date end = Symmetry010Date.of(year2, month2, dom2);
         ChronoPeriod period = Symmetry010Chronology.INSTANCE.period(yearPeriod, monthPeriod, dayPeriod);
-        assertEquals(start.until(end), period);
+        assertEquals(period, start.until(end));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -957,25 +957,25 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(Symmetry010Date.of(2014, 5, 21).plus(Symmetry010Chronology.INSTANCE.period(0, 2, 8)),
-                Symmetry010Date.of(2014, 7, 29));
+        assertEquals(Symmetry010Date.of(2014, 7, 29),
+                Symmetry010Date.of(2014, 5, 21).plus(Symmetry010Chronology.INSTANCE.period(0, 2, 8)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(Symmetry010Date.of(2014, 5, 26).plus(Period.ofMonths(2)),
-                Symmetry010Date.of(2014, 7, 26));
+        assertEquals(Symmetry010Date.of(2014, 7, 26),
+                Symmetry010Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(Symmetry010Date.of(2014, 5, 26).minus(Symmetry010Chronology.INSTANCE.period(0, 2, 3)),
-                Symmetry010Date.of(2014, 3, 23));
+        assertEquals(Symmetry010Date.of(2014, 3, 23),
+                Symmetry010Date.of(2014, 5, 26).minus(Symmetry010Chronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(Symmetry010Date.of(2014, 5, 26).minus(Period.ofMonths(2)), Symmetry010Date.of(2014, 3, 26));
+        assertEquals(Symmetry010Date.of(2014, 3, 26), Symmetry010Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -1018,6 +1018,6 @@ public class TestSymmetry010Chronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(Symmetry010Date date, String expected) {
-        assertEquals(date.toString(), expected);
+        assertEquals(expected, date.toString());
     }
 }

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -101,9 +101,9 @@ public class TestSymmetry454Chronology {
     public void test_chronology() {
         Chronology chrono = Chronology.of("Sym454");
         assertNotNull(chrono);
-        assertEquals(chrono, Symmetry454Chronology.INSTANCE);
-        assertEquals(chrono.getId(), "Sym454");
-        assertEquals(chrono.getCalendarType(), null);
+        assertEquals(Symmetry454Chronology.INSTANCE, chrono);
+        assertEquals("Sym454", chrono.getId());
+        assertEquals(null, chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -149,78 +149,78 @@ public class TestSymmetry454Chronology {
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(LocalDate.from(sym454), iso);
+        assertEquals(iso, LocalDate.from(sym454));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_from_LocalDate(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(Symmetry454Date.from(iso), sym454);
+        assertEquals(sym454, Symmetry454Date.from(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_chronology_dateEpochDay(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(Symmetry454Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()), sym454);
+        assertEquals(sym454, Symmetry454Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_toEpochDay(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(sym454.toEpochDay(), iso.toEpochDay());
+        assertEquals(iso.toEpochDay(), sym454.toEpochDay());
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_until_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(sym454.until(sym454), Symmetry454Chronology.INSTANCE.period(0, 0, 0));
+        assertEquals(Symmetry454Chronology.INSTANCE.period(0, 0, 0), sym454.until(sym454));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_until_LocalDate(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(sym454.until(iso), Symmetry454Chronology.INSTANCE.period(0, 0, 0));
+        assertEquals(Symmetry454Chronology.INSTANCE.period(0, 0, 0), sym454.until(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(Symmetry454Chronology.INSTANCE.date(iso), sym454);
+        assertEquals(sym454, Symmetry454Chronology.INSTANCE.date(iso));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(iso.until(sym454), Period.ZERO);
+        assertEquals(Period.ZERO, iso.until(sym454));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_plusDays(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(LocalDate.from(sym454.plus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(sym454.plus(1, DAYS)), iso.plusDays(1));
-        assertEquals(LocalDate.from(sym454.plus(35, DAYS)), iso.plusDays(35));
-        assertEquals(LocalDate.from(sym454.plus(-1, DAYS)), iso.plusDays(-1));
-        assertEquals(LocalDate.from(sym454.plus(-60, DAYS)), iso.plusDays(-60));
+        assertEquals(iso, LocalDate.from(sym454.plus(0, DAYS)));
+        assertEquals(iso.plusDays(1), LocalDate.from(sym454.plus(1, DAYS)));
+        assertEquals(iso.plusDays(35), LocalDate.from(sym454.plus(35, DAYS)));
+        assertEquals(iso.plusDays(-1), LocalDate.from(sym454.plus(-1, DAYS)));
+        assertEquals(iso.plusDays(-60), LocalDate.from(sym454.plus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_minusDays(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(LocalDate.from(sym454.minus(0, DAYS)), iso);
-        assertEquals(LocalDate.from(sym454.minus(1, DAYS)), iso.minusDays(1));
-        assertEquals(LocalDate.from(sym454.minus(35, DAYS)), iso.minusDays(35));
-        assertEquals(LocalDate.from(sym454.minus(-1, DAYS)), iso.minusDays(-1));
-        assertEquals(LocalDate.from(sym454.minus(-60, DAYS)), iso.minusDays(-60));
+        assertEquals(iso, LocalDate.from(sym454.minus(0, DAYS)));
+        assertEquals(iso.minusDays(1), LocalDate.from(sym454.minus(1, DAYS)));
+        assertEquals(iso.minusDays(35), LocalDate.from(sym454.minus(35, DAYS)));
+        assertEquals(iso.minusDays(-1), LocalDate.from(sym454.minus(-1, DAYS)));
+        assertEquals(iso.minusDays(-60), LocalDate.from(sym454.minus(-60, DAYS)));
     }
 
     @Test
     @UseDataProvider("data_samples")
     public void test_until_DAYS(Symmetry454Date sym454, LocalDate iso) {
-        assertEquals(sym454.until(iso.plusDays(0), DAYS), 0);
-        assertEquals(sym454.until(iso.plusDays(1), DAYS), 1);
-        assertEquals(sym454.until(iso.plusDays(35), DAYS), 35);
-        assertEquals(sym454.until(iso.minusDays(40), DAYS), -40);
+        assertEquals(0, sym454.until(iso.plusDays(0), DAYS));
+        assertEquals(1, sym454.until(iso.plusDays(1), DAYS));
+        assertEquals(35, sym454.until(iso.plusDays(35), DAYS));
+        assertEquals(-40, sym454.until(iso.minusDays(40), DAYS));
     }
 
     @DataProvider
@@ -334,19 +334,19 @@ public class TestSymmetry454Chronology {
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
-        assertEquals(Symmetry454Date.of(year, month, day).lengthOfMonth(), length);
+        assertEquals(length, Symmetry454Date.of(year, month, day).lengthOfMonth());
     }
 
     @Test
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
-        assertEquals(Symmetry454Date.of(year, month, 1).lengthOfMonth(), length);
+        assertEquals(length, Symmetry454Date.of(year, month, 1).lengthOfMonth());
     }
 
     @Test
     public void test_lengthOfMonth_specific() {
-        assertEquals(Symmetry454Date.of(2000, 12, 28).lengthOfMonth(), 28);
-        assertEquals(Symmetry454Date.of(2004, 12, 28).lengthOfMonth(), 35);
+        assertEquals(28, Symmetry454Date.of(2000, 12, 28).lengthOfMonth());
+        assertEquals(35, Symmetry454Date.of(2004, 12, 28).lengthOfMonth());
     }
 
     //-----------------------------------------------------------------------
@@ -363,7 +363,7 @@ public class TestSymmetry454Chronology {
             assertEquals(era, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             Symmetry454Date eraBased = Symmetry454Chronology.INSTANCE.date(era, year, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
 
 
@@ -374,7 +374,7 @@ public class TestSymmetry454Chronology {
             assertEquals(era, base.getEra());
             assertEquals(1 - year, base.get(YEAR_OF_ERA));
             Symmetry454Date eraBased = Symmetry454Chronology.INSTANCE.date(era, year, 1, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
@@ -387,18 +387,18 @@ public class TestSymmetry454Chronology {
             assertEquals(era, base.getEra());
             assertEquals(year, base.get(YEAR_OF_ERA));
             Symmetry454Date eraBased = Symmetry454Chronology.INSTANCE.dateYearDay(era, year, 1);
-            assertEquals(eraBased, base);
+            assertEquals(base, eraBased);
         }
     }
 
     @Test
     public void test_prolepticYear_specific() {
-        assertEquals(Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 4), 4);
-        assertEquals(Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 3), 3);
-        assertEquals(Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2), 2);
-        assertEquals(Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1), 1);
-        assertEquals(Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2000), 2000);
-        assertEquals(Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1582), 1582);
+        assertEquals(4, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
+        assertEquals(3, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 3));
+        assertEquals(2, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2));
+        assertEquals(1, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1));
+        assertEquals(2000, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 2000));
+        assertEquals(1582, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1582));
     }
 
     @DataProvider
@@ -436,8 +436,8 @@ public class TestSymmetry454Chronology {
 
     @Test
     public void test_Chronology_eraOf() {
-        assertEquals(Symmetry454Chronology.INSTANCE.eraOf(0), IsoEra.BCE);
-        assertEquals(Symmetry454Chronology.INSTANCE.eraOf(1), IsoEra.CE);
+        assertEquals(IsoEra.BCE, Symmetry454Chronology.INSTANCE.eraOf(0));
+        assertEquals(IsoEra.CE, Symmetry454Chronology.INSTANCE.eraOf(1));
     }
 
     @Test(expected = DateTimeException.class)
@@ -448,7 +448,7 @@ public class TestSymmetry454Chronology {
     @Test
     public void test_Chronology_eras() {
         List<Era> eras = Symmetry454Chronology.INSTANCE.eras();
-        assertEquals(eras.size(), 2);
+        assertEquals(2, eras.size());
         assertTrue(eras.contains(IsoEra.BCE));
         assertTrue(eras.contains(IsoEra.CE));
     }
@@ -458,19 +458,19 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_Chronology_range() {
-        assertEquals(Symmetry454Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH), ValueRange.of(1, 7));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR), ValueRange.of(1, 7));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH), ValueRange.of(1, 4, 5));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR), ValueRange.of(1, 52, 53));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(DAY_OF_WEEK), ValueRange.of(1, 7));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(DAY_OF_MONTH), ValueRange.of(1, 28, 35));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(DAY_OF_YEAR), ValueRange.of(1, 364, 371));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(ERA), ValueRange.of(0, 1));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(EPOCH_DAY), ValueRange.of(-1_000_000 * 364L - 177_474 * 7 - 719_162, 1_000_000 * 364L + 177_474 * 7 - 719_162));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(MONTH_OF_YEAR), ValueRange.of(1, 12));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(PROLEPTIC_MONTH), ValueRange.of(-12_000_000L, 11_999_999L));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(YEAR), ValueRange.of(-1_000_000L, 1_000_000));
-        assertEquals(Symmetry454Chronology.INSTANCE.range(YEAR_OF_ERA), ValueRange.of(-1_000_000, 1_000_000));
+        assertEquals(ValueRange.of(1, 7), Symmetry454Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_MONTH));
+        assertEquals(ValueRange.of(1, 7), Symmetry454Chronology.INSTANCE.range(ALIGNED_DAY_OF_WEEK_IN_YEAR));
+        assertEquals(ValueRange.of(1, 4, 5), Symmetry454Chronology.INSTANCE.range(ALIGNED_WEEK_OF_MONTH));
+        assertEquals(ValueRange.of(1, 52, 53), Symmetry454Chronology.INSTANCE.range(ALIGNED_WEEK_OF_YEAR));
+        assertEquals(ValueRange.of(1, 7), Symmetry454Chronology.INSTANCE.range(DAY_OF_WEEK));
+        assertEquals(ValueRange.of(1, 28, 35), Symmetry454Chronology.INSTANCE.range(DAY_OF_MONTH));
+        assertEquals(ValueRange.of(1, 364, 371), Symmetry454Chronology.INSTANCE.range(DAY_OF_YEAR));
+        assertEquals(ValueRange.of(0, 1), Symmetry454Chronology.INSTANCE.range(ERA));
+        assertEquals(ValueRange.of(-1_000_000 * 364L - 177_474 * 7 - 719_162, 1_000_000 * 364L + 177_474 * 7 - 719_162), Symmetry454Chronology.INSTANCE.range(EPOCH_DAY));
+        assertEquals(ValueRange.of(1, 12), Symmetry454Chronology.INSTANCE.range(MONTH_OF_YEAR));
+        assertEquals(ValueRange.of(-12_000_000L, 11_999_999L), Symmetry454Chronology.INSTANCE.range(PROLEPTIC_MONTH));
+        assertEquals(ValueRange.of(-1_000_000L, 1_000_000), Symmetry454Chronology.INSTANCE.range(YEAR));
+        assertEquals(ValueRange.of(-1_000_000, 1_000_000), Symmetry454Chronology.INSTANCE.range(YEAR_OF_ERA));
     }
 
     //-----------------------------------------------------------------------
@@ -525,7 +525,7 @@ public class TestSymmetry454Chronology {
     @Test
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
-        assertEquals(Symmetry454Date.of(year, month, dom).range(field), range);
+        assertEquals(range, Symmetry454Date.of(year, month, dom).range(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -574,7 +574,7 @@ public class TestSymmetry454Chronology {
     @Test
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
-        assertEquals(Symmetry454Date.of(year, month, dom).getLong(field), expected);
+        assertEquals(expected, Symmetry454Date.of(year, month, dom).getLong(field));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -666,7 +666,7 @@ public class TestSymmetry454Chronology {
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(Symmetry454Date.of(year, month, dom).with(field, value), Symmetry454Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).with(field, value));
     }
 
     @DataProvider
@@ -749,7 +749,7 @@ public class TestSymmetry454Chronology {
         Symmetry454Date base = Symmetry454Date.of(year, month, day);
         Symmetry454Date expected = Symmetry454Date.of(expectedYear, expectedMonth, expectedDay);
         Symmetry454Date actual = base.with(TemporalAdjusters.lastDayOfMonth());
-        assertEquals(actual, expected);
+        assertEquals(expected, actual);
     }
 
     //-----------------------------------------------------------------------
@@ -759,7 +759,7 @@ public class TestSymmetry454Chronology {
     public void test_adjust_toLocalDate() {
         Symmetry454Date sym454 = Symmetry454Date.of(2000, 1, 4);
         Symmetry454Date test = sym454.with(LocalDate.of(2012, 7, 6));
-        assertEquals(test, Symmetry454Date.of(2012, 7, 5));
+        assertEquals(Symmetry454Date.of(2012, 7, 5), test);
     }
 
     @Test(expected = DateTimeException.class)
@@ -775,14 +775,14 @@ public class TestSymmetry454Chronology {
     public void test_LocalDate_adjustToSymmetry454Date() {
         Symmetry454Date sym454 = Symmetry454Date.of(2012, 7, 19);
         LocalDate test = LocalDate.MIN.with(sym454);
-        assertEquals(test, LocalDate.of(2012, 7, 20));
+        assertEquals(LocalDate.of(2012, 7, 20), test);
     }
 
     @Test
     public void test_LocalDateTime_adjustToSymmetry454Date() {
         Symmetry454Date sym454 = Symmetry454Date.of(2012, 7, 19);
         LocalDateTime test = LocalDateTime.MIN.with(sym454);
-        assertEquals(test, LocalDateTime.of(2012, 7, 20, 0, 0));
+        assertEquals(LocalDateTime.of(2012, 7, 20, 0, 0), test);
     }
 
     //-----------------------------------------------------------------------
@@ -850,7 +850,7 @@ public class TestSymmetry454Chronology {
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(Symmetry454Date.of(year, month, dom).plus(amount, unit), Symmetry454Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -858,7 +858,7 @@ public class TestSymmetry454Chronology {
     public void test_plus_leapWeek_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
-        assertEquals(Symmetry454Date.of(year, month, dom).plus(amount, unit), Symmetry454Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).plus(amount, unit));
     }
 
     @Test
@@ -867,7 +867,7 @@ public class TestSymmetry454Chronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(Symmetry454Date.of(year, month, dom).minus(amount, unit), Symmetry454Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).minus(amount, unit));
     }
 
     @Test
@@ -876,7 +876,7 @@ public class TestSymmetry454Chronology {
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
             int year, int month, int dom) {
-        assertEquals(Symmetry454Date.of(year, month, dom).minus(amount, unit), Symmetry454Date.of(expectedYear, expectedMonth, expectedDom));
+        assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).minus(amount, unit));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -938,7 +938,7 @@ public class TestSymmetry454Chronology {
             TemporalUnit unit, long expected) {
         Symmetry454Date start = Symmetry454Date.of(year1, month1, dom1);
         Symmetry454Date end = Symmetry454Date.of(year2, month2, dom2);
-        assertEquals(start.until(end, unit), expected);
+        assertEquals(expected, start.until(end, unit));
     }
 
     @Test
@@ -950,7 +950,7 @@ public class TestSymmetry454Chronology {
         Symmetry454Date start = Symmetry454Date.of(year1, month1, dom1);
         Symmetry454Date end = Symmetry454Date.of(year2, month2, dom2);
         ChronoPeriod period = Symmetry454Chronology.INSTANCE.period(yearPeriod, monthPeriod, dayPeriod);
-        assertEquals(start.until(end), period);
+        assertEquals(period, start.until(end));
     }
 
     @Test(expected = UnsupportedTemporalTypeException.class)
@@ -965,25 +965,25 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_Period() {
-        assertEquals(Symmetry454Date.of(2014, 5, 21).plus(Symmetry454Chronology.INSTANCE.period(0, 2, 8)),
-                Symmetry454Date.of(2014, 8, 1));
+        assertEquals(Symmetry454Date.of(2014, 8, 1),
+                Symmetry454Date.of(2014, 5, 21).plus(Symmetry454Chronology.INSTANCE.period(0, 2, 8)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_plus_Period_ISO() {
-        assertEquals(Symmetry454Date.of(2014, 5, 26).plus(Period.ofMonths(2)),
-                Symmetry454Date.of(2014, 7, 26));
+        assertEquals(Symmetry454Date.of(2014, 7, 26),
+                Symmetry454Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
     public void test_minus_Period() {
-        assertEquals(Symmetry454Date.of(2014, 5, 26).minus(Symmetry454Chronology.INSTANCE.period(0, 2, 3)),
-                Symmetry454Date.of(2014, 3, 23));
+        assertEquals(Symmetry454Date.of(2014, 3, 23),
+                Symmetry454Date.of(2014, 5, 26).minus(Symmetry454Chronology.INSTANCE.period(0, 2, 3)));
     }
 
     @Test(expected = DateTimeException.class)
     public void test_minus_Period_ISO() {
-        assertEquals(Symmetry454Date.of(2014, 5, 26).minus(Period.ofMonths(2)), Symmetry454Date.of(2014, 3, 26));
+        assertEquals(Symmetry454Date.of(2014, 3, 26), Symmetry454Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -1026,6 +1026,6 @@ public class TestSymmetry454Chronology {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(Symmetry454Date date, String expected) {
-        assertEquals(date.toString(), expected);
+        assertEquals(expected, date.toString());
     }
 }

--- a/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
@@ -75,7 +75,7 @@ public class TestTaiInstant {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -87,18 +87,18 @@ public class TestTaiInstant {
         for (long i = -2; i <= 2; i++) {
             for (int j = 0; j < 10; j++) {
                 TaiInstant t = TaiInstant.ofTaiSeconds(i, j);
-                assertEquals(t.getTaiSeconds(), i);
-                assertEquals(t.getNano(), j);
+                assertEquals(i, t.getTaiSeconds());
+                assertEquals(j, t.getNano());
             }
             for (int j = -10; j < 0; j++) {
                 TaiInstant t = TaiInstant.ofTaiSeconds(i, j);
-                assertEquals(t.getTaiSeconds(), i - 1);
-                assertEquals(t.getNano(), j + 1000000000);
+                assertEquals(i - 1, t.getTaiSeconds());
+                assertEquals(j + 1000000000, t.getNano());
             }
             for (int j = 999999990; j < 1000000000; j++) {
                 TaiInstant t = TaiInstant.ofTaiSeconds(i, j);
-                assertEquals(t.getTaiSeconds(), i);
-                assertEquals(t.getNano(), j);
+                assertEquals(i, t.getTaiSeconds());
+                assertEquals(j, t.getNano());
             }
         }
     }
@@ -106,8 +106,8 @@ public class TestTaiInstant {
     @Test
     public void factory_ofTaiSeconds_long_long_nanosNegativeAdjusted() {
         TaiInstant test = TaiInstant.ofTaiSeconds(2L, -1);
-        assertEquals(test.getTaiSeconds(), 1);
-        assertEquals(test.getNano(), 999999999);
+        assertEquals(1, test.getTaiSeconds());
+        assertEquals(999999999, test.getNano());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -121,8 +121,8 @@ public class TestTaiInstant {
     @Test
     public void factory_of_Instant() {
         TaiInstant test = TaiInstant.of(Instant.ofEpochSecond(0, 2));
-        assertEquals(test.getTaiSeconds(), (40587L - 36204) * 24 * 60 * 60 + 10); //((1970 - 1958) * 365 + 3) * 24 * 60 * 60 + 10);
-        assertEquals(test.getNano(), 2);
+        assertEquals((40587L - 36204) * 24 * 60 * 60 + 10, test.getTaiSeconds()); //((1970 - 1958) * 365 + 3) * 24 * 60 * 60 + 10);
+        assertEquals(2, test.getNano());
     }
 
     @Test(expected = NullPointerException.class)
@@ -138,8 +138,8 @@ public class TestTaiInstant {
         for (int i = -1000; i < 1000; i++) {
             for (int j = 0; j < 10; j++) {
                 TaiInstant test = TaiInstant.of(UtcInstant.ofModifiedJulianDay(36204 + i, j * 1000000000L + 2L));
-                assertEquals(test.getTaiSeconds(), i * 24 * 60 * 60 + j + 10);
-                assertEquals(test.getNano(), 2);
+                assertEquals(i * 24 * 60 * 60 + j + 10, test.getTaiSeconds());
+                assertEquals(2, test.getNano());
             }
         }
     }
@@ -158,8 +158,8 @@ public class TestTaiInstant {
             for (int j = 900000000; j < 990000000; j += 10000000) {
                 String str = i + "." + j + "s(TAI)";
                 TaiInstant test = TaiInstant.parse(str);
-                assertEquals(test.getTaiSeconds(), i);
-                assertEquals(test.getNano(), j);
+                assertEquals(i, test.getTaiSeconds());
+                assertEquals(j, test.getNano());
             }
         }
     }
@@ -206,8 +206,8 @@ public class TestTaiInstant {
     @UseDataProvider("data_withTAISeconds")
     public void test_withTAISeconds(long tai, long nanos, long newTai, Long expectedTai, Long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos).withTaiSeconds(newTai);
-        assertEquals(i.getTaiSeconds(), expectedTai.longValue());
-        assertEquals(i.getNano(), expectedNanos.longValue());
+        assertEquals(expectedTai.longValue(), i.getTaiSeconds());
+        assertEquals(expectedNanos.longValue(), i.getNano());
     }
 
     //-----------------------------------------------------------------------
@@ -231,8 +231,8 @@ public class TestTaiInstant {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos);
         if (expectedTai != null) {
             i = i.withNano(newNano);
-            assertEquals(i.getTaiSeconds(), expectedTai.longValue());
-            assertEquals(i.getNano(), expectedNanos.longValue());
+            assertEquals(expectedTai.longValue(), i.getTaiSeconds());
+            assertEquals(expectedNanos.longValue(), i.getNano());
         } else {
             try {
                 i = i.withNano(newNano);
@@ -435,8 +435,8 @@ public class TestTaiInstant {
     @UseDataProvider("data_plus")
     public void test_plus(long seconds, int nanos, long plusSeconds, int plusNanos, long expectedSeconds, int expectedNanoOfSecond) {
         TaiInstant i = TaiInstant.ofTaiSeconds(seconds, nanos).plus(Duration.ofSeconds(plusSeconds, plusNanos));
-        assertEquals(i.getTaiSeconds(), expectedSeconds);
-        assertEquals(i.getNano(), expectedNanoOfSecond);
+        assertEquals(expectedSeconds, i.getTaiSeconds());
+        assertEquals(expectedNanoOfSecond, i.getNano());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -643,8 +643,8 @@ public class TestTaiInstant {
     @UseDataProvider("data_minus")
     public void test_minus(long seconds, int nanos, long minusSeconds, int minusNanos, long expectedSeconds, int expectedNanoOfSecond) {
         TaiInstant i = TaiInstant.ofTaiSeconds(seconds, nanos).minus(Duration.ofSeconds(minusSeconds, minusNanos));
-        assertEquals(i.getTaiSeconds(), expectedSeconds);
-        assertEquals(i.getNano(), expectedNanoOfSecond);
+        assertEquals(expectedSeconds, i.getTaiSeconds());
+        assertEquals(expectedNanoOfSecond, i.getNano());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -667,8 +667,8 @@ public class TestTaiInstant {
         TaiInstant tai1 = TaiInstant.ofTaiSeconds(10, 0);
         TaiInstant tai2 = TaiInstant.ofTaiSeconds(25, 0);
         Duration test = tai1.durationUntil(tai2);
-        assertEquals(test.getSeconds(), 15);
-        assertEquals(test.getNano(), 0);
+        assertEquals(15, test.getSeconds());
+        assertEquals(0, test.getNano());
     }
 
     @Test
@@ -676,8 +676,8 @@ public class TestTaiInstant {
         TaiInstant tai1 = TaiInstant.ofTaiSeconds(4, 5);
         TaiInstant tai2 = TaiInstant.ofTaiSeconds(4, 7);
         Duration test = tai1.durationUntil(tai2);
-        assertEquals(test.getSeconds(), 0);
-        assertEquals(test.getNano(), 2);
+        assertEquals(0, test.getSeconds());
+        assertEquals(2, test.getNano());
     }
 
     @Test
@@ -685,8 +685,8 @@ public class TestTaiInstant {
         TaiInstant tai1 = TaiInstant.ofTaiSeconds(4, 9);
         TaiInstant tai2 = TaiInstant.ofTaiSeconds(4, 7);
         Duration test = tai1.durationUntil(tai2);
-        assertEquals(test.getSeconds(), -1);
-        assertEquals(test.getNano(), 999999998);
+        assertEquals(-1, test.getSeconds());
+        assertEquals(999999998, test.getNano());
     }
 
     //-----------------------------------------------------------------------
@@ -698,7 +698,7 @@ public class TestTaiInstant {
             for (int j = 0; j < 10; j++) {
                 UtcInstant expected = UtcInstant.ofModifiedJulianDay(36204 + i, j * 1000000000L + 2L);
                 TaiInstant test = TaiInstant.ofTaiSeconds(i * 24 * 60 * 60 + j + 10, 2);
-                assertEquals(test.toUtcInstant(), expected);
+                assertEquals(expected, test.toUtcInstant());
             }
         }
     }
@@ -712,7 +712,7 @@ public class TestTaiInstant {
             for (int j = 0; j < 10; j++) {
                 Instant expected = Instant.ofEpochSecond(-378691200L + i * 24 * 60 * 60 + j).plusNanos(2);
                 TaiInstant test = TaiInstant.ofTaiSeconds(i * 24 * 60 * 60 + j + 10, 2);
-                assertEquals(test.toInstant(), expected);
+                assertEquals(expected, test.toInstant());
             }
         }
     }
@@ -745,14 +745,14 @@ public class TestTaiInstant {
             for (int j = 0; j < instants.length; j++) {
                 TaiInstant b = instants[j];
                 if (i < j) {
-                    assertEquals(a.compareTo(b) < 0, true);
-                    assertEquals(a.equals(b), false);
+                    assertEquals(true, a.compareTo(b) < 0);
+                    assertEquals(false, a.equals(b));
                 } else if (i > j) {
-                    assertEquals(a.compareTo(b) > 0, true);
-                    assertEquals(a.equals(b), false);
+                    assertEquals(true, a.compareTo(b) > 0);
+                    assertEquals(false, a.equals(b));
                 } else {
-                    assertEquals(a.compareTo(b), 0);
-                    assertEquals(a.equals(b), true);
+                    assertEquals(0, a.compareTo(b));
+                    assertEquals(true, a.equals(b));
                 }
             }
         }
@@ -781,37 +781,37 @@ public class TestTaiInstant {
         TaiInstant test5n = TaiInstant.ofTaiSeconds(5L, 30);
         TaiInstant test6 = TaiInstant.ofTaiSeconds(6L, 20);
 
-        assertEquals(test5a.equals(test5a), true);
-        assertEquals(test5a.equals(test5b), true);
-        assertEquals(test5a.equals(test5n), false);
-        assertEquals(test5a.equals(test6), false);
+        assertEquals(true, test5a.equals(test5a));
+        assertEquals(true, test5a.equals(test5b));
+        assertEquals(false, test5a.equals(test5n));
+        assertEquals(false, test5a.equals(test6));
 
-        assertEquals(test5b.equals(test5a), true);
-        assertEquals(test5b.equals(test5b), true);
-        assertEquals(test5b.equals(test5n), false);
-        assertEquals(test5b.equals(test6), false);
+        assertEquals(true, test5b.equals(test5a));
+        assertEquals(true, test5b.equals(test5b));
+        assertEquals(false, test5b.equals(test5n));
+        assertEquals(false, test5b.equals(test6));
 
-        assertEquals(test5n.equals(test5a), false);
-        assertEquals(test5n.equals(test5b), false);
-        assertEquals(test5n.equals(test5n), true);
-        assertEquals(test5n.equals(test6), false);
+        assertEquals(false, test5n.equals(test5a));
+        assertEquals(false, test5n.equals(test5b));
+        assertEquals(true, test5n.equals(test5n));
+        assertEquals(false, test5n.equals(test6));
 
-        assertEquals(test6.equals(test5a), false);
-        assertEquals(test6.equals(test5b), false);
-        assertEquals(test6.equals(test5n), false);
-        assertEquals(test6.equals(test6), true);
+        assertEquals(false, test6.equals(test5a));
+        assertEquals(false, test6.equals(test5b));
+        assertEquals(false, test6.equals(test5n));
+        assertEquals(true, test6.equals(test6));
     }
 
     @Test
     public void test_equals_null() {
         TaiInstant test5 = TaiInstant.ofTaiSeconds(5L, 20);
-        assertEquals(test5.equals(null), false);
+        assertEquals(false, test5.equals(null));
     }
 
     @Test
     public void test_equals_otherClass() {
         TaiInstant test5 = TaiInstant.ofTaiSeconds(5L, 20);
-        assertEquals(test5.equals(""), false);
+        assertEquals(false, test5.equals(""));
     }
 
     //-----------------------------------------------------------------------
@@ -824,12 +824,12 @@ public class TestTaiInstant {
         TaiInstant test5n = TaiInstant.ofTaiSeconds(5L, 30);
         TaiInstant test6 = TaiInstant.ofTaiSeconds(6L, 20);
 
-        assertEquals(test5a.hashCode() == test5a.hashCode(), true);
-        assertEquals(test5a.hashCode() == test5b.hashCode(), true);
-        assertEquals(test5b.hashCode() == test5b.hashCode(), true);
+        assertEquals(true, test5a.hashCode() == test5a.hashCode());
+        assertEquals(true, test5a.hashCode() == test5b.hashCode());
+        assertEquals(true, test5b.hashCode() == test5b.hashCode());
 
-        assertEquals(test5a.hashCode() == test5n.hashCode(), false);
-        assertEquals(test5a.hashCode() == test6.hashCode(), false);
+        assertEquals(false, test5a.hashCode() == test5n.hashCode());
+        assertEquals(false, test5a.hashCode() == test6.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -838,19 +838,19 @@ public class TestTaiInstant {
     @Test
     public void test_toString_standard() {
         TaiInstant t = TaiInstant.ofTaiSeconds(123L, 123456789);
-        assertEquals(t.toString(), "123.123456789s(TAI)");
+        assertEquals("123.123456789s(TAI)", t.toString());
     }
 
     @Test
     public void test_toString_negative() {
         TaiInstant t = TaiInstant.ofTaiSeconds(-123L, 123456789);
-        assertEquals(t.toString(), "-123.123456789s(TAI)");
+        assertEquals("-123.123456789s(TAI)", t.toString());
     }
 
     @Test
     public void test_toString_zeroDecimal() {
         TaiInstant t = TaiInstant.ofTaiSeconds(0L, 567);
-        assertEquals(t.toString(), "0.000000567s(TAI)");
+        assertEquals("0.000000567s(TAI)", t.toString());
     }
 
 }

--- a/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
@@ -85,7 +85,7 @@ public class TestUtcInstant {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertEquals(ois.readObject(), test);
+            assertEquals(test, ois.readObject());
         }
     }
 
@@ -97,9 +97,9 @@ public class TestUtcInstant {
         for (long i = -2; i <= 2; i++) {
             for (int j = 0; j < 10; j++) {
                 UtcInstant t = UtcInstant.ofModifiedJulianDay(i, j);
-                assertEquals(t.getModifiedJulianDay(), i);
-                assertEquals(t.getNanoOfDay(), j);
-                assertEquals(t.isLeapSecond(), false);
+                assertEquals(i, t.getModifiedJulianDay());
+                assertEquals(j, t.getNanoOfDay());
+                assertEquals(false, t.isLeapSecond());
             }
         }
     }
@@ -107,15 +107,15 @@ public class TestUtcInstant {
     @Test
     public void factory_ofModifiedJulianDay_long_long_startLeap() {
         UtcInstant t = UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_DAY);
-        assertEquals(t.getModifiedJulianDay(), MJD_1972_12_31_LEAP);
-        assertEquals(t.getNanoOfDay(), NANOS_PER_DAY);
+        assertEquals(MJD_1972_12_31_LEAP, t.getModifiedJulianDay());
+        assertEquals(NANOS_PER_DAY, t.getNanoOfDay());
     }
 
     @Test
     public void factory_ofModifiedJulianDay_long_long_endLeap() {
         UtcInstant t = UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_LEAP_DAY - 1);
-        assertEquals(t.getModifiedJulianDay(), MJD_1972_12_31_LEAP);
-        assertEquals(t.getNanoOfDay(), NANOS_PER_LEAP_DAY - 1);
+        assertEquals(MJD_1972_12_31_LEAP, t.getModifiedJulianDay());
+        assertEquals(NANOS_PER_LEAP_DAY - 1, t.getNanoOfDay());
     }
 
     @Test(expected = DateTimeException.class)
@@ -139,8 +139,8 @@ public class TestUtcInstant {
     @Test
     public void factory_of_Instant() {
         UtcInstant test = UtcInstant.of(Instant.ofEpochSecond(0, 2));  // 1970-01-01
-        assertEquals(test.getModifiedJulianDay(), 40587);
-        assertEquals(test.getNanoOfDay(), 2);
+        assertEquals(40587, test.getModifiedJulianDay());
+        assertEquals(2, test.getNanoOfDay());
     }
 
     @Test(expected = NullPointerException.class)
@@ -157,7 +157,7 @@ public class TestUtcInstant {
             for (int j = 0; j < 10; j++) {
                 UtcInstant expected = UtcInstant.ofModifiedJulianDay(36204 + i, j * NANOS_PER_SEC + 2L);
                 TaiInstant tai = TaiInstant.ofTaiSeconds(i * SECS_PER_DAY + j + 10, 2);
-                assertEquals(UtcInstant.of(tai), expected);
+                assertEquals(expected, UtcInstant.of(tai));
             }
         }
     }
@@ -172,8 +172,8 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     @Test
     public void factory_parse_CharSequence() {
-        assertEquals(UtcInstant.parse("1972-12-31T23:59:59Z"), UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_DAY - NANOS_PER_SEC));
-        assertEquals(UtcInstant.parse("1972-12-31T23:59:60Z"), UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_DAY));
+        assertEquals(UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_DAY - NANOS_PER_SEC), UtcInstant.parse("1972-12-31T23:59:59Z"));
+        assertEquals(UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_DAY), UtcInstant.parse("1972-12-31T23:59:60Z"));
     }
 
     @DataProvider
@@ -226,8 +226,8 @@ public class TestUtcInstant {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
             i = i.withModifiedJulianDay(newMjd);
-            assertEquals(i.getModifiedJulianDay(), expectedMjd.longValue());
-            assertEquals(i.getNanoOfDay(), expectedNanos.longValue());
+            assertEquals(expectedMjd.longValue(), i.getModifiedJulianDay());
+            assertEquals(expectedNanos.longValue(), i.getNanoOfDay());
         } else {
             try {
                 i = i.withModifiedJulianDay(newMjd);
@@ -269,8 +269,8 @@ public class TestUtcInstant {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
             i = i.withNanoOfDay(newNanoOfDay);
-            assertEquals(i.getModifiedJulianDay(), expectedMjd.longValue());
-            assertEquals(i.getNanoOfDay(), expectedNanos.longValue());
+            assertEquals(expectedMjd.longValue(), i.getModifiedJulianDay());
+            assertEquals(expectedNanos.longValue(), i.getNanoOfDay());
         } else {
             try {
                 i = i.withNanoOfDay(newNanoOfDay);
@@ -323,8 +323,8 @@ public class TestUtcInstant {
     @UseDataProvider("data_plus")
     public void test_plus(long mjd, long nanos, long plusSeconds, int plusNanos, long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos).plus(Duration.ofSeconds(plusSeconds, plusNanos));
-        assertEquals(i.getModifiedJulianDay(), expectedMjd);
-        assertEquals(i.getNanoOfDay(), expectedNanos);
+        assertEquals(expectedMjd, i.getModifiedJulianDay());
+        assertEquals(expectedNanos, i.getNanoOfDay());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -381,8 +381,8 @@ public class TestUtcInstant {
     @UseDataProvider("data_minus")
     public void test_minus(long mjd, long nanos, long minusSeconds, int minusNanos, long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos).minus(Duration.ofSeconds(minusSeconds, minusNanos));
-        assertEquals(i.getModifiedJulianDay(), expectedMjd);
-        assertEquals(i.getNanoOfDay(), expectedNanos);
+        assertEquals(expectedMjd, i.getModifiedJulianDay());
+        assertEquals(expectedNanos, i.getNanoOfDay());
     }
 
     @Test(expected = ArithmeticException.class)
@@ -405,8 +405,8 @@ public class TestUtcInstant {
         UtcInstant utc1 = UtcInstant.ofModifiedJulianDay(MJD_1972_12_30, 0);
         UtcInstant utc2 = UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, 0);
         Duration test = utc1.durationUntil(utc2);
-        assertEquals(test.getSeconds(), 86400);
-        assertEquals(test.getNano(), 0);
+        assertEquals(86400, test.getSeconds());
+        assertEquals(0, test.getNano());
     }
 
     @Test
@@ -414,8 +414,8 @@ public class TestUtcInstant {
         UtcInstant utc1 = UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, 0);
         UtcInstant utc2 = UtcInstant.ofModifiedJulianDay(MJD_1973_01_01, 0);
         Duration test = utc1.durationUntil(utc2);
-        assertEquals(test.getSeconds(), 86401);
-        assertEquals(test.getNano(), 0);
+        assertEquals(86401, test.getSeconds());
+        assertEquals(0, test.getNano());
     }
 
     @Test
@@ -423,8 +423,8 @@ public class TestUtcInstant {
         UtcInstant utc1 = UtcInstant.ofModifiedJulianDay(MJD_1973_01_01, 0);
         UtcInstant utc2 = UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, 0);
         Duration test = utc1.durationUntil(utc2);
-        assertEquals(test.getSeconds(), -86401);
-        assertEquals(test.getNano(), 0);
+        assertEquals(-86401, test.getSeconds());
+        assertEquals(0, test.getNano());
     }
 
     //-----------------------------------------------------------------------
@@ -436,8 +436,8 @@ public class TestUtcInstant {
             for (int j = 0; j < 10; j++) {
                 UtcInstant utc = UtcInstant.ofModifiedJulianDay(36204 + i, j * NANOS_PER_SEC + 2L);
                 TaiInstant test = utc.toTaiInstant();
-                assertEquals(test.getTaiSeconds(), i * SECS_PER_DAY + j + 10);
-                assertEquals(test.getNano(), 2);
+                assertEquals(i * SECS_PER_DAY + j + 10, test.getTaiSeconds());
+                assertEquals(2, test.getNano());
             }
         }
     }
@@ -457,7 +457,7 @@ public class TestUtcInstant {
             for (int j = 0; j < 10; j++) {
                 Instant expected = Instant.ofEpochSecond(315532800 + i * SECS_PER_DAY + j).plusNanos(2);
                 UtcInstant test = UtcInstant.ofModifiedJulianDay(44239 + i, j * NANOS_PER_SEC + 2);
-                assertEquals(test.toInstant(), expected);
+                assertEquals(expected, test.toInstant());
             }
         }
     }
@@ -490,14 +490,14 @@ public class TestUtcInstant {
             for (int j = 0; j < instants.length; j++) {
                 UtcInstant b = instants[j];
                 if (i < j) {
-                    assertEquals(a.compareTo(b), -1);
-                    assertEquals(a.equals(b), false);
+                    assertEquals(-1, a.compareTo(b));
+                    assertEquals(false, a.equals(b));
                 } else if (i > j) {
-                    assertEquals(a.compareTo(b), 1);
-                    assertEquals(a.equals(b), false);
+                    assertEquals(1, a.compareTo(b));
+                    assertEquals(false, a.equals(b));
                 } else {
-                    assertEquals(a.compareTo(b), 0);
-                    assertEquals(a.equals(b), true);
+                    assertEquals(0, a.compareTo(b));
+                    assertEquals(true, a.equals(b));
                 }
             }
         }
@@ -526,37 +526,37 @@ public class TestUtcInstant {
         UtcInstant test5n = UtcInstant.ofModifiedJulianDay(5L, 30);
         UtcInstant test6 = UtcInstant.ofModifiedJulianDay(6L, 20);
 
-        assertEquals(test5a.equals(test5a), true);
-        assertEquals(test5a.equals(test5b), true);
-        assertEquals(test5a.equals(test5n), false);
-        assertEquals(test5a.equals(test6), false);
+        assertEquals(true, test5a.equals(test5a));
+        assertEquals(true, test5a.equals(test5b));
+        assertEquals(false, test5a.equals(test5n));
+        assertEquals(false, test5a.equals(test6));
 
-        assertEquals(test5b.equals(test5a), true);
-        assertEquals(test5b.equals(test5b), true);
-        assertEquals(test5b.equals(test5n), false);
-        assertEquals(test5b.equals(test6), false);
+        assertEquals(true, test5b.equals(test5a));
+        assertEquals(true, test5b.equals(test5b));
+        assertEquals(false, test5b.equals(test5n));
+        assertEquals(false, test5b.equals(test6));
 
-        assertEquals(test5n.equals(test5a), false);
-        assertEquals(test5n.equals(test5b), false);
-        assertEquals(test5n.equals(test5n), true);
-        assertEquals(test5n.equals(test6), false);
+        assertEquals(false, test5n.equals(test5a));
+        assertEquals(false, test5n.equals(test5b));
+        assertEquals(true, test5n.equals(test5n));
+        assertEquals(false, test5n.equals(test6));
 
-        assertEquals(test6.equals(test5a), false);
-        assertEquals(test6.equals(test5b), false);
-        assertEquals(test6.equals(test5n), false);
-        assertEquals(test6.equals(test6), true);
+        assertEquals(false, test6.equals(test5a));
+        assertEquals(false, test6.equals(test5b));
+        assertEquals(false, test6.equals(test5n));
+        assertEquals(true, test6.equals(test6));
     }
 
     @Test
     public void test_equals_null() {
         UtcInstant test5 = UtcInstant.ofModifiedJulianDay(5L, 20);
-        assertEquals(test5.equals(null), false);
+        assertEquals(false, test5.equals(null));
     }
 
     @Test
     public void test_equals_otherClass() {
         UtcInstant test5 = UtcInstant.ofModifiedJulianDay(5L, 20);
-        assertEquals(test5.equals(""), false);
+        assertEquals(false, test5.equals(""));
     }
 
     //-----------------------------------------------------------------------
@@ -569,12 +569,12 @@ public class TestUtcInstant {
         UtcInstant test5n = UtcInstant.ofModifiedJulianDay(5L, 30);
         UtcInstant test6 = UtcInstant.ofModifiedJulianDay(6L, 20);
 
-        assertEquals(test5a.hashCode() == test5a.hashCode(), true);
-        assertEquals(test5a.hashCode() == test5b.hashCode(), true);
-        assertEquals(test5b.hashCode() == test5b.hashCode(), true);
+        assertEquals(true, test5a.hashCode() == test5a.hashCode());
+        assertEquals(true, test5a.hashCode() == test5b.hashCode());
+        assertEquals(true, test5b.hashCode() == test5b.hashCode());
 
-        assertEquals(test5a.hashCode() == test5n.hashCode(), false);
-        assertEquals(test5a.hashCode() == test6.hashCode(), false);
+        assertEquals(false, test5a.hashCode() == test5n.hashCode());
+        assertEquals(false, test5a.hashCode() == test6.hashCode());
     }
 
     //-----------------------------------------------------------------------
@@ -602,13 +602,13 @@ public class TestUtcInstant {
     @Test
     @UseDataProvider("data_toString")
     public void test_toString(long mjd, long nod, String expected) {
-        assertEquals(UtcInstant.ofModifiedJulianDay(mjd, nod).toString(), expected);
+        assertEquals(expected, UtcInstant.ofModifiedJulianDay(mjd, nod).toString());
     }
 
     @Test
     @UseDataProvider("data_toString")
     public void test_toString_parse(long mjd, long nod, String str) {
-        assertEquals(UtcInstant.parse(str), UtcInstant.ofModifiedJulianDay(mjd, nod));
+        assertEquals(UtcInstant.ofModifiedJulianDay(mjd, nod), UtcInstant.parse(str));
     }
 
 }

--- a/src/test/java/org/threeten/extra/scale/TestUtcRules.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcRules.java
@@ -89,7 +89,7 @@ public class TestUtcRules {
             oos.writeObject(test);
         }
         try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            assertSame(ois.readObject(), test);
+            assertSame(test, ois.readObject());
         }
     }
 

--- a/src/test/java/org/threeten/extra/scale/TestUtcRules.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcRules.java
@@ -98,7 +98,7 @@ public class TestUtcRules {
     //-----------------------------------------------------------------------
     @Test
     public void test_getName() {
-        assertEquals(rules.getName(), "System");
+        assertEquals("System", rules.getName());
     }
 
     //-----------------------------------------------------------------------
@@ -240,14 +240,14 @@ public class TestUtcRules {
     @Test
     @UseDataProvider("data_leapSeconds")
     public void test_leapSeconds(long mjd, int adjust, int offset, String checkDate) {
-        assertEquals(mjd, LocalDate.parse(checkDate).getLong(JulianFields.MODIFIED_JULIAN_DAY));
+        assertEquals(LocalDate.parse(checkDate).getLong(JulianFields.MODIFIED_JULIAN_DAY), mjd);
 
-        assertEquals(rules.getLeapSecondAdjustment(mjd), adjust);
-        assertEquals(rules.getTaiOffset(mjd), offset);
+        assertEquals(adjust, rules.getLeapSecondAdjustment(mjd));
+        assertEquals(offset, rules.getTaiOffset(mjd));
         if (adjust != 0) {
             long[] leaps = rules.getLeapSecondDates();
             Arrays.sort(leaps);
-            assertEquals(Arrays.binarySearch(leaps, mjd) >= 0, true);
+            assertEquals(true, Arrays.binarySearch(leaps, mjd) >= 0);
         }
     }
 
@@ -275,13 +275,13 @@ public class TestUtcRules {
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1980, 0);
         for (int i = -10; i < 10; i++) {
             Duration duration = Duration.ofNanos(i);
-            assertEquals(rules.convertToUtc(tai.plus(duration)), expected.plus(duration));
-            assertEquals(rules.convertToTai(expected.plus(duration)), tai.plus(duration)); // check reverse
+            assertEquals(expected.plus(duration), rules.convertToUtc(tai.plus(duration)));
+            assertEquals(tai.plus(duration), rules.convertToTai(expected.plus(duration))); // check reverse
         }
         for (int i = -10; i < 10; i++) {
             Duration duration = Duration.ofSeconds(i);
-            assertEquals(rules.convertToUtc(tai.plus(duration)), expected.plus(duration));
-            assertEquals(rules.convertToTai(expected.plus(duration)), tai.plus(duration)); // check reverse
+            assertEquals(expected.plus(duration), rules.convertToUtc(tai.plus(duration)));
+            assertEquals(tai.plus(duration), rules.convertToTai(expected.plus(duration))); // check reverse
         }
     }
 
@@ -289,64 +289,64 @@ public class TestUtcRules {
     public void test_convertToUtc_TaiInstant_furtherAfterLeap() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1980 + 1, 0);  // 1980-01-01 (19 leap secs added)
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1980, NANOS_PER_SEC);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_justAfterLeap() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1980, 0);  // 1980-01-01 (19 leap secs added)
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1980, 0);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_inLeap() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1980 - 1, 0);  // 1980-01-01 (1 second before 1980)
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1980 - 1, SECS_PER_DAY * NANOS_PER_SEC);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_justBeforeLeap() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1980 - 2, 0);  // 1980-01-01 (2 seconds before 1980)
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1980 - 1, (SECS_PER_DAY - 1) * NANOS_PER_SEC);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_1800() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1800, 0);  // 1800-01-01
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1800, 0);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_1900() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1900, 0);  // 1900-01-01
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1900, 0);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_1958() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC1958, 0);  // 1958-01-01
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_1958, 0);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
     public void test_convertToUtc_TaiInstant_2100() {
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC2100, 0);  // 2100-01-01
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_2100, 0);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test(expected = NullPointerException.class)
@@ -365,8 +365,8 @@ public class TestUtcRules {
         rules.register(MJD_2100 - 1, -1);
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC2100_EXTRA_NEGATIVE_LEAP - 1, 0);  // 2100-01-01 (1 second before 2100)
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_2100 - 1, (SECS_PER_DAY - 2) * NANOS_PER_SEC);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     @Test
@@ -374,8 +374,8 @@ public class TestUtcRules {
         rules.register(MJD_2100 - 1, -1);
         TaiInstant tai = TaiInstant.ofTaiSeconds(TAI_SECS_UTC2100_EXTRA_NEGATIVE_LEAP, 0);  // 2100-01-01
         UtcInstant expected = UtcInstant.ofModifiedJulianDay(MJD_2100, 0);
-        assertEquals(rules.convertToUtc(tai), expected);
-        assertEquals(rules.convertToTai(expected), tai); // check reverse
+        assertEquals(expected, rules.convertToUtc(tai));
+        assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
     //-----------------------------------------------------------------------
@@ -386,8 +386,8 @@ public class TestUtcRules {
         OffsetDateTime odt = OffsetDateTime.of(1979, 12, 31, 23, 43, 21, 0, ZoneOffset.UTC);
         Instant instant = odt.toInstant();
         UtcInstant utc = UtcInstant.ofModifiedJulianDay(MJD_1980 - 1, (SECS_PER_DAY + 1 - 1000) * NANOS_PER_SEC);
-        assertEquals(rules.convertToInstant(utc), instant);
-        assertEquals(rules.convertToUtc(instant), utc);
+        assertEquals(instant, rules.convertToInstant(utc));
+        assertEquals(utc, rules.convertToUtc(instant));
     }
 
     @Test
@@ -402,8 +402,8 @@ public class TestUtcRules {
             Instant instant = odt.toInstant();
             UtcInstant utc = UtcInstant.ofModifiedJulianDay(
                     MJD_1980 - 1, (SECS_PER_DAY + 1 - 1000) * NANOS_PER_SEC + i * NANOS_PER_SEC);
-            assertEquals(rules.convertToInstant(utc), instant);
-            assertEquals(rules.convertToUtc(instant), utc);
+            assertEquals(instant, rules.convertToInstant(utc));
+            assertEquals(utc, rules.convertToUtc(instant));
         }
     }
 
@@ -417,8 +417,8 @@ public class TestUtcRules {
             Instant instant = odt.toInstant();
             UtcInstant utc = UtcInstant.ofModifiedJulianDay(
                     MJD_1980 - 1, (SECS_PER_DAY + 1 - 1000) * NANOS_PER_SEC + i * 1000000);
-            assertEquals(rules.convertToInstant(utc), instant);
-            assertEquals(rules.convertToUtc(instant), utc);
+            assertEquals(instant, rules.convertToInstant(utc));
+            assertEquals(utc, rules.convertToUtc(instant));
         }
     }
 
@@ -432,8 +432,8 @@ public class TestUtcRules {
             Instant instant = odt.toInstant();
             UtcInstant utc = UtcInstant.ofModifiedJulianDay(
                     MJD_1980 - 1, (SECS_PER_DAY + 1 - 1000) * NANOS_PER_SEC + i * 1000);
-            assertEquals(rules.convertToInstant(utc), instant);
-            assertEquals(rules.convertToUtc(instant), utc);
+            assertEquals(instant, rules.convertToInstant(utc));
+            assertEquals(utc, rules.convertToUtc(instant));
         }
     }
 
@@ -446,10 +446,10 @@ public class TestUtcRules {
             OffsetDateTime odt = OffsetDateTime.of(1979, 12, 31, 23, 43, 21, (int) (slsNanos % NANOS_PER_SEC), ZoneOffset.UTC);
             Instant instant = odt.toInstant();
             UtcInstant utc = UtcInstant.ofModifiedJulianDay(MJD_1980 - 1, utcNanos);
-            assertEquals(rules.convertToInstant(utc), instant);
+            assertEquals(instant, rules.convertToInstant(utc));
             // not all instants can map back to the correct UTC value
             long reverseUtcNanos = startSls + ((slsNanos - startSls) * 1000L) / (1000L - 1);
-            assertEquals(rules.convertToUtc(instant), UtcInstant.ofModifiedJulianDay(MJD_1980 - 1, reverseUtcNanos));
+            assertEquals(UtcInstant.ofModifiedJulianDay(MJD_1980 - 1, reverseUtcNanos), rules.convertToUtc(instant));
         }
     }
 
@@ -458,8 +458,8 @@ public class TestUtcRules {
         OffsetDateTime odt = OffsetDateTime.of(1980, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
         Instant instant = odt.toInstant();
         UtcInstant utc = UtcInstant.ofModifiedJulianDay(MJD_1980, 0);
-        assertEquals(rules.convertToInstant(utc), instant);
-        assertEquals(rules.convertToUtc(instant), utc);
+        assertEquals(instant, rules.convertToInstant(utc));
+        assertEquals(utc, rules.convertToUtc(instant));
     }
 
     @Test
@@ -467,8 +467,8 @@ public class TestUtcRules {
         OffsetDateTime odt = OffsetDateTime.of(1980, 1, 1, 0, 0, 1, 0, ZoneOffset.UTC);
         Instant instant = odt.toInstant();
         UtcInstant utc = UtcInstant.ofModifiedJulianDay(MJD_1980, NANOS_PER_SEC);
-        assertEquals(rules.convertToInstant(utc), instant);
-        assertEquals(rules.convertToUtc(instant), utc);
+        assertEquals(instant, rules.convertToInstant(utc));
+        assertEquals(utc, rules.convertToUtc(instant));
     }
 
     //-----------------------------------------------------------------------
@@ -480,9 +480,9 @@ public class TestUtcRules {
         long mjd = dates[dates.length - 1] + 1;
         rules.register(mjd, 1);
         long[] test = rules.getLeapSecondDates();
-        assertEquals(test.length, dates.length + 1);
-        assertEquals(test[test.length - 1], mjd);
-        assertEquals(rules.getLeapSecondAdjustment(mjd), 1);
+        assertEquals(dates.length + 1, test.length);
+        assertEquals(mjd, test[test.length - 1]);
+        assertEquals(1, rules.getLeapSecondAdjustment(mjd));
     }
 
     @Test
@@ -491,9 +491,9 @@ public class TestUtcRules {
         long mjd = dates[dates.length - 1] + 1;
         rules.register(mjd, -1);
         long[] test = rules.getLeapSecondDates();
-        assertEquals(test.length, dates.length + 1);
-        assertEquals(test[test.length - 1], mjd);
-        assertEquals(rules.getLeapSecondAdjustment(mjd), -1);
+        assertEquals(dates.length + 1, test.length);
+        assertEquals(mjd, test[test.length - 1]);
+        assertEquals(-1, rules.getLeapSecondAdjustment(mjd));
     }
 
     @Test
@@ -503,8 +503,8 @@ public class TestUtcRules {
         int adj = rules.getLeapSecondAdjustment(mjd);
         rules.register(mjd, adj);
         long[] test = rules.getLeapSecondDates();
-        assertEquals(Arrays.equals(test, dates), true);
-        assertEquals(rules.getLeapSecondAdjustment(mjd), adj);
+        assertEquals(true, Arrays.equals(test, dates));
+        assertEquals(adj, rules.getLeapSecondAdjustment(mjd));
     }
 
     @Test
@@ -514,8 +514,8 @@ public class TestUtcRules {
         int adj = rules.getLeapSecondAdjustment(mjd);
         rules.register(mjd, adj);
         long[] test = rules.getLeapSecondDates();
-        assertEquals(Arrays.equals(test, dates), true);
-        assertEquals(rules.getLeapSecondAdjustment(mjd), adj);
+        assertEquals(true, Arrays.equals(test, dates));
+        assertEquals(adj, rules.getLeapSecondAdjustment(mjd));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -561,7 +561,7 @@ public class TestUtcRules {
     //-----------------------------------------------------------------------
     @Test
     public void test_toString() {
-        assertEquals(rules.toString(), "UtcRules[System]");
+        assertEquals("UtcRules[System]", rules.toString());
     }
 
 }


### PR DESCRIPTION
Fixes #98. I left a lot of `assertEquals(false/true/null, ...)` calls untouched, as I wanted this PR to remain restricted to the subject = easier to review.
