### PR TITLE
Add missing @Test annotations, fixing or ignoring failing tests

### DIFF
--- a/src/test/java/org/threeten/extra/TestAmountFormats.java
+++ b/src/test/java/org/threeten/extra/TestAmountFormats.java
@@ -37,6 +37,7 @@ import java.time.Duration;
 import java.time.Period;
 import java.util.Locale;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -167,11 +168,15 @@ public class TestAmountFormats {
     }
 
     //-----------------------------------------------------------------------
+    @Test
+    @Ignore // Currently failing: says 29 hours, not 1 day and 5 hours
     public void test_wordBased_pl_formatStandard() {
         Duration p = Duration.ofDays(1).plusHours(5).plusMinutes(6).plusSeconds(7).plusNanos(8_000_000L);
         assertEquals("1 dzie\u0144, 5 godzin, 6 minut, 7 sekund i 8 milisekund", AmountFormats.wordBased(p, PL));
     }
 
+    @Test
+    @Ignore // Currently failing: 12 months becomes 1 year
     public void test_wordBased_pl_predicatex() {
         assertEquals("1 rok", AmountFormats.wordBased(Period.ofYears(1), PL));
         assertEquals("2 lata", AmountFormats.wordBased(Period.ofYears(2), PL));
@@ -322,21 +327,20 @@ public class TestAmountFormats {
         assertEquals("2225 milisekund", AmountFormats.wordBased(Duration.ofMillis(2225), PL));
     }
 
+    @Test
     public void test_wordBased_ru_predicate() {
         assertEquals("1 \u0433\u043E\u0434", AmountFormats.wordBased(Period.ofYears(1), RU));
         assertEquals("2 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(2), RU));
-        assertEquals("3 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(2), RU));
-        assertEquals("4 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(2), RU));
+        assertEquals("3 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(3), RU));
+        assertEquals("4 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(4), RU));
         assertEquals("5 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(5), RU));
-        assertEquals("11 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(12), RU));
+        assertEquals("11 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(11), RU));
         assertEquals("12 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(12), RU));
-        assertEquals("13 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(12), RU));
-        assertEquals("14 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(12), RU));
+        assertEquals("13 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(13), RU));
+        assertEquals("14 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(14), RU));
         assertEquals("15 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(15), RU));
-        assertEquals("21 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(15), RU));
-        assertEquals("22 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(2), RU));
-        assertEquals("23 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(2), RU));
-        assertEquals("24 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(2), RU));
-        assertEquals("25 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(15), RU));
+        assertEquals("21 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(21), RU));
+        assertEquals("24 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(24), RU));
+        assertEquals("25 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(25), RU));
     }
 }

--- a/src/test/java/org/threeten/extra/TestAmountFormats.java
+++ b/src/test/java/org/threeten/extra/TestAmountFormats.java
@@ -340,7 +340,10 @@ public class TestAmountFormats {
         assertEquals("14 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(14), RU));
         assertEquals("15 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(15), RU));
         assertEquals("21 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(21), RU));
+        assertEquals("22 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(22), RU));
         assertEquals("24 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(24), RU));
         assertEquals("25 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(25), RU));
+        assertEquals("31 \u043B\u0435\u0442", AmountFormats.wordBased(Period.ofYears(31), RU));
+        assertEquals("32 \u0433\u043E\u0434\u0430", AmountFormats.wordBased(Period.ofYears(32), RU));
     }
 }

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -384,6 +384,7 @@ public class TestHours {
 
     //-----------------------------------------------------------------------
     @SuppressWarnings("deprecation")
+    @Test
     public void test_toDuration() {
         for (int i = -20; i < 20; i++) {
             assertEquals(Duration.ofHours(i), Hours.of(i).toPeriod());


### PR DESCRIPTION
A few @Test annotations were missing, and therefore weren't being executed.

When I didn't know the correct modification, I added @Ignore with a comment describing the failing test. For the failing russian tests, it was clear that the Periods being tested were incorrect and could be corrected. However, I don't know if the output strings are correct.