### PR TITLE
Update lists of available classes on the website

### DIFF
--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -32,9 +32,16 @@ The following features are included:
 * [`LocalDateRange`](apidocs/org.threeten.extra/org/threeten/extra/LocalDateRange.html) - a range between two dates
 * [`PeriodDuration`](apidocs/org.threeten.extra/org/threeten/extra/PeriodDuration.html) - combines `Period` and `Duration`
 * Weekend adjusters
-* [Coptic](apidocs/org.threeten.extra/org/threeten/extra/chrono/CopticChronology.html) calendar system
-* [Ethiopic](apidocs/org.threeten.extra/org/threeten/extra/chrono/EthiopicChronology.html) calendar system
-* [Julian](apidocs/org.threeten.extra/org/threeten/extra/chrono/JulianChronology.html) calendar system
+* [Accounting](apidocs/org.threeten.extra/org/threeten/extra/chrono/AccountingChronology.html),
+[British Cutover](apidocs/org.threeten.extra/org/threeten/extra/chrono/BritishCutoverChronology.html),
+[Coptic](apidocs/org.threeten.extra/org/threeten/extra/chrono/CopticChronology.html),
+[Discordian](apidocs/org.threeten.extra/org/threeten/extra/chrono/DiscordianChronology.html),
+[Ethiopic](apidocs/org.threeten.extra/org/threeten/extra/chrono/EthiopicChronology.html),
+[International Fixed](apidocs/org.threeten.extra/org/threeten/extra/chrono/InternationalFixedChronology.html),
+[Julian](apidocs/org.threeten.extra/org/threeten/extra/chrono/JulianChronology.html),
+[Pax](apidocs/org.threeten.extra/org/threeten/extra/chrono/PaxChronology.html),
+[Symmetry010](apidocs/org.threeten.extra/org/threeten/extra/chrono/Symmetry010Chronology.html) and
+[Symmetry454](apidocs/org.threeten.extra/org/threeten/extra/chrono/Symmetry454Chronology.html) calendar systems
 * [Word-based](apidocs/org.threeten.extra/org/threeten/extra/AmountFormats.html) period and duration formatting
 * Support for the TAI and UTC [time-scales](apidocs/org.threeten.extra/org/threeten/extra/scale/package-summary.html)
 

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -21,11 +21,15 @@ The following features are included:
 * [`Quarter`](apidocs/org.threeten.extra/org/threeten/extra/Quarter.html) - the four quarters, Q1, Q2, Q3 and Q4
 * [`YearQuarter`](apidocs/org.threeten.extra/org/threeten/extra/YearQuarter.html) - combines a year and quarter, 2014-Q4
 * [`YearWeek`](apidocs/org.threeten.extra/org/threeten/extra/YearWeek.html) - combines a week-based-year and a week, 2014-W06
-* [`Days`](apidocs/org.threeten.extra/org/threeten/extra/Days.html),
+* [`Seconds`](apidocs/org.threeten.extra/org/threeten/extra/Seconds.html),
+[`Minutes`](apidocs/org.threeten.extra/org/threeten/extra/Minutes.html),
+[`Hours`](apidocs/org.threeten.extra/org/threeten/extra/Hours.html),
+[`Days`](apidocs/org.threeten.extra/org/threeten/extra/Days.html),
 [`Weeks`](apidocs/org.threeten.extra/org/threeten/extra/Weeks.html),
 [`Months`](apidocs/org.threeten.extra/org/threeten/extra/Months.html) and
 [`Years`](apidocs/org.threeten.extra/org/threeten/extra/Years.html) - amounts of time
 * [`Interval`](apidocs/org.threeten.extra/org/threeten/extra/Interval.html) - an interval between two instants
+* [`LocalDateRange`](apidocs/org.threeten.extra/org/threeten/extra/LocalDateRange.html) - a range between two dates
 * [`PeriodDuration`](apidocs/org.threeten.extra/org/threeten/extra/PeriodDuration.html) - combines `Period` and `Duration`
 * Weekend adjusters
 * [Coptic](apidocs/org.threeten.extra/org/threeten/extra/chrono/CopticChronology.html) calendar system

--- a/src/site/markdown/userguide.md
+++ b/src/site/markdown/userguide.md
@@ -15,11 +15,15 @@ These include:
 * [`Quarter`](apidocs/org.threeten.extra/org/threeten/extra/Quarter.html) - the four quarters, Q1, Q2, Q3 and Q4
 * [`YearQuarter`](apidocs/org.threeten.extra/org/threeten/extra/YearQuarter.html) - combines a year and quarter, 2014-Q4
 * [`YearWeek`](apidocs/org.threeten.extra/org/threeten/extra/YearWeek.html) - combines a week-based-year and a week, 2014-W06
+* [`Seconds`](apidocs/org.threeten.extra/org/threeten/extra/Seconds.html) - an amount of time measured in seconds
+* [`Minutes`](apidocs/org.threeten.extra/org/threeten/extra/Minutes.html) - an amount of time measured in minutes
+* [`Hours`](apidocs/org.threeten.extra/org/threeten/extra/Hours.html) - an amount of time measured in hours
 * [`Days`](apidocs/org.threeten.extra/org/threeten/extra/Days.html) - an amount of time measured in days
 * [`Weeks`](apidocs/org.threeten.extra/org/threeten/extra/Weeks.html) - an amount of time measured in weeks
 * [`Months`](apidocs/org.threeten.extra/org/threeten/extra/Months.html) - an amount of time measured in months
 * [`Years`](apidocs/org.threeten.extra/org/threeten/extra/Years.html) - an amount of time measured in years
 * [`Interval`](apidocs/org.threeten.extra/org/threeten/extra/Interval.html) - an interval between two instants
+* [`LocalDateRange`](apidocs/org.threeten.extra/org/threeten/extra/LocalDateRange.html) - a range between two dates
 * [`PeriodDuration`](apidocs/org.threeten.extra/org/threeten/extra/PeriodDuration.html) - combines a `Period` and a `Duration`
 
 


### PR DESCRIPTION
This PR intends to update the lists with available value types and calendar systems on the website. I don't know if there was a reason (not frequently used?) to omit these classes there, but if there was, feel free to close this PR.

I almost missed the `LocalDateRange` class because it was not in the user guide. :)