### PR TITLE
Add Year-based static factory methods to YearWeek and YearQuarter

### DIFF
--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -192,7 +192,7 @@ public final class YearQuarter
     /**
      * Obtains an instance of {@code YearQuarter} from a year and quarter.
      *
-     * @param year  the year to represent, from MIN_YEAR to MAX_YEAR, not null
+     * @param year  the year to represent, not null
      * @param quarter  the quarter-of-year to represent, from 1 to 4
      * @return the year-quarter, not null
      * @throws DateTimeException if the quarter value is invalid

--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -181,7 +181,7 @@ public final class YearQuarter
     /**
      * Obtains an instance of {@code YearQuarter} from a year and quarter.
      *
-     * @param year  the year to represent, from MIN_YEAR to MAX_YEAR, not null
+     * @param year  the year to represent, not null
      * @param quarter  the quarter-of-year to represent, not null
      * @return the year-quarter, not null
      */

--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -181,6 +181,29 @@ public final class YearQuarter
     /**
      * Obtains an instance of {@code YearQuarter} from a year and quarter.
      *
+     * @param year  the year to represent, from MIN_YEAR to MAX_YEAR, not null
+     * @param quarter  the quarter-of-year to represent, not null
+     * @return the year-quarter, not null
+     */
+    public static YearQuarter of(Year year, Quarter quarter) {
+        return of(year.getValue(), quarter);
+    }
+
+    /**
+     * Obtains an instance of {@code YearQuarter} from a year and quarter.
+     *
+     * @param year  the year to represent, from MIN_YEAR to MAX_YEAR, not null
+     * @param quarter  the quarter-of-year to represent, from 1 to 4
+     * @return the year-quarter, not null
+     * @throws DateTimeException if the quarter value is invalid
+     */
+    public static YearQuarter of(Year year, int quarter) {
+        return of(year.getValue(), Quarter.of(quarter));
+    }
+
+    /**
+     * Obtains an instance of {@code YearQuarter} from a year and quarter.
+     *
      * @param year  the year to represent, from MIN_YEAR to MAX_YEAR
      * @param quarter  the quarter-of-year to represent, not null
      * @return the year-quarter, not null

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -173,6 +173,21 @@ public final class YearWeek
      * If the week is 53 and the year does not have 53 weeks, week one of the following
      * year is selected.
      *
+     * @param year  the week-based-year to represent, from MIN_YEAR to MAX_YEAR, not null
+     * @param week  the week-of-week-based-year to represent, from 1 to 53
+     * @return the year-week, not null
+     * @throws DateTimeException if the week value is invalid
+     */
+    public static YearWeek of(Year year, int week) {
+      return of(year.getValue(), week);
+    }
+
+    /**
+     * Obtains an instance of {@code YearWeek} from a week-based-year and week.
+     * <p>
+     * If the week is 53 and the year does not have 53 weeks, week one of the following
+     * year is selected.
+     *
      * @param weekBasedYear  the week-based-year to represent, from MIN_YEAR to MAX_YEAR
      * @param week  the week-of-week-based-year to represent, from 1 to 53
      * @return the year-week, not null

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -173,7 +173,7 @@ public final class YearWeek
      * If the week is 53 and the year does not have 53 weeks, week one of the following
      * year is selected.
      *
-     * @param year  the week-based-year to represent, from MIN_YEAR to MAX_YEAR, not null
+     * @param year  the week-based-year to represent, not null
      * @param week  the week-of-week-based-year to represent, from 1 to 53
      * @return the year-week, not null
      * @throws DateTimeException if the week value is invalid

--- a/src/test/java/org/threeten/extra/TestYearQuarter.java
+++ b/src/test/java/org/threeten/extra/TestYearQuarter.java
@@ -188,16 +188,6 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = DateTimeException.class)
-    public void test_of_Year_int_yearTooLow() {
-        YearQuarter.of(Year.of(Year.MIN_VALUE - 1), 2);
-    }
-
-    @Test(expected = DateTimeException.class)
-    public void test_of_Year_int_yearTooHigh() {
-        YearQuarter.of(Year.of(Year.MAX_VALUE + 1), 2);
-    }
-
     @Test(expected = NullPointerException.class)
     public void test_of_Year_int_null() {
         YearQuarter.of((Year) null, 2);

--- a/src/test/java/org/threeten/extra/TestYearQuarter.java
+++ b/src/test/java/org/threeten/extra/TestYearQuarter.java
@@ -144,6 +144,66 @@ public class TestYearQuarter {
     }
 
     //-----------------------------------------------------------------------
+    // of(Year,Quarter)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_of_Year_Quarter() {
+        for (int year = -100; year <= 100; year++) {
+            for (Quarter quarter : Quarter.values()) {
+                YearQuarter test = YearQuarter.of(Year.of(year), quarter);
+                assertEquals(year, test.getYear());
+                assertEquals(quarter.getValue(), test.getQuarterValue());
+                assertEquals(quarter, test.getQuarter());
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_of_Year_Quarter_nullQuarter() {
+        YearQuarter.of(Year.of(2012), (Quarter) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_of_Year_Quarter_nullYear() {
+        YearQuarter.of((Year) null, Quarter.Q2);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_of_Year_Quarter_nullBoth() {
+        YearQuarter.of((Year) null, (Quarter) null);
+    }
+
+    //-----------------------------------------------------------------------
+    // of(Year,int)
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_of_Year_int() {
+        for (int year = -100; year <= 100; year++) {
+            for (Quarter quarter : Quarter.values()) {
+                YearQuarter test = YearQuarter.of(Year.of(year), quarter.getValue());
+                assertEquals(year, test.getYear());
+                assertEquals(quarter.getValue(), test.getQuarterValue());
+                assertEquals(quarter, test.getQuarter());
+            }
+        }
+    }
+
+    @Test(expected = DateTimeException.class)
+    public void test_of_Year_int_yearTooLow() {
+        YearQuarter.of(Year.of(Year.MIN_VALUE - 1), 2);
+    }
+
+    @Test(expected = DateTimeException.class)
+    public void test_of_Year_int_yearTooHigh() {
+        YearQuarter.of(Year.of(Year.MAX_VALUE + 1), 2);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_of_Year_int_null() {
+        YearQuarter.of((Year) null, 2);
+    }
+
+    //-----------------------------------------------------------------------
     // of(int,Quarter)
     //-----------------------------------------------------------------------
     @Test

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -89,6 +89,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.chrono.IsoChronology;
@@ -365,6 +366,22 @@ public class TestYearWeek {
     @Test(expected = NullPointerException.class)
     public void now_Clock_nullClock() {
         YearWeek.now((Clock) null);
+    }
+
+    //-----------------------------------------------------------------------
+    // of(Year, int)
+    //-----------------------------------------------------------------------
+    @Test
+    @UseDataProvider("data_sampleYearWeeks")
+    public void test_of_Year_int(int year, int week) {
+        YearWeek yearWeek = YearWeek.of(Year.of(year), week);
+        assertEquals(year, yearWeek.getYear());
+        assertEquals(week, yearWeek.getWeek());
+    }
+
+    @Test
+    public void test_carry_Year_int() {
+        assertTrue(YearWeek.of(Year.of(2014), 53).equals(TEST));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Adds the following static factory methods:

- `YearWeek.of(Year, int)`
- `YearQuarter.of(Year, Quarter)`
- `YearQuarter.of(Year, int)`

Fixes https://github.com/ThreeTen/threeten-extra/issues/155