### PR TITLE
Upgrade to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
       <url>https://github.com/Clockwork-Muse</url>
     </contributor>
     <contributor>
+      <name>M. Justin</name>
+      <url>https://github.com/mjustin</url>
+    </contributor>
+    <contributor>
       <name>Bruno P. Kinoshita</name>
       <url>https://github.com/kinow</url>
     </contributor>

--- a/pom.xml
+++ b/pom.xml
@@ -492,15 +492,27 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.7.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.tngtech.java</groupId>
-      <artifactId>junit-dataprovider</artifactId>
-      <version>1.10.0</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.7.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.7.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.tngtech.junit.dataprovider</groupId>
+      <artifactId>junit-jupiter-params-dataprovider</artifactId>
+      <version>2.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/threeten/extra/AbstractDateTimeTest.java
+++ b/src/test/java/org/threeten/extra/AbstractDateTimeTest.java
@@ -33,8 +33,8 @@ package org.threeten.extra;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.DateTimeException;
 import java.time.temporal.TemporalAccessor;
@@ -110,12 +110,7 @@ public abstract class AbstractDateTimeTest {
     public void basicTest_range_TemporalField_unsupported() {
         for (TemporalAccessor sample : samples()) {
             for (TemporalField field : invalidFields()) {
-                try {
-                    sample.range(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
+                assertThrows(DateTimeException.class, () -> sample.range(field), "Failed on " + sample + " " + field);
             }
         }
     }
@@ -123,12 +118,7 @@ public abstract class AbstractDateTimeTest {
     @Test
     public void basicTest_range_TemporalField_null() {
         for (TemporalAccessor sample : samples()) {
-            try {
-                sample.range(null);
-                fail("Failed on " + sample);
-            } catch (NullPointerException ex) {
-                // expected
-            }
+            assertThrows(NullPointerException.class, () -> sample.range(null), "Failed on " + sample);
         }
     }
 
@@ -142,12 +132,7 @@ public abstract class AbstractDateTimeTest {
                 if (sample.range(field).isIntValue()) {
                     sample.get(field);  // no exception
                 } else {
-                    try {
-                        sample.get(field);
-                        fail("Failed on " + sample + " " + field);
-                    } catch (DateTimeException ex) {
-                        // expected
-                    }
+                    assertThrows(DateTimeException.class, () -> sample.get(field), "Failed on " + sample + " " + field);
                 }
             }
         }
@@ -157,12 +142,7 @@ public abstract class AbstractDateTimeTest {
     public void basicTest_get_TemporalField_unsupported() {
         for (TemporalAccessor sample : samples()) {
             for (TemporalField field : invalidFields()) {
-                try {
-                    sample.get(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
+                assertThrows(DateTimeException.class, () -> sample.get(field), "Failed on " + sample + " " + field);
             }
         }
     }
@@ -170,12 +150,7 @@ public abstract class AbstractDateTimeTest {
     @Test
     public void basicTest_get_TemporalField_null() {
         for (TemporalAccessor sample : samples()) {
-            try {
-                sample.get(null);
-                fail("Failed on " + sample);
-            } catch (NullPointerException ex) {
-                // expected
-            }
+            assertThrows(NullPointerException.class, () -> sample.get(null), "Failed on " + sample);
         }
     }
 
@@ -195,12 +170,7 @@ public abstract class AbstractDateTimeTest {
     public void basicTest_getLong_TemporalField_unsupported() {
         for (TemporalAccessor sample : samples()) {
             for (TemporalField field : invalidFields()) {
-                try {
-                    sample.getLong(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
+                assertThrows(DateTimeException.class, () -> sample.getLong(field), "Failed on " + sample + " " + field);
             }
         }
     }
@@ -208,12 +178,7 @@ public abstract class AbstractDateTimeTest {
     @Test
     public void basicTest_getLong_TemporalField_null() {
         for (TemporalAccessor sample : samples()) {
-            try {
-                sample.getLong(null);
-                fail("Failed on " + sample);
-            } catch (NullPointerException ex) {
-                // expected
-            }
+            assertThrows(NullPointerException.class, () -> sample.getLong(null), "Failed on " + sample);
         }
     }
 

--- a/src/test/java/org/threeten/extra/AbstractDateTimeTest.java
+++ b/src/test/java/org/threeten/extra/AbstractDateTimeTest.java
@@ -31,17 +31,17 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.DateTimeException;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalField;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base test class for {@code DateTime}.
@@ -73,7 +73,7 @@ public abstract class AbstractDateTimeTest {
     public void basicTest_isSupported_TemporalField_supported() {
         for (TemporalAccessor sample : samples()) {
             for (TemporalField field : validFields()) {
-                assertTrue("Failed on " + sample + " " + field, sample.isSupported(field));
+                assertTrue(sample.isSupported(field), "Failed on " + sample + " " + field);
             }
         }
     }
@@ -82,7 +82,7 @@ public abstract class AbstractDateTimeTest {
     public void basicTest_isSupported_TemporalField_unsupported() {
         for (TemporalAccessor sample : samples()) {
             for (TemporalField field : invalidFields()) {
-                assertFalse("Failed on " + sample + " " + field, sample.isSupported(field));
+                assertFalse(sample.isSupported(field), "Failed on " + sample + " " + field);
             }
         }
     }
@@ -90,7 +90,7 @@ public abstract class AbstractDateTimeTest {
     @Test
     public void basicTest_isSupported_TemporalField_null() {
         for (TemporalAccessor sample : samples()) {
-            assertFalse("Failed on " + sample, sample.isSupported(null));
+            assertFalse(sample.isSupported(null), "Failed on " + sample);
         }
     }
 

--- a/src/test/java/org/threeten/extra/TestAmPm.java
+++ b/src/test/java/org/threeten/extra/TestAmPm.java
@@ -62,9 +62,10 @@ import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
 import static java.time.temporal.ChronoUnit.HALF_DAYS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.time.DateTimeException;
@@ -76,7 +77,7 @@ import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test AmPm.
@@ -103,14 +104,14 @@ public class TestAmPm {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_valueTooLow() {
-        AmPm.of(-1);
+        assertThrows(DateTimeException.class, () -> AmPm.of(-1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_valueTooHigh() {
-        AmPm.of(2);
+        assertThrows(DateTimeException.class, () -> AmPm.of(2));
     }
 
     //-----------------------------------------------------------------------
@@ -126,14 +127,14 @@ public class TestAmPm {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofHour_int_valueTooLow() {
-        AmPm.ofHour(-1);
+        assertThrows(DateTimeException.class, () -> AmPm.ofHour(-1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofHour_int_valueTooHigh() {
-        AmPm.ofHour(24);
+        assertThrows(DateTimeException.class, () -> AmPm.ofHour(24));
     }
 
     //-----------------------------------------------------------------------
@@ -145,14 +146,14 @@ public class TestAmPm {
         assertEquals(AmPm.PM, AmPm.from(LocalTime.of(17, 30)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessor_invalid_noDerive() {
-        AmPm.from(LocalDate.of(2007, 7, 30));
+        assertThrows(DateTimeException.class, () -> AmPm.from(LocalDate.of(2007, 7, 30)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        AmPm.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> AmPm.from((TemporalAccessor) null));
     }
 
     //-----------------------------------------------------------------------
@@ -163,14 +164,14 @@ public class TestAmPm {
         assertEquals("AM", AmPm.AM.getDisplayName(TextStyle.SHORT, Locale.US));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getDisplayName_nullStyle() {
-        AmPm.AM.getDisplayName(null, Locale.US);
+        assertThrows(NullPointerException.class, () -> AmPm.AM.getDisplayName(null, Locale.US));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getDisplayName_nullLocale() {
-        AmPm.AM.getDisplayName(TextStyle.FULL, null);
+        assertThrows(NullPointerException.class, () -> AmPm.AM.getDisplayName(TextStyle.FULL, null));
     }
 
     //-----------------------------------------------------------------------
@@ -220,14 +221,14 @@ public class TestAmPm {
         assertEquals(AMPM_OF_DAY.range(), AmPm.AM.range(AMPM_OF_DAY));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_invalidField() {
-        AmPm.AM.range(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> AmPm.AM.range(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_range_null() {
-        AmPm.AM.range(null);
+        assertThrows(NullPointerException.class, () -> AmPm.AM.range(null));
     }
 
     //-----------------------------------------------------------------------
@@ -239,14 +240,14 @@ public class TestAmPm {
         assertEquals(1, AmPm.PM.get(AMPM_OF_DAY));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_get_invalidField() {
-        AmPm.PM.get(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> AmPm.PM.get(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_get_null() {
-        AmPm.PM.get(null);
+        assertThrows(NullPointerException.class, () -> AmPm.PM.get(null));
     }
 
     //-----------------------------------------------------------------------
@@ -258,14 +259,14 @@ public class TestAmPm {
         assertEquals(1, AmPm.PM.getLong(AMPM_OF_DAY));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField() {
-        AmPm.PM.getLong(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> AmPm.PM.getLong(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getLong_null() {
-        AmPm.PM.getLong(null);
+        assertThrows(NullPointerException.class, () -> AmPm.PM.getLong(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestAmountFormats.java
+++ b/src/test/java/org/threeten/extra/TestAmountFormats.java
@@ -31,23 +31,21 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.Period;
 import java.util.Locale;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test AmountFormats.
  */
-@RunWith(DataProviderRunner.class)
 public class TestAmountFormats {
 
     private static final Locale PL = new Locale("pl");
@@ -99,7 +97,7 @@ public class TestAmountFormats {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_wordBased")
     public void test_wordBased(Period period, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(period, locale));
@@ -135,7 +133,7 @@ public class TestAmountFormats {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("duration_wordBased")
     public void test_wordBased(Duration duration, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(duration, locale));
@@ -162,7 +160,7 @@ public class TestAmountFormats {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("period_duration_wordBased")
     public void test_wordBased(Period period, Duration duration, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(period, duration, locale));
@@ -295,7 +293,7 @@ public class TestAmountFormats {
     }
 
     // -----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("wordBased_ru_formatSeparator")
     public void test_wordBased_ru_formatSeparator(String expected, Duration duration) {
         assertEquals(expected, AmountFormats.wordBased(duration, RU));
@@ -310,7 +308,7 @@ public class TestAmountFormats {
     }
 
     // -----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("wordBased_ru_period_predicate")
     public void test_wordBased_ru_period_predicate(String expected, Period period) {
         assertEquals(expected, AmountFormats.wordBased(period, RU));
@@ -438,7 +436,7 @@ public class TestAmountFormats {
     }
 
     // -----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("wordBased_ru_duration_predicate")
     public void test_wordBased_ru_duration_predicate(String expected, Duration duration) {
         assertEquals(expected, AmountFormats.wordBased(duration, RU));

--- a/src/test/java/org/threeten/extra/TestConvert.java
+++ b/src/test/java/org/threeten/extra/TestConvert.java
@@ -31,7 +31,7 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -39,16 +39,14 @@ import java.time.LocalDate;
 import java.time.Period;
 
 import org.joda.convert.StringConvert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+
 import org.threeten.extra.scale.TaiInstant;
 import org.threeten.extra.scale.UtcInstant;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
-@RunWith(DataProviderRunner.class)
 public class TestConvert {
 
     @DataProvider
@@ -71,13 +69,13 @@ public class TestConvert {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_inputs")
     public void test_convertToString(Object obj, String str) {
         assertEquals(str, StringConvert.INSTANCE.convertToString(obj));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_inputs")
     public void test_convertFromString(Object obj, String str) {
         assertEquals(obj, StringConvert.INSTANCE.convertFromString(obj.getClass(), str));

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -73,10 +73,11 @@ import static java.time.temporal.ChronoField.SECOND_OF_DAY;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -107,7 +108,7 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test DayOfMonth.
@@ -227,14 +228,14 @@ public class TestDayOfMonth {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_tooLow() {
-        DayOfMonth.of(0);
+        assertThrows(DateTimeException.class, () -> DayOfMonth.of(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_tooHigh() {
-        DayOfMonth.of(32);
+        assertThrows(DateTimeException.class, () -> DayOfMonth.of(32));
     }
 
     //-----------------------------------------------------------------------
@@ -322,14 +323,14 @@ public class TestDayOfMonth {
         assertEquals(date.getDayOfMonth(), DayOfMonth.from(JapaneseDate.from(date)).getValue());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessor_noDerive() {
-        DayOfMonth.from(LocalTime.NOON);
+        assertThrows(DateTimeException.class, () -> DayOfMonth.from(LocalTime.NOON));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        DayOfMonth.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> DayOfMonth.from((TemporalAccessor) null));
     }
 
     @Test
@@ -386,14 +387,14 @@ public class TestDayOfMonth {
         assertEquals(DAY_OF_MONTH.range(), TEST.range(DAY_OF_MONTH));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_invalidField() {
-        TEST.range(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.range(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_range_null() {
-        TEST.range((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -404,14 +405,14 @@ public class TestDayOfMonth {
         assertEquals(12, TEST.get(DAY_OF_MONTH));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_get_invalidField() {
-        TEST.get(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.get(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_get_null() {
-        TEST.get((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -427,19 +428,19 @@ public class TestDayOfMonth {
         assertEquals(12L, TEST.getLong(TestingField.INSTANCE));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField() {
-        TEST.getLong(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.getLong(MONTH_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField2() {
-        TEST.getLong(IsoFields.DAY_OF_QUARTER);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.getLong(IsoFields.DAY_OF_QUARTER));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getLong_null() {
-        TEST.getLong((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -547,28 +548,28 @@ public class TestDayOfMonth {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_april31() {
         LocalDate base = LocalDate.of(2007, 4, 1);
         DayOfMonth test = DayOfMonth.of(31);
-        test.adjustInto(base);
+        assertThrows(DateTimeException.class, () -> test.adjustInto(base));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_february29_notLeapYear() {
         LocalDate base = LocalDate.of(2007, 2, 1);
         DayOfMonth test = DayOfMonth.of(29);
-        test.adjustInto(base);
+        assertThrows(DateTimeException.class, () -> test.adjustInto(base));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_nonIso() {
-        TEST.adjustInto(JapaneseDate.now());
+        assertThrows(DateTimeException.class, () -> TEST.adjustInto(JapaneseDate.now()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_adjustInto_null() {
-        TEST.adjustInto((Temporal) null);
+        assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
     //-----------------------------------------------------------------------
@@ -608,9 +609,9 @@ public class TestDayOfMonth {
         assertEquals(MonthDay.of(12, 28), test.atMonth(DECEMBER));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_atMonth_null() {
-        TEST.atMonth((Month) null);
+        assertThrows(NullPointerException.class, () -> TEST.atMonth((Month) null));
     }
 
     //-----------------------------------------------------------------------
@@ -650,14 +651,14 @@ public class TestDayOfMonth {
         assertEquals(MonthDay.of(12, 28), test.atMonth(12));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atMonth_tooLow() {
-        TEST.atMonth(0);
+        assertThrows(DateTimeException.class, () -> TEST.atMonth(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atMonth_tooHigh() {
-        TEST.atMonth(13);
+        assertThrows(DateTimeException.class, () -> TEST.atMonth(13));
     }
 
     //-----------------------------------------------------------------------
@@ -698,9 +699,9 @@ public class TestDayOfMonth {
         assertEquals(LocalDate.of(2012, 12, 28), test.atYearMonth(YearMonth.of(2012, 12)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_atYearMonth_null() {
-        TEST.atYearMonth((YearMonth) null);
+        assertThrows(NullPointerException.class, () -> TEST.atYearMonth((YearMonth) null));
     }
 
     //-----------------------------------------------------------------------
@@ -726,11 +727,12 @@ public class TestDayOfMonth {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_nullDayOfMonth() {
         DayOfMonth doy = null;
         DayOfMonth test = DayOfMonth.of(1);
-        test.compareTo(doy);
+        assertThrows(NullPointerException.class, () ->
+                test.compareTo(doy));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -731,8 +731,7 @@ public class TestDayOfMonth {
     public void test_compareTo_nullDayOfMonth() {
         DayOfMonth doy = null;
         DayOfMonth test = DayOfMonth.of(1);
-        assertThrows(NullPointerException.class, () ->
-                test.compareTo(doy));
+        assertThrows(NullPointerException.class, () -> test.compareTo(doy));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -477,8 +477,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_adjustInto_nonIso() {
-        assertThrows(DateTimeException.class, () ->
-                TEST.adjustInto(JapaneseDate.now()));
+        assertThrows(DateTimeException.class, () -> TEST.adjustInto(JapaneseDate.now()));
     }
 
     @Test
@@ -503,8 +502,7 @@ public class TestDayOfYear {
     @Test
     public void test_atYear_fromStartOfYear_notLeapYear_day366() {
         DayOfYear test = DayOfYear.of(LEAP_YEAR_LENGTH);
-        assertThrows(DateTimeException.class, () ->
-                test.atYear(YEAR_STANDARD));
+        assertThrows(DateTimeException.class, () -> test.atYear(YEAR_STANDARD));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -61,8 +61,9 @@ import static java.time.temporal.ChronoField.SECOND_OF_DAY;
 import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -91,7 +92,7 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test DayOfYear.
@@ -214,14 +215,14 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_tooLow() {
-        DayOfYear.of(0);
+        assertThrows(DateTimeException.class, () -> DayOfYear.of(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_tooHigh() {
-        DayOfYear.of(367);
+        assertThrows(DateTimeException.class, () -> DayOfYear.of(367));
     }
 
     //-----------------------------------------------------------------------
@@ -261,14 +262,14 @@ public class TestDayOfYear {
         assertEquals(date.getDayOfYear(), DayOfYear.from(JapaneseDate.from(date)).getValue());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessor_noDerive() {
-        DayOfYear.from(LocalTime.NOON);
+        assertThrows(DateTimeException.class, () -> DayOfYear.from(LocalTime.NOON));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        DayOfYear.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> DayOfYear.from((TemporalAccessor) null));
     }
 
     @Test
@@ -324,14 +325,14 @@ public class TestDayOfYear {
         assertEquals(DAY_OF_YEAR.range(), TEST.range(DAY_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_invalidField() {
-        TEST.range(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.range(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_range_null() {
-        TEST.range((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -342,14 +343,14 @@ public class TestDayOfYear {
         assertEquals(12, TEST.get(DAY_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_get_invalidField() {
-        TEST.get(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.get(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_get_null() {
-        TEST.get((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -365,19 +366,19 @@ public class TestDayOfYear {
         assertEquals(12L, TEST.getLong(TestingField.INSTANCE));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField() {
-        TEST.getLong(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.getLong(MONTH_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField2() {
-        TEST.getLong(IsoFields.DAY_OF_QUARTER);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.getLong(IsoFields.DAY_OF_QUARTER));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getLong_null() {
-        TEST.getLong((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -438,18 +439,18 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_fromStartOfYear_notLeapYear_day366() {
         LocalDate base = LocalDate.of(2007, 1, 1);
         DayOfYear test = DayOfYear.of(LEAP_YEAR_LENGTH);
-        test.adjustInto(base);
+        assertThrows(DateTimeException.class, () -> test.adjustInto(base));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_fromEndOfYear_notLeapYear_day366() {
         LocalDate base = LocalDate.of(2007, 12, 31);
         DayOfYear test = DayOfYear.of(LEAP_YEAR_LENGTH);
-        test.adjustInto(base);
+        assertThrows(DateTimeException.class, () -> test.adjustInto(base));
     }
 
     @Test
@@ -474,14 +475,16 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_nonIso() {
-        TEST.adjustInto(JapaneseDate.now());
+        assertThrows(DateTimeException.class, () ->
+                TEST.adjustInto(JapaneseDate.now()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_adjustInto_null() {
-        TEST.adjustInto((Temporal) null);
+        assertThrows(NullPointerException.class, () ->
+                TEST.adjustInto((Temporal) null));
     }
 
     //-----------------------------------------------------------------------
@@ -497,10 +500,11 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atYear_fromStartOfYear_notLeapYear_day366() {
         DayOfYear test = DayOfYear.of(LEAP_YEAR_LENGTH);
-        test.atYear(YEAR_STANDARD);
+        assertThrows(DateTimeException.class, () ->
+                test.atYear(YEAR_STANDARD));
     }
 
     @Test
@@ -513,9 +517,10 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_atYear_Year_nullYear() {
-        TEST.atYear((Year) null);
+        assertThrows(NullPointerException.class, () ->
+                TEST.atYear((Year) null));
     }
 
     //-----------------------------------------------------------------------
@@ -531,10 +536,10 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atYear_int_fromStartOfYear_notLeapYear_day366() {
         DayOfYear test = DayOfYear.of(LEAP_YEAR_LENGTH);
-        test.atYear(2007);
+        assertThrows(DateTimeException.class, () -> test.atYear(2007));
     }
 
     @Test
@@ -547,9 +552,9 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atYear_int_invalidDay() {
-        TEST.atYear(Year.MIN_VALUE - 1);
+        assertThrows(DateTimeException.class, () -> TEST.atYear(Year.MIN_VALUE - 1));
     }
 
     //-----------------------------------------------------------------------
@@ -575,11 +580,12 @@ public class TestDayOfYear {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_nullDayOfYear() {
         DayOfYear doy = null;
         DayOfYear test = DayOfYear.of(1);
-        test.compareTo(doy);
+        assertThrows(NullPointerException.class, () ->
+                test.compareTo(doy));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -482,8 +482,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_adjustInto_null() {
-        assertThrows(NullPointerException.class, () ->
-                TEST.adjustInto((Temporal) null));
+        assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
     //-----------------------------------------------------------------------
@@ -517,8 +516,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_atYear_Year_nullYear() {
-        assertThrows(NullPointerException.class, () ->
-                TEST.atYear((Year) null));
+        assertThrows(NullPointerException.class, () -> TEST.atYear((Year) null));
     }
 
     //-----------------------------------------------------------------------
@@ -582,8 +580,7 @@ public class TestDayOfYear {
     public void test_compareTo_nullDayOfYear() {
         DayOfYear doy = null;
         DayOfYear test = DayOfYear.of(1);
-        assertThrows(NullPointerException.class, () ->
-                test.compareTo(doy));
+        assertThrows(NullPointerException.class, () -> test.compareTo(doy));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestDays.java
+++ b/src/test/java/org/threeten/extra/TestDays.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,17 +52,15 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestDays {
 
     //-----------------------------------------------------------------------
@@ -136,9 +135,9 @@ public class TestDays {
         assertEquals((Integer.MIN_VALUE / 7) * 7, Days.ofWeeks(Integer.MIN_VALUE / 7).getAmount());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_ofWeeks_overflow() {
-        Days.ofWeeks((Integer.MAX_VALUE / 7) + 7);
+        assertThrows(ArithmeticException.class, () -> Days.ofWeeks((Integer.MAX_VALUE / 7) + 7));
     }
 
     //-----------------------------------------------------------------------
@@ -167,19 +166,19 @@ public class TestDays {
         assertEquals(Days.of(2), Days.from(Duration.ofDays(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_remainder() {
-        Days.from(Duration.ofHours(3));
+        assertThrows(DateTimeException.class, () -> Days.from(Duration.ofHours(3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_noConversion() {
-        Days.from(Period.ofMonths(2));
+        assertThrows(DateTimeException.class, () -> Days.from(Period.ofMonths(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_null() {
-        Days.from((TemporalAmount) null);
+        assertThrows(NullPointerException.class, () -> Days.from((TemporalAmount) null));
     }
 
     //-----------------------------------------------------------------------
@@ -214,19 +213,19 @@ public class TestDays {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
         assertEquals(Days.of(expectedDays), Days.parse(str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
         assertEquals(Days.of(expectedDays), Days.parse("+" + str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
         assertEquals(Days.of(-expectedDays), Days.parse("-" + str));
@@ -252,15 +251,15 @@ public class TestDays {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Days.parse(str);
+        assertThrows(DateTimeParseException.class, () -> Days.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Days.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Days.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -269,9 +268,9 @@ public class TestDays {
         assertEquals(6, Days.of(6).get(ChronoUnit.DAYS));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_get_invalidType() {
-        Days.of(6).get(IsoFields.QUARTER_YEARS);
+        assertThrows(DateTimeException.class, () -> Days.of(6).get(IsoFields.QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -280,14 +279,14 @@ public class TestDays {
         assertEquals(Days.of(365 + 366), Days.between(LocalDate.of(2019, 1, 1), LocalDate.of(2021, 1, 1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_date_null() {
-        Days.between(LocalDate.now(), (Temporal) null);
+        assertThrows(NullPointerException.class, () -> Days.between(LocalDate.now(), (Temporal) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_null_date() {
-        Days.between((Temporal) null, LocalDate.now());
+        assertThrows(NullPointerException.class, () -> Days.between((Temporal) null, LocalDate.now()));
     }
 
     //-----------------------------------------------------------------------
@@ -311,29 +310,29 @@ public class TestDays {
         assertEquals(Days.of(Integer.MIN_VALUE), Days.of(Integer.MIN_VALUE + 1).plus(Period.ofDays(-1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_PeriodYears() {
-        Days.of(1).plus(Period.ofYears(2));
+        assertThrows(DateTimeException.class, () -> Days.of(1).plus(Period.ofYears(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_Duration() {
-        Days.of(1).plus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Days.of(1).plus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Days.of(Integer.MAX_VALUE - 1).plus(Days.of(2));
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MAX_VALUE - 1).plus(Days.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Days.of(Integer.MIN_VALUE + 1).plus(Days.of(-2));
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE + 1).plus(Days.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Days.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Days.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -347,14 +346,14 @@ public class TestDays {
         assertEquals(Days.of(Integer.MIN_VALUE), Days.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Days.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Days.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE + 1).plus(-2));
     }
 
     //-----------------------------------------------------------------------
@@ -378,29 +377,29 @@ public class TestDays {
         assertEquals(Days.of(Integer.MIN_VALUE), Days.of(Integer.MIN_VALUE + 1).minus(Period.ofDays(1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_PeriodYears() {
-        Days.of(1).minus(Period.ofYears(2));
+        assertThrows(DateTimeException.class, () -> Days.of(1).minus(Period.ofYears(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_Duration() {
-        Days.of(1).minus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Days.of(1).minus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Days.of(Integer.MAX_VALUE - 1).minus(Days.of(-2));
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MAX_VALUE - 1).minus(Days.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Days.of(Integer.MIN_VALUE + 1).minus(Days.of(2));
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE + 1).minus(Days.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Days.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Days.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -414,14 +413,14 @@ public class TestDays {
         assertEquals(Days.of(Integer.MIN_VALUE), Days.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Days.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Days.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE + 1).minus(2));
     }
 
     //-----------------------------------------------------------------------
@@ -441,14 +440,14 @@ public class TestDays {
         assertEquals(Days.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Days.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Days.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
 
     //-----------------------------------------------------------------------
@@ -470,9 +469,9 @@ public class TestDays {
         assertEquals(Days.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Days.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Days.of(1).dividedBy(0));
     }
 
     //-----------------------------------------------------------------------
@@ -484,9 +483,9 @@ public class TestDays {
         assertEquals(Days.of(-Integer.MAX_VALUE), Days.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Days.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE).negated());
     }
 
     //-----------------------------------------------------------------------
@@ -499,9 +498,9 @@ public class TestDays {
         assertEquals(Days.of(Integer.MAX_VALUE), Days.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Days.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Days.of(Integer.MIN_VALUE).abs());
     }
 
     //-----------------------------------------------------------------------
@@ -535,10 +534,11 @@ public class TestDays {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Days test5 = Days.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestDays.java
+++ b/src/test/java/org/threeten/extra/TestDays.java
@@ -537,8 +537,7 @@ public class TestDays {
     @Test
     public void test_compareTo_null() {
         Days test5 = Days.of(5);
-        assertThrows(NullPointerException.class, () ->
-                test5.compareTo(null));
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -45,25 +46,23 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestHours {
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_isSerializable() {
         assertTrue(Serializable.class.isAssignableFrom(Hours.class));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_deserializationSingleton() throws Exception {
@@ -143,19 +142,19 @@ public class TestHours {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
         assertEquals(Hours.of(expectedDays), Hours.parse(str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
         assertEquals(Hours.of(expectedDays), Hours.parse("+" + str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
         assertEquals(Hours.of(-expectedDays), Hours.parse("-" + str));
@@ -181,17 +180,17 @@ public class TestHours {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Hours.parse(str);
+        assertThrows(DateTimeParseException.class, () -> Hours.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Hours.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Hours.parse((CharSequence) null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_TemporalAmount_Hours() {
@@ -213,19 +212,19 @@ public class TestHours {
         assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).plus(Duration.ofHours(-1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Hours.of(Integer.MAX_VALUE - 1).plus(Hours.of(2));
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MAX_VALUE - 1).plus(Hours.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Hours.of(Integer.MIN_VALUE + 1).plus(Hours.of(-2));
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE + 1).plus(Hours.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Hours.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Hours.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -239,14 +238,14 @@ public class TestHours {
         assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Hours.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Hours.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE + 1).plus(-2));
     }
 
     //-----------------------------------------------------------------------
@@ -270,19 +269,19 @@ public class TestHours {
         assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).minus(Duration.ofHours(1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Hours.of(Integer.MAX_VALUE - 1).minus(Hours.of(-2));
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MAX_VALUE - 1).minus(Hours.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Hours.of(Integer.MIN_VALUE + 1).minus(Hours.of(2));
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE + 1).minus(Hours.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Hours.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Hours.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -296,14 +295,14 @@ public class TestHours {
         assertEquals(Hours.of(Integer.MIN_VALUE), Hours.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Hours.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Hours.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE + 1).minus(2));
     }
 
     //-----------------------------------------------------------------------
@@ -323,14 +322,14 @@ public class TestHours {
         assertEquals(Hours.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Hours.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Hours.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
 
     //-----------------------------------------------------------------------
@@ -352,9 +351,9 @@ public class TestHours {
         assertEquals(Hours.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Hours.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Hours.of(1).dividedBy(0));
     }
 
     //-----------------------------------------------------------------------
@@ -366,9 +365,9 @@ public class TestHours {
         assertEquals(Hours.of(-Integer.MAX_VALUE), Hours.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Hours.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE).negated());
     }
 
     //-----------------------------------------------------------------------
@@ -381,9 +380,9 @@ public class TestHours {
         assertEquals(Hours.of(Integer.MAX_VALUE), Hours.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Hours.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Hours.of(Integer.MIN_VALUE).abs());
     }
 
     //-----------------------------------------------------------------------
@@ -422,10 +421,10 @@ public class TestHours {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Hours test5 = Hours.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------
@@ -467,5 +466,5 @@ public class TestHours {
         Hours testM1 = Hours.of(-1);
         assertEquals("PT-1H", testM1.toString());
     }
-    
+
 }

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -33,9 +33,10 @@ package org.threeten.extra;
 
 import static java.time.temporal.ChronoUnit.HOURS;
 import static java.time.temporal.ChronoUnit.MONTHS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -50,17 +51,15 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestInterval {
 
     static Instant NOW1 = ZonedDateTime.of(2014, 12, 1, 1, 0, 0, 0, ZoneOffset.UTC).toInstant();
@@ -119,19 +118,19 @@ public class TestInterval {
         assertEquals(false, test.isUnboundedEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_Instant_Instant_badOrder() {
-        Interval.of(NOW2, NOW1);
+        assertThrows(DateTimeException.class, () -> Interval.of(NOW2, NOW1));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Instant_Instant_nullStart() {
-        Interval.of(null, NOW2);
+        assertThrows(NullPointerException.class, () -> Interval.of(null, NOW2));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Instant_Instant_nullEnd() {
-        Interval.of(NOW1, (Instant) null);
+        assertThrows(NullPointerException.class, () -> Interval.of(NOW1, (Instant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -149,19 +148,19 @@ public class TestInterval {
         assertEquals(NOW1, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_Instant_Duration_negative() {
-        Interval.of(NOW2, Duration.ofSeconds(-1));
+        assertThrows(DateTimeException.class, () -> Interval.of(NOW2, Duration.ofSeconds(-1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Instant_Duration_nullInstant() {
-        Interval.of(null, Duration.ZERO);
+        assertThrows(NullPointerException.class, () -> Interval.of(null, Duration.ZERO));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Instant_Duration_nullDuration() {
-        Interval.of(NOW1, (Duration) null);
+        assertThrows(NullPointerException.class, () -> Interval.of(NOW1, (Duration) null));
     }
 
     /* Lower and upper bound for Intervals */
@@ -194,8 +193,8 @@ public class TestInterval {
             {Instant.MIN.toString() + "/" + Instant.MAX, Instant.MIN, Instant.MAX}
         };
     }
-    
-    @Test
+
+    @ParameterizedTest
     @UseDataProvider("data_parseValid")
     public void test_parse_CharSequence(String input, Instant start, Instant end) {
         Interval test = Interval.parse(input);
@@ -203,19 +202,19 @@ public class TestInterval {
         assertEquals(end, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_parse_CharSequence_badOrder() {
-        Interval.parse(NOW2 + "/" + NOW1);
+        assertThrows(DateTimeException.class, () -> Interval.parse(NOW2 + "/" + NOW1));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequence_badFormat() {
-        Interval.parse(NOW2 + "-" + NOW1);
+        assertThrows(DateTimeParseException.class, () -> Interval.parse(NOW2 + "-" + NOW1));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Interval.parse(null);
+        assertThrows(NullPointerException.class, () -> Interval.parse(null));
     }
 
     //-----------------------------------------------------------------------
@@ -227,16 +226,18 @@ public class TestInterval {
         assertEquals(NOW3, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withStart_badOrder() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.withStart(NOW3);
+        assertThrows(DateTimeException.class, () ->
+                base.withStart(NOW3));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_withStart_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.withStart(null);
+        assertThrows(NullPointerException.class, () ->
+                base.withStart(null));
     }
 
     //-----------------------------------------------------------------------
@@ -248,16 +249,16 @@ public class TestInterval {
         assertEquals(NOW2, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withEnd_badOrder() {
         Interval base = Interval.of(NOW2, NOW3);
-        base.withEnd(NOW1);
+        assertThrows(DateTimeException.class, () -> base.withEnd(NOW1));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_withEnd_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.withEnd(null);
+        assertThrows(NullPointerException.class, () -> base.withEnd(null));
     }
 
     //-----------------------------------------------------------------------
@@ -289,10 +290,11 @@ public class TestInterval {
         assertEquals(true, test.contains(Instant.MAX));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_contains_Instant_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.contains((Instant) null);
+        assertThrows(NullPointerException.class, () ->
+                base.contains((Instant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -331,10 +333,11 @@ public class TestInterval {
         assertEquals(false, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_encloses_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.encloses((Interval) null);
+        assertThrows(NullPointerException.class, () ->
+                base.encloses((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -372,10 +375,11 @@ public class TestInterval {
         assertEquals(false, test.abuts(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_abuts_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.abuts((Interval) null);
+        assertThrows(NullPointerException.class, () ->
+                base.abuts((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -413,10 +417,11 @@ public class TestInterval {
         assertEquals(false, test.isConnected(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_isConnected_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.isConnected((Interval) null);
+        assertThrows(NullPointerException.class, () ->
+                base.isConnected((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -454,10 +459,11 @@ public class TestInterval {
         assertEquals(false, test.overlaps(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(2))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_overlaps_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        base.overlaps((Interval) null);
+        assertThrows(NullPointerException.class, () ->
+                base.overlaps((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -477,7 +483,7 @@ public class TestInterval {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_intersection")
     public void test_intersection(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
@@ -489,7 +495,7 @@ public class TestInterval {
         assertEquals(expected, test1.intersection(test2));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_intersection")
     public void test_intersection_reverse(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
@@ -501,12 +507,13 @@ public class TestInterval {
         assertEquals(expected, test2.intersection(test1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_intersectionBad() {
         Interval test1 = Interval.of(NOW1, NOW2);
         Interval test2 = Interval.of(NOW3, NOW4);
         assertEquals(false, test1.isConnected(test2));
-        test1.intersection(test2);
+        assertThrows(DateTimeException.class, () ->
+                test1.intersection(test2));
     }
 
     @Test
@@ -532,7 +539,7 @@ public class TestInterval {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_union")
     public void test_unionAndSpan(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
@@ -545,7 +552,7 @@ public class TestInterval {
         assertEquals(expected, test1.span(test2));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_union")
     public void test_unionAndSpan_reverse(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
@@ -558,7 +565,7 @@ public class TestInterval {
         assertEquals(expected, test2.span(test1));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_union")
     public void test_span_enclosesInputs(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
@@ -570,12 +577,13 @@ public class TestInterval {
         assertEquals(true, expected.encloses(test2));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_union_disconnected() {
         Interval test1 = Interval.of(NOW1, NOW2);
         Interval test2 = Interval.of(NOW3, NOW4);
         assertFalse(test1.isConnected(test2));
-        test1.union(test2);
+        assertThrows(DateTimeException.class, () ->
+                test1.union(test2));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -229,15 +229,13 @@ public class TestInterval {
     @Test
     public void test_withStart_badOrder() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(DateTimeException.class, () ->
-                base.withStart(NOW3));
+        assertThrows(DateTimeException.class, () -> base.withStart(NOW3));
     }
 
     @Test
     public void test_withStart_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(NullPointerException.class, () ->
-                base.withStart(null));
+        assertThrows(NullPointerException.class, () -> base.withStart(null));
     }
 
     //-----------------------------------------------------------------------
@@ -512,8 +510,7 @@ public class TestInterval {
         Interval test1 = Interval.of(NOW1, NOW2);
         Interval test2 = Interval.of(NOW3, NOW4);
         assertEquals(false, test1.isConnected(test2));
-        assertThrows(DateTimeException.class, () ->
-                test1.intersection(test2));
+        assertThrows(DateTimeException.class, () -> test1.intersection(test2));
     }
 
     @Test
@@ -582,8 +579,7 @@ public class TestInterval {
         Interval test1 = Interval.of(NOW1, NOW2);
         Interval test2 = Interval.of(NOW3, NOW4);
         assertFalse(test1.isConnected(test2));
-        assertThrows(DateTimeException.class, () ->
-                test1.union(test2));
+        assertThrows(DateTimeException.class, () -> test1.union(test2));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -291,8 +291,7 @@ public class TestInterval {
     @Test
     public void test_contains_Instant_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(NullPointerException.class, () ->
-                base.contains((Instant) null));
+        assertThrows(NullPointerException.class, () -> base.contains((Instant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -334,8 +333,7 @@ public class TestInterval {
     @Test
     public void test_encloses_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(NullPointerException.class, () ->
-                base.encloses((Interval) null));
+        assertThrows(NullPointerException.class, () -> base.encloses((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -376,8 +374,7 @@ public class TestInterval {
     @Test
     public void test_abuts_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(NullPointerException.class, () ->
-                base.abuts((Interval) null));
+        assertThrows(NullPointerException.class, () -> base.abuts((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -418,8 +415,7 @@ public class TestInterval {
     @Test
     public void test_isConnected_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(NullPointerException.class, () ->
-                base.isConnected((Interval) null));
+        assertThrows(NullPointerException.class, () -> base.isConnected((Interval) null));
     }
 
     //-----------------------------------------------------------------------
@@ -460,8 +456,7 @@ public class TestInterval {
     @Test
     public void test_overlaps_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
-        assertThrows(NullPointerException.class, () ->
-                base.overlaps((Interval) null));
+        assertThrows(NullPointerException.class, () -> base.overlaps((Interval) null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -618,8 +618,7 @@ public class TestLocalDateRange {
     @Test
     public void test_withStart_invalid() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_30);
-        assertThrows(DateTimeException.class, () ->
-                base.withStart(DATE_2012_07_31));
+        assertThrows(DateTimeException.class, () -> base.withStart(DATE_2012_07_31));
     }
 
     //-----------------------------------------------------------------------
@@ -662,8 +661,7 @@ public class TestLocalDateRange {
     @Test
     public void test_withEnd_invalid() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        assertThrows(DateTimeException.class, () ->
-                base.withEnd(DATE_2012_07_27));
+        assertThrows(DateTimeException.class, () -> base.withEnd(DATE_2012_07_27));
     }
 
     //-----------------------------------------------------------------------
@@ -891,8 +889,7 @@ public class TestLocalDateRange {
         LocalDateRange test1 = LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_28);
         LocalDateRange test2 = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30);
         assertEquals(false, test1.isConnected(test2));
-        assertThrows(DateTimeException.class, () ->
-                test1.intersection(test2));
+        assertThrows(DateTimeException.class, () -> test1.intersection(test2));
     }
 
     @Test
@@ -961,8 +958,7 @@ public class TestLocalDateRange {
         LocalDateRange test1 = LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_28);
         LocalDateRange test2 = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30);
         assertFalse(test1.isConnected(test2));
-        assertThrows(DateTimeException.class, () ->
-                test1.union(test2));
+        assertThrows(DateTimeException.class, () -> test1.union(test2));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -31,9 +31,10 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -50,18 +51,16 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 import com.google.common.collect.Range;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test date range.
  */
-@RunWith(DataProviderRunner.class)
 public class TestLocalDateRange {
 
     private static final LocalDate MINP1 = LocalDate.MIN.plusDays(1);
@@ -144,19 +143,19 @@ public class TestLocalDateRange {
         assertEquals("-999999999-01-01/+999999999-12-31", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_MIN_MIN() {
-        LocalDateRange.of(LocalDate.MIN, LocalDate.MIN);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(LocalDate.MIN, LocalDate.MIN));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_MIN_MINP1() {
-        LocalDateRange.of(LocalDate.MIN, MINP1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(LocalDate.MIN, MINP1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_MINP1_MINP1() {
-        LocalDateRange.of(MINP1, MINP1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(MINP1, MINP1));
     }
 
     @Test
@@ -198,19 +197,19 @@ public class TestLocalDateRange {
         assertEquals("-999999999-01-03/-999999999-01-03", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_MAX_MAX() {
-        LocalDateRange.of(LocalDate.MAX, LocalDate.MAX);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(LocalDate.MAX, LocalDate.MAX));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_MAXM1_MAX() {
-        LocalDateRange.of(MAXM1, LocalDate.MAX);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(MAXM1, LocalDate.MAX));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_MAXM1_MAXM1() {
-        LocalDateRange.of(MAXM1, MAXM1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(MAXM1, MAXM1));
     }
 
     @Test
@@ -226,9 +225,9 @@ public class TestLocalDateRange {
         assertEquals("2012-07-30/2012-07-30", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_badOrder() {
-        LocalDateRange.of(DATE_2012_07_31, DATE_2012_07_30);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(DATE_2012_07_31, DATE_2012_07_30));
     }
 
     //-----------------------------------------------------------------------
@@ -284,9 +283,9 @@ public class TestLocalDateRange {
         assertEquals("-999999999-01-01/+999999999-12-31", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofClosed_MIN_MIN() {
-        LocalDateRange.ofClosed(LocalDate.MIN, LocalDate.MIN);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofClosed(LocalDate.MIN, LocalDate.MIN));
     }
 
     @Test
@@ -354,24 +353,24 @@ public class TestLocalDateRange {
         assertEquals("-999999999-01-03/-999999999-01-04", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofClosed_MAX_MAX() {
-        LocalDateRange.ofClosed(LocalDate.MAX, LocalDate.MAX);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofClosed(LocalDate.MAX, LocalDate.MAX));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofClosed_MAXM1_MAX() {
-        LocalDateRange.ofClosed(MAXM1, LocalDate.MAX);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofClosed(MAXM1, LocalDate.MAX));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofClosed_MAXM1_MAXM1() {
-        LocalDateRange.ofClosed(MAXM1, MAXM1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofClosed(MAXM1, MAXM1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofClosed_badOrder() {
-        LocalDateRange.ofClosed(DATE_2012_07_31, DATE_2012_07_30);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofClosed(DATE_2012_07_31, DATE_2012_07_30));
     }
 
     //-----------------------------------------------------------------------
@@ -387,24 +386,24 @@ public class TestLocalDateRange {
         assertEquals("2012-07-30/2012-07-30", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofEmpty_MIN() {
-        LocalDateRange.ofEmpty(LocalDate.MIN);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofEmpty(LocalDate.MIN));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofEmpty_MINP1() {
-        LocalDateRange.ofEmpty(MINP1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofEmpty(MINP1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofEmpty_MAX() {
-        LocalDateRange.ofEmpty(LocalDate.MAX);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofEmpty(LocalDate.MAX));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofEmpty_MAXM1() {
-        LocalDateRange.ofEmpty(MAXM1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofEmpty(MAXM1));
     }
 
     //-----------------------------------------------------------------------
@@ -433,14 +432,14 @@ public class TestLocalDateRange {
         assertEquals("-999999999-01-01/2012-07-30", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofUnboundedStart_MIN() {
-        LocalDateRange.ofUnboundedStart(LocalDate.MIN);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofUnboundedStart(LocalDate.MIN));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofUnboundedStart_MINP1() {
-        LocalDateRange.ofUnboundedStart(MINP1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofUnboundedStart(MINP1));
     }
 
     //-----------------------------------------------------------------------
@@ -456,14 +455,14 @@ public class TestLocalDateRange {
         assertEquals("2012-07-30/+999999999-12-31", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofUnboundedEnd_MAX() {
-        LocalDateRange.ofUnboundedEnd(LocalDate.MAX);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofUnboundedEnd(LocalDate.MAX));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofUnboundedEnd_MAXM1() {
-        LocalDateRange.ofUnboundedEnd(MAXM1);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofUnboundedEnd(MAXM1));
     }
 
     //-----------------------------------------------------------------------
@@ -478,29 +477,29 @@ public class TestLocalDateRange {
         assertEquals("2012-07-28/2012-07-31", test.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_period_negative() {
-        LocalDateRange.of(DATE_2012_07_31, Period.ofDays(-1));
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(DATE_2012_07_31, Period.ofDays(-1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_period_atMIN() {
-        LocalDateRange.of(LocalDate.MIN, Period.ofDays(0));
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(LocalDate.MIN, Period.ofDays(0)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_period_atMAX() {
-        LocalDateRange.of(LocalDate.MAX, Period.ofDays(0));
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(LocalDate.MAX, Period.ofDays(0)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_period_atMAXM1_0D() {
-        LocalDateRange.of(MAXM1, Period.ofDays(0));
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(MAXM1, Period.ofDays(0)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_period_atMAXM1_1D() {
-        LocalDateRange.of(MAXM1, Period.ofDays(1));
+        assertThrows(DateTimeException.class, () -> LocalDateRange.of(MAXM1, Period.ofDays(1)));
     }
 
     //-----------------------------------------------------------------------
@@ -546,19 +545,19 @@ public class TestLocalDateRange {
         assertEquals(DATE_2012_07_27, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_parse_CharSequence_badOrder() {
-        LocalDateRange.parse(DATE_2012_07_29 + "/" + DATE_2012_07_27);
+        assertThrows(DateTimeException.class, () -> LocalDateRange.parse(DATE_2012_07_29 + "/" + DATE_2012_07_27));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequence_badFormat() {
-        LocalDateRange.parse(DATE_2012_07_29 + "-" + DATE_2012_07_27);
+        assertThrows(DateTimeParseException.class, () -> LocalDateRange.parse(DATE_2012_07_29 + "-" + DATE_2012_07_27));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        LocalDateRange.parse(null);
+        assertThrows(NullPointerException.class, () -> LocalDateRange.parse(null));
     }
 
     //-----------------------------------------------------------------------
@@ -616,10 +615,11 @@ public class TestLocalDateRange {
         assertEquals(DATE_2012_07_31, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withStart_invalid() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_30);
-        base.withStart(DATE_2012_07_31);
+        assertThrows(DateTimeException.class, () ->
+                base.withStart(DATE_2012_07_31));
     }
 
     //-----------------------------------------------------------------------
@@ -659,10 +659,11 @@ public class TestLocalDateRange {
         assertEquals(DATE_2012_07_30, test.getEnd());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withEnd_invalid() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
-        base.withEnd(DATE_2012_07_27);
+        assertThrows(DateTimeException.class, () ->
+                base.withEnd(DATE_2012_07_27));
     }
 
     //-----------------------------------------------------------------------
@@ -752,7 +753,7 @@ public class TestLocalDateRange {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_queries")
     public void test_encloses(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
@@ -760,7 +761,7 @@ public class TestLocalDateRange {
         assertEquals(isEnclosedBy, test.encloses(LocalDateRange.of(start, end)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_queries")
     public void test_abuts(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
@@ -768,7 +769,7 @@ public class TestLocalDateRange {
         assertEquals(abuts, test.abuts(LocalDateRange.of(start, end)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_queries")
     public void test_isConnected(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
@@ -776,7 +777,7 @@ public class TestLocalDateRange {
         assertEquals(isConnected, test.isConnected(LocalDateRange.of(start, end)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_queries")
     public void test_overlaps(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
@@ -784,7 +785,7 @@ public class TestLocalDateRange {
         assertEquals(overlaps, test.overlaps(LocalDateRange.of(start, end)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_queries")
     public void test_crossCheck(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
@@ -861,7 +862,7 @@ public class TestLocalDateRange {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_intersection")
     public void test_intersection(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
@@ -873,7 +874,7 @@ public class TestLocalDateRange {
         assertEquals(expected, test1.intersection(test2));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_intersection")
     public void test_intersection_reverse(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
@@ -885,12 +886,13 @@ public class TestLocalDateRange {
         assertEquals(expected, test2.intersection(test1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_intersectionBad() {
         LocalDateRange test1 = LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_28);
         LocalDateRange test2 = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30);
         assertEquals(false, test1.isConnected(test2));
-        test1.intersection(test2);
+        assertThrows(DateTimeException.class, () ->
+                test1.intersection(test2));
     }
 
     @Test
@@ -916,7 +918,7 @@ public class TestLocalDateRange {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_union")
     public void test_unionAndSpan(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
@@ -929,7 +931,7 @@ public class TestLocalDateRange {
         assertEquals(expected, test1.span(test2));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_union")
     public void test_unionAndSpan_reverse(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
@@ -942,7 +944,7 @@ public class TestLocalDateRange {
         assertEquals(expected, test2.span(test1));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_union")
     public void test_span_enclosesInputs(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
@@ -954,12 +956,13 @@ public class TestLocalDateRange {
         assertEquals(true, expected.encloses(test2));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_union_disconnected() {
         LocalDateRange test1 = LocalDateRange.of(DATE_2012_07_01, DATE_2012_07_28);
         LocalDateRange test2 = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_30);
         assertFalse(test1.isConnected(test2));
-        test1.union(test2);
+        assertThrows(DateTimeException.class, () ->
+                test1.union(test2));
     }
 
     @Test
@@ -1052,14 +1055,14 @@ public class TestLocalDateRange {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_isBefore")
     public void test_isBefore_range(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertEquals(before, test.isBefore(LocalDateRange.of(start, end)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_isBefore")
     public void test_isBefore_date(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -1132,14 +1135,14 @@ public class TestLocalDateRange {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_isAfter")
     public void test_isAfter_range(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertEquals(before, test.isAfter(LocalDateRange.of(start, end)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_isAfter")
     public void test_isAfter_date(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -1184,14 +1187,14 @@ public class TestLocalDateRange {
         assertEquals(Period.ofDays(0), LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_29).toPeriod());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_toPeriod_unbounded_MIN() {
-        LocalDateRange.of(LocalDate.MIN, DATE_2012_07_29).toPeriod();
+        assertThrows(ArithmeticException.class, () -> LocalDateRange.of(LocalDate.MIN, DATE_2012_07_29).toPeriod());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_toPeriod_unbounded_MAX() {
-        LocalDateRange.of(DATE_2012_07_29, LocalDate.MAX).toPeriod();
+        assertThrows(ArithmeticException.class, () -> LocalDateRange.of(DATE_2012_07_29, LocalDate.MAX).toPeriod());
     }
 
     //-----------------------------------------------------------------------
@@ -1234,7 +1237,7 @@ public class TestLocalDateRange {
         return list;
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_crossCheckGuava")
     public void crossCheckGuava_encloses(
             LocalDateRange extraRange1,
@@ -1247,7 +1250,7 @@ public class TestLocalDateRange {
         assertEquals(guava, extra);
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_crossCheckGuava")
     public void crossCheckGuava_isConnected(
             LocalDateRange extraRange1,
@@ -1260,7 +1263,7 @@ public class TestLocalDateRange {
         assertEquals(guava, extra);
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_crossCheckGuava")
     public void crossCheckGuava_intersection(
             LocalDateRange extraRange1,
@@ -1288,7 +1291,7 @@ public class TestLocalDateRange {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_crossCheckGuava")
     public void crossCheckGuava_span(
             LocalDateRange extraRange1,

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -45,19 +46,17 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestMinutes {
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_isSerializable() {
@@ -76,7 +75,7 @@ public class TestMinutes {
             assertSame(test, ois.readObject());
         }
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_ZERO() {
@@ -87,7 +86,7 @@ public class TestMinutes {
         assertTrue(Minutes.ZERO.isZero());
         assertFalse(Minutes.ZERO.isPositive());
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
@@ -127,12 +126,12 @@ public class TestMinutes {
         assertEquals(-120, Minutes.ofHours(-2).getAmount());
         assertEquals((Integer.MIN_VALUE / 60) * 60, Minutes.ofHours(Integer.MIN_VALUE / 60).getAmount());
     }
-    
-    @Test(expected = ArithmeticException.class)
+
+    @Test
     public void test_ofHours_overflow() {
-        Minutes.ofHours((Integer.MAX_VALUE / 60) + 60);
+        assertThrows(ArithmeticException.class, () -> Minutes.ofHours((Integer.MAX_VALUE / 60) + 60));
     }
-    
+
     //-----------------------------------------------------------------------
     @DataProvider
     public static Object[][] data_valid() {
@@ -177,19 +176,19 @@ public class TestMinutes {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedMinutes) {
         assertEquals(Minutes.of(expectedMinutes), Minutes.parse(str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedMinutes) {
         assertEquals(Minutes.of(expectedMinutes), Minutes.parse("+" + str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedMinutes) {
         assertEquals(Minutes.of(-expectedMinutes), Minutes.parse("-" + str));
@@ -217,17 +216,17 @@ public class TestMinutes {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Minutes.parse(str);
+        assertThrows(DateTimeParseException.class, () -> Minutes.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Minutes.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Minutes.parse((CharSequence) null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_TemporalAmount_Minutes() {
@@ -238,22 +237,22 @@ public class TestMinutes {
         assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE - 1).plus(Minutes.of(1)));
         assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).plus(Minutes.of(-1)));
     }
-    
-    @Test(expected = ArithmeticException.class)
+
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Minutes.of(Integer.MAX_VALUE - 1).plus(Minutes.of(2));
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MAX_VALUE - 1).plus(Minutes.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Minutes.of(Integer.MIN_VALUE + 1).plus(Minutes.of(-2));
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).plus(Minutes.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Minutes.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).plus(null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_int() {
@@ -265,16 +264,16 @@ public class TestMinutes {
         assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Minutes.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Minutes.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).plus(-2));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_minus_TemporalAmount_Minutes() {
@@ -286,21 +285,21 @@ public class TestMinutes {
         assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).minus(Minutes.of(1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Minutes.of(Integer.MAX_VALUE - 1).minus(Minutes.of(-2));
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MAX_VALUE - 1).minus(Minutes.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Minutes.of(Integer.MIN_VALUE + 1).minus(Minutes.of(2));
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).minus(Minutes.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Minutes.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).minus(null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_minus_int() {
@@ -312,16 +311,16 @@ public class TestMinutes {
         assertEquals(Minutes.of(Integer.MIN_VALUE), Minutes.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Minutes.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Minutes.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).minus(2));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_multipliedBy() {
@@ -339,16 +338,16 @@ public class TestMinutes {
         assertEquals(Minutes.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Minutes.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Minutes.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_dividedBy() {
@@ -368,11 +367,11 @@ public class TestMinutes {
         assertEquals(Minutes.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Minutes.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Minutes.of(1).dividedBy(0));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_negated() {
@@ -382,11 +381,11 @@ public class TestMinutes {
         assertEquals(Minutes.of(-Integer.MAX_VALUE), Minutes.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Minutes.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE).negated());
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_abs() {
@@ -397,11 +396,11 @@ public class TestMinutes {
         assertEquals(Minutes.of(Integer.MAX_VALUE), Minutes.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Minutes.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Minutes.of(Integer.MIN_VALUE).abs());
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_addTo() {
@@ -425,7 +424,7 @@ public class TestMinutes {
             assertEquals(Duration.ofMinutes(i), Minutes.of(i).toDuration());
         }
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_compareTo() {
@@ -436,10 +435,11 @@ public class TestMinutes {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Minutes test5 = Minutes.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------
@@ -481,5 +481,5 @@ public class TestMinutes {
         Minutes testM1 = Minutes.of(-1);
         assertEquals("PT-1M", testM1.toString());
     }
-    
+
 }

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -438,8 +438,7 @@ public class TestMinutes {
     @Test
     public void test_compareTo_null() {
         Minutes test5 = Minutes.of(5);
-        assertThrows(NullPointerException.class, () ->
-                test5.compareTo(null));
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestMonths.java
+++ b/src/test/java/org/threeten/extra/TestMonths.java
@@ -532,8 +532,7 @@ public class TestMonths {
     @Test
     public void test_compareTo_null() {
         Months test5 = Months.of(5);
-        assertThrows(NullPointerException.class, () ->
-                test5.compareTo(null));
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestMonths.java
+++ b/src/test/java/org/threeten/extra/TestMonths.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,17 +52,17 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestMonths {
 
     //-----------------------------------------------------------------------
@@ -136,9 +137,9 @@ public class TestMonths {
         assertEquals((Integer.MIN_VALUE / 12) * 12, Months.ofYears(Integer.MIN_VALUE / 12).getAmount());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_ofYears_overflow() {
-        Months.ofYears((Integer.MAX_VALUE / 12) + 12);
+        assertThrows(ArithmeticException.class, () -> Months.ofYears((Integer.MAX_VALUE / 12) + 12));
     }
 
     //-----------------------------------------------------------------------
@@ -167,14 +168,14 @@ public class TestMonths {
         assertEquals(Months.of(41), Months.from(Period.of(3, 5, 0)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_noConversion() {
-        Months.from(Period.ofDays(2));
+        assertThrows(DateTimeException.class, () -> Months.from(Period.ofDays(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_null() {
-        Months.from((TemporalAmount) null);
+        assertThrows(NullPointerException.class, () -> Months.from((TemporalAmount) null));
     }
 
     //-----------------------------------------------------------------------
@@ -209,19 +210,19 @@ public class TestMonths {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
         assertEquals(Months.of(expectedDays), Months.parse(str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
         assertEquals(Months.of(expectedDays), Months.parse("+" + str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
         assertEquals(Months.of(-expectedDays), Months.parse("-" + str));
@@ -245,15 +246,15 @@ public class TestMonths {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Months.parse(str);
+        assertThrows(DateTimeParseException.class, () -> Months.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Months.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Months.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -262,14 +263,14 @@ public class TestMonths {
         assertEquals(Months.of(24), Months.between(LocalDate.of(2019, 1, 1), LocalDate.of(2021, 1, 1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_date_null() {
-        Months.between(LocalDate.now(), (Temporal) null);
+        assertThrows(NullPointerException.class, () -> Months.between(LocalDate.now(), (Temporal) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_null_date() {
-        Months.between((Temporal) null, LocalDate.now());
+        assertThrows(NullPointerException.class, () -> Months.between((Temporal) null, LocalDate.now()));
     }
 
     //-----------------------------------------------------------------------
@@ -278,9 +279,9 @@ public class TestMonths {
         assertEquals(6, Months.of(6).get(ChronoUnit.MONTHS));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_get_invalidType() {
-        Months.of(6).get(IsoFields.QUARTER_YEARS);
+        assertThrows(DateTimeException.class, () -> Months.of(6).get(IsoFields.QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -304,29 +305,29 @@ public class TestMonths {
         assertEquals(Months.of(Integer.MIN_VALUE), Months.of(Integer.MIN_VALUE + 1).plus(Period.ofMonths(-1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_PeriodDays() {
-        Months.of(1).plus(Period.ofDays(2));
+        assertThrows(DateTimeException.class, () -> Months.of(1).plus(Period.ofDays(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_Duration() {
-        Months.of(1).plus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Months.of(1).plus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Months.of(Integer.MAX_VALUE - 1).plus(Months.of(2));
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MAX_VALUE - 1).plus(Months.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Months.of(Integer.MIN_VALUE + 1).plus(Months.of(-2));
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE + 1).plus(Months.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Months.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Months.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -340,14 +341,14 @@ public class TestMonths {
         assertEquals(Months.of(Integer.MIN_VALUE), Months.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Months.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Months.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE + 1).plus(-2));
     }
 
     //-----------------------------------------------------------------------
@@ -371,29 +372,29 @@ public class TestMonths {
         assertEquals(Months.of(Integer.MIN_VALUE), Months.of(Integer.MIN_VALUE + 1).minus(Period.ofMonths(1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_PeriodDays() {
-        Months.of(1).minus(Period.ofDays(2));
+        assertThrows(DateTimeException.class, () -> Months.of(1).minus(Period.ofDays(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_Duration() {
-        Months.of(1).minus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Months.of(1).minus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Months.of(Integer.MAX_VALUE - 1).minus(Months.of(-2));
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MAX_VALUE - 1).minus(Months.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Months.of(Integer.MIN_VALUE + 1).minus(Months.of(2));
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE + 1).minus(Months.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Months.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Months.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -407,14 +408,14 @@ public class TestMonths {
         assertEquals(Months.of(Integer.MIN_VALUE), Months.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Months.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Months.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE + 1).minus(2));
     }
 
     //-----------------------------------------------------------------------
@@ -434,14 +435,14 @@ public class TestMonths {
         assertEquals(Months.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Months.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Months.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
 
     //-----------------------------------------------------------------------
@@ -463,9 +464,9 @@ public class TestMonths {
         assertEquals(Months.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Months.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Months.of(1).dividedBy(0));
     }
 
     //-----------------------------------------------------------------------
@@ -477,9 +478,9 @@ public class TestMonths {
         assertEquals(Months.of(-Integer.MAX_VALUE), Months.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Months.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE).negated());
     }
 
     //-----------------------------------------------------------------------
@@ -492,9 +493,9 @@ public class TestMonths {
         assertEquals(Months.of(Integer.MAX_VALUE), Months.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Months.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Months.of(Integer.MIN_VALUE).abs());
     }
 
     //-----------------------------------------------------------------------
@@ -528,10 +529,11 @@ public class TestMonths {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Months test5 = Months.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestMutableClock.java
+++ b/src/test/java/org/threeten/extra/TestMutableClock.java
@@ -31,9 +31,10 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -60,7 +61,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class.
@@ -89,14 +90,14 @@ public class TestMutableClock {
                 MutableClock.of(Instant.EPOCH, ZoneOffset.MAX).getZone());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_nullInstant() {
-        MutableClock.of(null, ZoneOffset.UTC);
+        assertThrows(NullPointerException.class, () -> MutableClock.of(null, ZoneOffset.UTC));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_nullZone() {
-        MutableClock.of(Instant.EPOCH, null);
+        assertThrows(NullPointerException.class, () -> MutableClock.of(Instant.EPOCH, null));
     }
 
     @Test
@@ -117,9 +118,9 @@ public class TestMutableClock {
         assertEquals(Instant.EPOCH.plusSeconds(10), clock.instant());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_setInstant_null() {
-        MutableClock.epochUTC().setInstant(null);
+        assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().setInstant(null));
     }
 
     @Test
@@ -141,9 +142,9 @@ public class TestMutableClock {
                 clock.instant());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_add_amountOnly_null() {
-        MutableClock.epochUTC().add(null);
+        assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().add(null));
     }
 
     @Test
@@ -165,9 +166,9 @@ public class TestMutableClock {
                 clock.instant());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_add_amountAndUnit_nullUnit() {
-        MutableClock.epochUTC().add(0, null);
+        assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().add(0, null));
     }
 
     @Test
@@ -188,9 +189,9 @@ public class TestMutableClock {
         assertEquals(Instant.EPOCH, clock.instant());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_set_adjuster_null() {
-        MutableClock.epochUTC().set(null);
+        assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().set(null));
     }
 
     @Test
@@ -209,9 +210,9 @@ public class TestMutableClock {
                 clock.instant());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_set_fieldAndValue_nullField() {
-        MutableClock.epochUTC().set(null, 0);
+        assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().set(null, 0));
     }
 
     @Test
@@ -238,9 +239,9 @@ public class TestMutableClock {
         assertEquals(clock, withSameZone);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_withZone_null() {
-        MutableClock.epochUTC().withZone(null);
+        assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().withZone(null));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestOffsetDate.java
+++ b/src/test/java/org/threeten/extra/TestOffsetDate.java
@@ -46,11 +46,12 @@ import static java.time.temporal.ChronoField.OFFSET_SECONDS;
 import static java.time.temporal.ChronoField.PROLEPTIC_MONTH;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -84,25 +85,23 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test OffsetDate.
  */
-@RunWith(DataProviderRunner.class)
 public class TestOffsetDate extends AbstractDateTimeTest {
     private static final ZoneOffset OFFSET_PONE = ZoneOffset.ofHours(1);
     private static final ZoneOffset OFFSET_PTWO = ZoneOffset.ofHours(2);
 
     private OffsetDate TEST_2007_07_15_PONE;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         TEST_2007_07_15_PONE = OffsetDate.of(LocalDate.of(2007, 7, 15), OFFSET_PONE);
     }
@@ -206,14 +205,14 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         }
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void now_Clock_nullZoneId() {
-        OffsetDate.now((ZoneId) null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.now((ZoneId) null));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void now_Clock_nullClock() {
-        OffsetDate.now((Clock) null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.now((Clock) null));
     }
 
     //-----------------------------------------------------------------------
@@ -252,29 +251,29 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of(2007, Month.JULY, 15), OFFSET_PONE), TEST_2007_07_15_PONE);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_intsMonthOffset_dayTooLow() {
-        OffsetDate.of(LocalDate.of(2007, Month.JANUARY, 0), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, Month.JANUARY, 0), OFFSET_PONE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_intsMonthOffset_dayTooHigh() {
-        OffsetDate.of(LocalDate.of(2007, Month.JANUARY, 32), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, Month.JANUARY, 32), OFFSET_PONE));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_of_intsMonthOffset_nullMonth() {
-        OffsetDate.of(LocalDate.of(2007, null, 30), OFFSET_PONE);
+        assertThrows(NullPointerException.class, () -> OffsetDate.of(LocalDate.of(2007, null, 30), OFFSET_PONE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_intsMonthOffset_yearTooLow() {
-        OffsetDate.of(LocalDate.of(Integer.MIN_VALUE, Month.JANUARY, 1), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Integer.MIN_VALUE, Month.JANUARY, 1), OFFSET_PONE));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_of_intsMonthOffset_nullOffset() {
-        OffsetDate.of(LocalDate.of(2007, Month.JANUARY, 30), null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.of(LocalDate.of(2007, Month.JANUARY, 30), null));
     }
 
     //-----------------------------------------------------------------------
@@ -284,34 +283,34 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         check(test, 2007, 7, 15, OFFSET_PONE);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_ints_dayTooLow() {
-        OffsetDate.of(LocalDate.of(2007, 1, 0), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, 1, 0), OFFSET_PONE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_ints_dayTooHigh() {
-        OffsetDate.of(LocalDate.of(2007, 1, 32), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, 1, 32), OFFSET_PONE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_ints_monthTooLow() {
-        OffsetDate.of(LocalDate.of(2007, 0, 1), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, 0, 1), OFFSET_PONE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_ints_monthTooHigh() {
-        OffsetDate.of(LocalDate.of(2007, 13, 1), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, 13, 1), OFFSET_PONE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void factory_of_ints_yearTooLow() {
-        OffsetDate.of(LocalDate.of(Integer.MIN_VALUE, 1, 1), OFFSET_PONE);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Integer.MIN_VALUE, 1, 1), OFFSET_PONE));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_of_ints_nullOffset() {
-        OffsetDate.of(LocalDate.of(2007, 1, 1), (ZoneOffset) null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.of(LocalDate.of(2007, 1, 1), (ZoneOffset) null));
     }
 
     //-----------------------------------------------------------------------
@@ -322,15 +321,15 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         check(test, 2008, 6, 30, OFFSET_PONE);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_of_LocalDateZoneOffset_nullDate() {
-        OffsetDate.of((LocalDate) null, OFFSET_PONE);
+        assertThrows(NullPointerException.class, () -> OffsetDate.of((LocalDate) null, OFFSET_PONE));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_of_LocalDateZoneOffset_nullOffset() {
         LocalDate localDate = LocalDate.of(2008, 6, 30);
-        OffsetDate.of(localDate, (ZoneOffset) null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.of(localDate, (ZoneOffset) null));
     }
 
     //-----------------------------------------------------------------------
@@ -347,27 +346,27 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(TEST_2007_07_15_PONE, OffsetDate.from(base));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessor_invalid_noDerive() {
-        OffsetDate.from(LocalTime.of(12, 30));
+        assertThrows(DateTimeException.class, () -> OffsetDate.from(LocalTime.of(12, 30)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        OffsetDate.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.from((TemporalAccessor) null));
     }
 
     //-----------------------------------------------------------------------
     // parse()
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleToString")
     public void factory_parse_validText(int y, int m, int d, String offsetId, String parsable) {
         OffsetDate t = OffsetDate.parse(parsable);
-        assertNotNull(parsable, t);
-        assertEquals(parsable, y, t.getYear());
-        assertEquals(parsable, m, t.getMonth().getValue());
-        assertEquals(parsable, d, t.getDayOfMonth());
+        assertNotNull(t, parsable);
+        assertEquals(y, t.getYear(), parsable);
+        assertEquals(m, t.getMonth().getValue(), parsable);
+        assertEquals(d, t.getDayOfMonth(), parsable);
         assertEquals(ZoneOffset.of(offsetId), t.getOffset());
     }
 
@@ -393,25 +392,25 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test(expected=DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_sampleBadParse")
     public void factory_parse_invalidText(String unparsable) {
-        OffsetDate.parse(unparsable);
+        assertThrows(DateTimeParseException.class, () -> OffsetDate.parse(unparsable));
     }
 
-    @Test(expected=DateTimeParseException.class)
+    @Test
     public void factory_parse_illegalValue() {
-        OffsetDate.parse("2008-06-32+01:00");
+        assertThrows(DateTimeParseException.class, () -> OffsetDate.parse("2008-06-32+01:00"));
     }
 
-    @Test(expected=DateTimeParseException.class)
+    @Test
     public void factory_parse_invalidValue() {
-        OffsetDate.parse("2008-06-31+01:00");
+        assertThrows(DateTimeParseException.class, () -> OffsetDate.parse("2008-06-31+01:00"));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_parse_nullText() {
-        OffsetDate.parse((String) null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.parse((String) null));
     }
 
     //-----------------------------------------------------------------------
@@ -424,40 +423,34 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of(2010, 12, 3), ZoneOffset.ofHours(1)), test);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_parse_formatter_nullText() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("y M d");
-        OffsetDate.parse((String) null, f);
+        assertThrows(NullPointerException.class, () -> OffsetDate.parse((String) null, f));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void factory_parse_formatter_nullFormatter() {
-        OffsetDate.parse("ANY", null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.parse("ANY", null));
     }
 
     //-----------------------------------------------------------------------
     // constructor
     //-----------------------------------------------------------------------
-    @Test(expected=NullPointerException.class)
+    @Test
     public void constructor_nullDate() throws Throwable  {
         Constructor<OffsetDate> con = OffsetDate.class.getDeclaredConstructor(LocalDate.class, ZoneOffset.class);
         con.setAccessible(true);
-        try {
-            con.newInstance(null, OFFSET_PONE);
-        } catch (InvocationTargetException ex) {
-            throw ex.getCause();
-        }
+        InvocationTargetException thrown = assertThrows(InvocationTargetException.class, () -> con.newInstance(null, OFFSET_PONE));
+        assertTrue(thrown.getCause() instanceof NullPointerException);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void constructor_nullOffset() throws Throwable  {
         Constructor<OffsetDate> con = OffsetDate.class.getDeclaredConstructor(LocalDate.class, ZoneOffset.class);
         con.setAccessible(true);
-        try {
-            con.newInstance(LocalDate.of(2008, 6, 30), null);
-        } catch (InvocationTargetException ex) {
-            throw ex.getCause();
-        }
+        InvocationTargetException thrown = assertThrows(InvocationTargetException.class, () -> con.newInstance(LocalDate.of(2008, 6, 30), null));
+        assertTrue(thrown.getCause() instanceof NullPointerException);
     }
 
     //-----------------------------------------------------------------------
@@ -476,7 +469,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_get_OffsetDate(int y, int m, int d, ZoneOffset offset) {
         LocalDate localDate = LocalDate.of(y, m, d);
@@ -576,9 +569,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OFFSET_PONE, TemporalQueries.zone().queryFrom(TEST_2007_07_15_PONE));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_query_null() {
-        TEST_2007_07_15_PONE.query(null);
+        assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.query(null));
     }
 
     //-----------------------------------------------------------------------
@@ -605,7 +598,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until(long expected, OffsetDate od1, OffsetDate od2, TemporalUnit unit) {
         assertEquals(expected, od1.until(od2, unit));
@@ -619,10 +612,10 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(2, start.until(end, ChronoUnit.MONTHS));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_until_invalidType() {
         OffsetDate od1 = OffsetDate.of(2012, 6, 30, OFFSET_PONE);
-        od1.until(Instant.ofEpochSecond(7), ChronoUnit.SECONDS);
+        assertThrows(DateTimeException.class, () -> od1.until(Instant.ofEpochSecond(7), ChronoUnit.SECONDS));
     }
 
     //-----------------------------------------------------------------------
@@ -643,9 +636,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(base, test);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_withOffsetSameLocal_null() {
-        TEST_2007_07_15_PONE.withOffsetSameLocal(null);
+        assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.withOffsetSameLocal(null));
     }
 
     //-----------------------------------------------------------------------
@@ -697,9 +690,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(base, test);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_with_adjustment_null() {
-        TEST_2007_07_15_PONE.with((TemporalAdjuster) null);
+        assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.with((TemporalAdjuster) null));
     }
 
     //-----------------------------------------------------------------------
@@ -717,14 +710,14 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of(2008, 6, 30), ZoneOffset.ofHoursMinutesSeconds(2, 0, 5)), test.with(ChronoField.OFFSET_SECONDS, 7205));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_with_TemporalField_null() {
-        TEST_2007_07_15_PONE.with((TemporalField) null, 0);
+        assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.with((TemporalField) null, 0));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_with_TemporalField_invalidField() {
-        TEST_2007_07_15_PONE.with(ChronoField.AMPM_OF_DAY, 0);
+        assertThrows(DateTimeException.class, () -> TEST_2007_07_15_PONE.with(ChronoField.AMPM_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -742,9 +735,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(TEST_2007_07_15_PONE, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_withYear_int_invalid() {
-        TEST_2007_07_15_PONE.withYear(Year.MIN_VALUE - 1);
+        assertThrows(DateTimeException.class, () -> TEST_2007_07_15_PONE.withYear(Year.MIN_VALUE - 1));
     }
 
     @Test
@@ -769,9 +762,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(TEST_2007_07_15_PONE, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_withMonth_int_invalid() {
-        TEST_2007_07_15_PONE.withMonth(13);
+        assertThrows(DateTimeException.class, () -> TEST_2007_07_15_PONE.withMonth(13));
     }
 
     @Test
@@ -796,14 +789,14 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of(2007, 7, 15), OFFSET_PONE), t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_withDayOfMonth_invalidForMonth() {
-        OffsetDate.of(LocalDate.of(2007, 11, 30), OFFSET_PONE).withDayOfMonth(31);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, 11, 30), OFFSET_PONE).withDayOfMonth(31));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_withDayOfMonth_invalidAlways() {
-        OffsetDate.of(LocalDate.of(2007, 11, 30), OFFSET_PONE).withDayOfMonth(32);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(2007, 11, 30), OFFSET_PONE).withDayOfMonth(32));
     }
 
     //-----------------------------------------------------------------------
@@ -821,14 +814,14 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(TEST_2007_07_15_PONE, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_withDayOfYear_illegal() {
-        TEST_2007_07_15_PONE.withDayOfYear(367);
+        assertThrows(DateTimeException.class, () -> TEST_2007_07_15_PONE.withDayOfYear(367));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_withDayOfYear_invalid() {
-        TEST_2007_07_15_PONE.withDayOfYear(366);
+        assertThrows(DateTimeException.class, () -> TEST_2007_07_15_PONE.withDayOfYear(366));
     }
 
     //-----------------------------------------------------------------------
@@ -854,9 +847,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(TEST_2007_07_15_PONE, t);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_plus_PlusAdjuster_null() {
-        TEST_2007_07_15_PONE.plus((TemporalAmount) null);
+        assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.plus((TemporalAmount) null));
     }
 
     //-----------------------------------------------------------------------
@@ -894,26 +887,26 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of((int) (-40L + years), 6, 1), OFFSET_PONE), test);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusYears_long_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 1, 1), OFFSET_PONE).plusYears(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 1, 1), OFFSET_PONE).plusYears(1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusYears_long_invalidTooLargeMaxAddMax() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.plusYears(Long.MAX_VALUE);
+        assertThrows(DateTimeException.class, () -> test.plusYears(Long.MAX_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusYears_long_invalidTooLargeMaxAddMin() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.plusYears(Long.MIN_VALUE);
+        assertThrows(DateTimeException.class, () -> test.plusYears(Long.MIN_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusYears_long_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusYears(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusYears(-1));
     }
 
     //-----------------------------------------------------------------------
@@ -976,26 +969,26 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of((int) (-40L + months / 12), 6 + (int) (months % 12), 1), OFFSET_PONE), test);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusMonths_long_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE).plusMonths(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE).plusMonths(1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusMonths_long_invalidTooLargeMaxAddMax() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.plusMonths(Long.MAX_VALUE);
+        assertThrows(DateTimeException.class, () -> test.plusMonths(Long.MAX_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusMonths_long_invalidTooLargeMaxAddMin() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.plusMonths(Long.MIN_VALUE);
+        assertThrows(DateTimeException.class, () -> test.plusMonths(Long.MIN_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusMonths_long_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusMonths(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusMonths(-1));
     }
 
     //-----------------------------------------------------------------------
@@ -1033,7 +1026,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samplePlusWeeksSymmetry")
     public void test_plusWeeks_symmetry(OffsetDate reference) {
         for (int weeks = 0; weeks < 365 * 8; weeks++) {
@@ -1107,24 +1100,24 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(expected, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusWeeks_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).plusWeeks(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).plusWeeks(1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusWeeks_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 7), OFFSET_PONE).plusWeeks(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 7), OFFSET_PONE).plusWeeks(-1));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_plusWeeks_invalidMaxMinusMax() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).plusWeeks(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).plusWeeks(Long.MAX_VALUE));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_plusWeeks_invalidMaxMinusMin() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).plusWeeks(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).plusWeeks(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -1162,7 +1155,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samplePlusDaysSymmetry")
     public void test_plusDays_symmetry(OffsetDate reference) {
         for (int days = 0; days < 365 * 8; days++) {
@@ -1236,24 +1229,24 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(expected, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusDays_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).plusDays(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).plusDays(1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_plusDays_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusDays(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusDays(-1));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_plusDays_overflowTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).plusDays(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).plusDays(Long.MAX_VALUE));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_plusDays_overflowTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusDays(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).plusDays(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -1279,9 +1272,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(TEST_2007_07_15_PONE, t);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_plus_MinusAdjuster_null() {
-        TEST_2007_07_15_PONE.minus((TemporalAmount) null);
+        assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.minus((TemporalAmount) null));
     }
 
     //-----------------------------------------------------------------------
@@ -1319,26 +1312,26 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of((int) (40L - years), 6, 1), OFFSET_PONE), test);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusYears_long_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 1, 1), OFFSET_PONE).minusYears(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 1, 1), OFFSET_PONE).minusYears(-1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusYears_long_invalidTooLargeMaxAddMax() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.minusYears(Long.MAX_VALUE);
+        assertThrows(DateTimeException.class, () -> test.minusYears(Long.MAX_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusYears_long_invalidTooLargeMaxAddMin() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.minusYears(Long.MIN_VALUE);
+        assertThrows(DateTimeException.class, () -> test.minusYears(Long.MIN_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusYears_long_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusYears(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusYears(1));
     }
 
     //-----------------------------------------------------------------------
@@ -1401,26 +1394,26 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(OffsetDate.of(LocalDate.of((int) (40L - months / 12), 6 - (int) (months % 12), 1), OFFSET_PONE), test);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusMonths_long_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE).minusMonths(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE).minusMonths(-1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusMonths_long_invalidTooLargeMaxAddMax() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.minusMonths(Long.MAX_VALUE);
+        assertThrows(DateTimeException.class, () -> test.minusMonths(Long.MAX_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusMonths_long_invalidTooLargeMaxAddMin() {
         OffsetDate test = OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 1), OFFSET_PONE);
-        test.minusMonths(Long.MIN_VALUE);
+        assertThrows(DateTimeException.class, () -> test.minusMonths(Long.MIN_VALUE));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusMonths_long_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusMonths(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusMonths(1));
     }
 
     //-----------------------------------------------------------------------
@@ -1458,7 +1451,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleMinusWeeksSymmetry")
     public void test_minusWeeks_symmetry(OffsetDate reference) {
         for (int weeks = 0; weeks < 365 * 8; weeks++) {
@@ -1532,24 +1525,24 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(expected, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusWeeks_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).minusWeeks(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).minusWeeks(-1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusWeeks_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 7), OFFSET_PONE).minusWeeks(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 7), OFFSET_PONE).minusWeeks(1));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_minusWeeks_invalidMaxMinusMax() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).minusWeeks(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).minusWeeks(Long.MAX_VALUE));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_minusWeeks_invalidMaxMinusMin() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).minusWeeks(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 25), OFFSET_PONE).minusWeeks(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -1587,7 +1580,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleMinusDaysSymmetry")
     public void test_minusDays_symmetry(OffsetDate reference) {
         for (int days = 0; days < 365 * 8; days++) {
@@ -1661,24 +1654,24 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(expected, t);
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusDays_invalidTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).minusDays(-1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).minusDays(-1));
     }
 
-    @Test(expected=DateTimeException.class)
+    @Test
     public void test_minusDays_invalidTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusDays(1);
+        assertThrows(DateTimeException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusDays(1));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_minusDays_overflowTooLarge() {
-        OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).minusDays(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MAX_VALUE, 12, 31), OFFSET_PONE).minusDays(Long.MIN_VALUE));
     }
 
-    @Test(expected=ArithmeticException.class)
+    @Test
     public void test_minusDays_overflowTooSmall() {
-        OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusDays(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> OffsetDate.of(LocalDate.of(Year.MIN_VALUE, 1, 1), OFFSET_PONE).minusDays(Long.MAX_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -1691,9 +1684,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals("2010 12 3", t);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_format_formatter_null() {
-        OffsetDate.of(LocalDate.of(2010, 12, 3), OFFSET_PONE).format(null);
+        assertThrows(NullPointerException.class, () -> OffsetDate.of(LocalDate.of(2010, 12, 3), OFFSET_PONE).format(null));
     }
 
     //-----------------------------------------------------------------------
@@ -1706,16 +1699,16 @@ public class TestOffsetDate extends AbstractDateTimeTest {
                 t.atTime(LocalTime.of(11, 30)));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_atTime_Local_nullLocalTime() {
         OffsetDate t = OffsetDate.of(LocalDate.of(2008, 6, 30), OFFSET_PTWO);
-        t.atTime((LocalTime) null);
+        assertThrows(NullPointerException.class, () -> t.atTime((LocalTime) null));
     }
 
     //-----------------------------------------------------------------------
     // toLocalDate()
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_toLocalDate(int year, int month, int day, ZoneOffset offset) {
         LocalDate t = LocalDate.of(year, month, day);
@@ -1779,17 +1772,17 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertTrue(a.atTime(LocalTime.MIDNIGHT).toInstant().compareTo(b.atTime(LocalTime.MIDNIGHT).toInstant()) == 0);
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         OffsetDate a = OffsetDate.of(LocalDate.of(2008, 6, 30), OFFSET_PONE);
-        a.compareTo(null);
+        assertThrows(NullPointerException.class, () -> a.compareTo(null));
     }
 
-    @Test(expected=ClassCastException.class)
+    @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void compareToNonOffsetDate() {
        Comparable c = TEST_2007_07_15_PONE;
-       c.compareTo(new Object());
+        assertThrows(ClassCastException.class, () -> c.compareTo(new Object()));
     }
 
     //-----------------------------------------------------------------------
@@ -1861,28 +1854,28 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertFalse(b.isAfter(b));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_isBefore_null() {
         OffsetDate a = OffsetDate.of(LocalDate.of(2008, 6, 30), OFFSET_PONE);
-        a.isBefore(null);
+        assertThrows(NullPointerException.class, () -> a.isBefore(null));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_isAfter_null() {
         OffsetDate a = OffsetDate.of(LocalDate.of(2008, 6, 30), OFFSET_PONE);
-        a.isAfter(null);
+        assertThrows(NullPointerException.class, () -> a.isAfter(null));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void test_isEqual_null() {
         OffsetDate a = OffsetDate.of(LocalDate.of(2008, 6, 30), OFFSET_PONE);
-        a.isEqual(null);
+        assertThrows(NullPointerException.class, () -> a.isEqual(null));
     }
 
     //-----------------------------------------------------------------------
     // equals() / hashCode()
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_equals_true(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(LocalDate.of(y, m, d), offset);
@@ -1890,7 +1883,8 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertTrue(a.equals(b));
         assertTrue(a.hashCode() == b.hashCode());
     }
-    @Test
+
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_equals_false_year_differs(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(LocalDate.of(y, m, d), offset);
@@ -1898,7 +1892,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertFalse(a.equals(b));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_equals_false_month_differs(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(LocalDate.of(y, m, d), offset);
@@ -1906,7 +1900,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertFalse(a.equals(b));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_equals_false_day_differs(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(LocalDate.of(y, m, d), offset);
@@ -1914,7 +1908,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertFalse(a.equals(b));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleDates")
     public void test_equals_false_offset_differs(int y, int m, int d, ZoneOffset ignored) {
         OffsetDate a = OffsetDate.of(LocalDate.of(y, m, d), OFFSET_PONE);
@@ -1963,7 +1957,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleToString")
     public void test_toString(int y, int m, int d, String offsetId, String expected) {
         OffsetDate t = OffsetDate.of(LocalDate.of(y, m, d), ZoneOffset.of(offsetId));

--- a/src/test/java/org/threeten/extra/TestPackedFields.java
+++ b/src/test/java/org/threeten/extra/TestPackedFields.java
@@ -35,7 +35,8 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.FOREVER;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -45,7 +46,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.format.ResolverStyle;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test PackedFields.
@@ -68,9 +69,9 @@ public class TestPackedFields {
         assertEquals(99991231, PackedFields.PACKED_DATE.range().getMaximum());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_date_rangeRefinedBy_time() {
-        PackedFields.PACKED_DATE.rangeRefinedBy(LocalTime.of(11, 30));
+        assertThrows(DateTimeException.class, () -> PackedFields.PACKED_DATE.rangeRefinedBy(LocalTime.of(11, 30)));
     }
 
     @Test
@@ -80,14 +81,14 @@ public class TestPackedFields {
         assertEquals(99991231, LocalDate.of(9999, 12, 31).get(PackedFields.PACKED_DATE));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_date_getFrom_rangeLow() {
-        PackedFields.PACKED_DATE.getFrom(LocalDate.of(999, 12, 31));
+        assertThrows(DateTimeException.class, () -> PackedFields.PACKED_DATE.getFrom(LocalDate.of(999, 12, 31)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_date_getFrom_rangeHigh() {
-        PackedFields.PACKED_DATE.getFrom(LocalDate.of(10000, 1, 1));
+        assertThrows(DateTimeException.class, () -> PackedFields.PACKED_DATE.getFrom(LocalDate.of(10000, 1, 1)));
     }
 
     @Test
@@ -95,9 +96,9 @@ public class TestPackedFields {
         assertEquals(LocalDate.of(2015, 12, 3), LocalDate.MIN.with(PackedFields.PACKED_DATE, 20151203));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_date_adjustInto_range() {
-        LocalDate.MIN.with(PackedFields.PACKED_DATE, 1230101);
+        assertThrows(DateTimeException.class, () -> LocalDate.MIN.with(PackedFields.PACKED_DATE, 1230101));
     }
 
     @Test
@@ -106,10 +107,11 @@ public class TestPackedFields {
         assertEquals(LocalDate.of(2015, 12, 3), LocalDate.parse("20151203", f));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_date_resolve_invalid_smart() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_DATE).toFormatter();
-        LocalDate.parse("20151403", f.withResolverStyle(ResolverStyle.SMART));
+        assertThrows(DateTimeParseException.class, () ->
+                LocalDate.parse("20151403", f.withResolverStyle(ResolverStyle.SMART)));
     }
 
     @Test
@@ -134,9 +136,9 @@ public class TestPackedFields {
         assertEquals(2359, PackedFields.PACKED_HOUR_MIN.range().getMaximum());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_hourMin_rangeRefinedBy_time() {
-        PackedFields.PACKED_HOUR_MIN.rangeRefinedBy(LocalDate.of(2015, 12, 3));
+        assertThrows(DateTimeException.class, () -> PackedFields.PACKED_HOUR_MIN.rangeRefinedBy(LocalDate.of(2015, 12, 3)));
     }
 
     @Test
@@ -150,9 +152,9 @@ public class TestPackedFields {
         assertEquals(LocalTime.of(11, 30), LocalTime.MIDNIGHT.with(PackedFields.PACKED_HOUR_MIN, 1130));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_hourMin_adjustInto_value() {
-        LocalDate.MIN.with(PackedFields.PACKED_HOUR_MIN, 1273);
+        assertThrows(DateTimeException.class, () -> LocalDate.MIN.with(PackedFields.PACKED_HOUR_MIN, 1273));
     }
 
     @Test
@@ -161,10 +163,10 @@ public class TestPackedFields {
         assertEquals(LocalTime.of(11, 30), LocalTime.parse("1130", f));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_hourMin_resolve_invalid_smart() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_HOUR_MIN).toFormatter();
-        LocalTime.parse("1173", f.withResolverStyle(ResolverStyle.SMART));
+        assertThrows(DateTimeParseException.class, () -> LocalTime.parse("1173", f.withResolverStyle(ResolverStyle.SMART)));
     }
 
     @Test
@@ -189,9 +191,9 @@ public class TestPackedFields {
         assertEquals(235959, PackedFields.PACKED_TIME.range().getMaximum());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_time_rangeRefinedBy_time() {
-        PackedFields.PACKED_TIME.rangeRefinedBy(LocalDate.of(2015, 12, 3));
+        assertThrows(DateTimeException.class, () -> PackedFields.PACKED_TIME.rangeRefinedBy(LocalDate.of(2015, 12, 3)));
     }
 
     @Test
@@ -206,9 +208,9 @@ public class TestPackedFields {
         assertEquals(LocalTime.of(11, 30, 52), LocalTime.MIDNIGHT.with(PackedFields.PACKED_TIME, 113052));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_time_adjustInto_value() {
-        LocalDate.MIN.with(PackedFields.PACKED_TIME, 127310);
+        assertThrows(DateTimeException.class, () -> LocalDate.MIN.with(PackedFields.PACKED_TIME, 127310));
     }
 
     @Test
@@ -217,10 +219,11 @@ public class TestPackedFields {
         assertEquals(LocalTime.of(11, 30, 52), LocalTime.parse("113052", f));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_time_resolve_invalid_smart() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_TIME).toFormatter();
-        LocalTime.parse("117361", f.withResolverStyle(ResolverStyle.SMART));
+        assertThrows(DateTimeParseException.class, () ->
+                LocalTime.parse("117361", f.withResolverStyle(ResolverStyle.SMART)));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestPackedFields.java
+++ b/src/test/java/org/threeten/extra/TestPackedFields.java
@@ -110,8 +110,7 @@ public class TestPackedFields {
     @Test
     public void test_date_resolve_invalid_smart() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_DATE).toFormatter();
-        assertThrows(DateTimeParseException.class, () ->
-                LocalDate.parse("20151403", f.withResolverStyle(ResolverStyle.SMART)));
+        assertThrows(DateTimeParseException.class, () -> LocalDate.parse("20151403", f.withResolverStyle(ResolverStyle.SMART)));
     }
 
     @Test
@@ -222,8 +221,7 @@ public class TestPackedFields {
     @Test
     public void test_time_resolve_invalid_smart() {
         DateTimeFormatter f = new DateTimeFormatterBuilder().appendValue(PackedFields.PACKED_TIME).toFormatter();
-        assertThrows(DateTimeParseException.class, () ->
-                LocalTime.parse("117361", f.withResolverStyle(ResolverStyle.SMART)));
+        assertThrows(DateTimeParseException.class, () -> LocalTime.parse("117361", f.withResolverStyle(ResolverStyle.SMART)));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestPeriodDuration.java
+++ b/src/test/java/org/threeten/extra/TestPeriodDuration.java
@@ -258,14 +258,12 @@ public class TestPeriodDuration {
     @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        assertThrows(DateTimeParseException.class, () ->
-                PeriodDuration.parse(str));
+        assertThrows(DateTimeParseException.class, () -> PeriodDuration.parse(str));
     }
 
     @Test
     public void test_parse_CharSequence_null() {
-        assertThrows(NullPointerException.class, () ->
-                PeriodDuration.parse((CharSequence) null));
+        assertThrows(NullPointerException.class, () -> PeriodDuration.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestPeriodDuration.java
+++ b/src/test/java/org/threeten/extra/TestPeriodDuration.java
@@ -37,8 +37,9 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -54,17 +55,15 @@ import java.time.Period;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestPeriodDuration {
 
     private static final Period P1Y2M3D = Period.of(1, 2, 3);
@@ -107,9 +106,9 @@ public class TestPeriodDuration {
         assertEquals(0, PeriodDuration.ZERO.get(NANOS));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ZERO_getEra() {
-        PeriodDuration.ZERO.get(ERAS);
+        assertThrows(DateTimeException.class, () -> PeriodDuration.ZERO.get(ERAS));
     }
 
     //-----------------------------------------------------------------------
@@ -220,19 +219,19 @@ public class TestPeriodDuration {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, Period period, Duration duration) {
         assertEquals(PeriodDuration.of(period, duration), PeriodDuration.parse(str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, Period period, Duration duration) {
         assertEquals(PeriodDuration.of(period, duration), PeriodDuration.parse("+" + str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, Period period, Duration duration) {
         assertEquals(PeriodDuration.of(period, duration).negated(), PeriodDuration.parse("-" + str));
@@ -256,15 +255,17 @@ public class TestPeriodDuration {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        PeriodDuration.parse(str);
+        assertThrows(DateTimeParseException.class, () ->
+                PeriodDuration.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        PeriodDuration.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () ->
+                PeriodDuration.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -275,19 +276,19 @@ public class TestPeriodDuration {
         assertEquals(PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(9)), test.plus(Duration.ofSeconds(4)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        PeriodDuration.of(Period.of(Integer.MAX_VALUE - 1, 0, 0)).plus(PeriodDuration.of(Period.ofYears(2)));
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Period.of(Integer.MAX_VALUE - 1, 0, 0)).plus(PeriodDuration.of(Period.ofYears(2))));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        PeriodDuration.of(Period.of(Integer.MIN_VALUE + 1, 0, 0)).plus(PeriodDuration.of(Period.ofYears(-2)));
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Period.of(Integer.MIN_VALUE + 1, 0, 0)).plus(PeriodDuration.of(Period.ofYears(-2))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        P1Y2M3D.plus(null);
+        assertThrows(NullPointerException.class, () -> P1Y2M3D.plus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -298,19 +299,19 @@ public class TestPeriodDuration {
         assertEquals(PeriodDuration.of(P1Y2M3D, Duration.ofSeconds(1)), test.minus(Duration.ofSeconds(4)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        PeriodDuration.of(Period.of(Integer.MAX_VALUE - 1, 0, 0)).minus(PeriodDuration.of(Period.ofYears(-2)));
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Period.of(Integer.MAX_VALUE - 1, 0, 0)).minus(PeriodDuration.of(Period.ofYears(-2))));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        PeriodDuration.of(Period.of(Integer.MIN_VALUE + 1, 0, 0)).minus(PeriodDuration.of(Period.ofYears(2)));
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Period.of(Integer.MIN_VALUE + 1, 0, 0)).minus(PeriodDuration.of(Period.ofYears(2))));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        P1Y2M3D.minus(null);
+        assertThrows(NullPointerException.class, () -> P1Y2M3D.minus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -323,14 +324,14 @@ public class TestPeriodDuration {
         assertEquals(PeriodDuration.of(Period.of(-3,  -6, -9), Duration.ofSeconds(-15)), test.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        PeriodDuration.of(Period.ofYears(Integer.MAX_VALUE / 2 + 1)).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Period.ofYears(Integer.MAX_VALUE / 2 + 1)).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        PeriodDuration.of(Period.ofYears(Integer.MIN_VALUE / 2 - 1)).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Period.ofYears(Integer.MIN_VALUE / 2 - 1)).multipliedBy(2));
     }
 
     //-----------------------------------------------------------------------
@@ -339,9 +340,9 @@ public class TestPeriodDuration {
         assertEquals(PeriodDuration.of(P1Y2M3D.negated(), DUR_5.negated()), PeriodDuration.of(P1Y2M3D, DUR_5).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        PeriodDuration.of(Duration.ofSeconds(Long.MIN_VALUE)).negated();
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Duration.ofSeconds(Long.MIN_VALUE)).negated());
     }
 
     //-----------------------------------------------------------------------
@@ -364,9 +365,9 @@ public class TestPeriodDuration {
                 PeriodDuration.of(P1Y2M3D, Duration.ofHours(-73)).normalizedStandardDays());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_normalizedStandardDaysn_overflow() {
-        PeriodDuration.of(Duration.ofSeconds(Long.MIN_VALUE)).normalizedStandardDays();
+        assertThrows(ArithmeticException.class, () -> PeriodDuration.of(Duration.ofSeconds(Long.MIN_VALUE)).normalizedStandardDays());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestQuarter.java
+++ b/src/test/java/org/threeten/extra/TestQuarter.java
@@ -63,9 +63,10 @@ import static java.time.temporal.ChronoField.YEAR;
 import static java.time.temporal.ChronoField.YEAR_OF_ERA;
 import static java.time.temporal.IsoFields.QUARTER_OF_YEAR;
 import static java.time.temporal.IsoFields.QUARTER_YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.threeten.extra.Quarter.Q3;
 
 import java.io.Serializable;
@@ -82,17 +83,15 @@ import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Locale;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test Quarter.
  */
-@RunWith(DataProviderRunner.class)
 public class TestQuarter {
 
     //-----------------------------------------------------------------------
@@ -115,14 +114,14 @@ public class TestQuarter {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_valueTooLow() {
-        Quarter.of(0);
+        assertThrows(DateTimeException.class, () -> Quarter.of(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_valueTooHigh() {
-        Quarter.of(5);
+        assertThrows(DateTimeException.class, () -> Quarter.of(5));
     }
 
     //-----------------------------------------------------------------------
@@ -144,14 +143,14 @@ public class TestQuarter {
         assertSame(Quarter.Q4, Quarter.ofMonth(12));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofMonth_int_valueTooLow() {
-        Quarter.ofMonth(0);
+        assertThrows(DateTimeException.class, () -> Quarter.ofMonth(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_ofMonth_int_valueTooHigh() {
-        Quarter.ofMonth(13);
+        assertThrows(DateTimeException.class, () -> Quarter.ofMonth(13));
     }
 
     //-----------------------------------------------------------------------
@@ -179,14 +178,14 @@ public class TestQuarter {
         assertEquals(Quarter.Q4, Quarter.from(Month.DECEMBER));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessorl_invalid_noDerive() {
-        Quarter.from(LocalTime.of(12, 30));
+        assertThrows(DateTimeException.class, () -> Quarter.from(LocalTime.of(12, 30)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        Quarter.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> Quarter.from((TemporalAccessor) null));
     }
 
     @Test
@@ -203,14 +202,14 @@ public class TestQuarter {
         assertEquals("Q1", Quarter.Q1.getDisplayName(TextStyle.SHORT, Locale.US));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getDisplayName_nullStyle() {
-        Quarter.Q1.getDisplayName(null, Locale.US);
+        assertThrows(NullPointerException.class, () -> Quarter.Q1.getDisplayName(null, Locale.US));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getDisplayName_nullLocale() {
-        Quarter.Q1.getDisplayName(TextStyle.FULL, null);
+        assertThrows(NullPointerException.class, () -> Quarter.Q1.getDisplayName(TextStyle.FULL, null));
     }
 
     //-----------------------------------------------------------------------
@@ -261,14 +260,14 @@ public class TestQuarter {
         assertEquals(QUARTER_OF_YEAR.range(), Quarter.Q1.range(QUARTER_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_invalidField() {
-        Quarter.Q1.range(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Quarter.Q1.range(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_range_null() {
-        Quarter.Q1.range(null);
+        assertThrows(NullPointerException.class, () -> Quarter.Q1.range(null));
     }
 
     //-----------------------------------------------------------------------
@@ -282,14 +281,14 @@ public class TestQuarter {
         assertEquals(4, Quarter.Q4.get(QUARTER_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_get_invalidField() {
-        Quarter.Q2.get(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Quarter.Q2.get(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_get_null() {
-        Quarter.Q2.get(null);
+        assertThrows(NullPointerException.class, () -> Quarter.Q2.get(null));
     }
 
     //-----------------------------------------------------------------------
@@ -303,14 +302,14 @@ public class TestQuarter {
         assertEquals(4, Quarter.Q4.getLong(QUARTER_OF_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField() {
-        Quarter.Q2.getLong(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Quarter.Q2.getLong(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getLong_null() {
-        Quarter.Q2.getLong(null);
+        assertThrows(NullPointerException.class, () -> Quarter.Q2.getLong(null));
     }
 
     //-----------------------------------------------------------------------
@@ -333,7 +332,7 @@ public class TestQuarter {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_long(int base, long amount, int expected) {
         assertEquals(Quarter.of(expected), Quarter.of(base).plus(amount));
@@ -359,7 +358,7 @@ public class TestQuarter {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_minus")
     public void test_minus_long(int base, long amount, int expected) {
         assertEquals(Quarter.of(expected), Quarter.of(base).minus(amount));

--- a/src/test/java/org/threeten/extra/TestSeconds.java
+++ b/src/test/java/org/threeten/extra/TestSeconds.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -45,19 +46,17 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestSeconds {
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_isSerializable() {
@@ -76,7 +75,7 @@ public class TestSeconds {
             assertSame(test, ois.readObject());
         }
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_ZERO() {
@@ -87,7 +86,7 @@ public class TestSeconds {
         assertTrue(Seconds.ZERO.isZero());
         assertFalse(Seconds.ZERO.isPositive());
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_of() {
@@ -127,12 +126,12 @@ public class TestSeconds {
         assertEquals(-7200, Seconds.ofHours(-2).getAmount());
         assertEquals((Integer.MIN_VALUE / 3600) * 3600, Seconds.ofHours(Integer.MIN_VALUE / 3600).getAmount());
     }
-    
-    @Test(expected = ArithmeticException.class)
+
+    @Test
     public void test_ofHours_overflow() {
-        Seconds.ofHours((Integer.MAX_VALUE / 3600) + 3600);
+        assertThrows(ArithmeticException.class, () -> Seconds.ofHours((Integer.MAX_VALUE / 3600) + 3600));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_ofMinutes() {
@@ -144,12 +143,12 @@ public class TestSeconds {
         assertEquals(-120, Seconds.ofMinutes(-2).getAmount());
         assertEquals((Integer.MIN_VALUE / 60) * 60, Seconds.ofMinutes(Integer.MIN_VALUE / 60).getAmount());
     }
-    
-    @Test(expected = ArithmeticException.class)
+
+    @Test
     public void test_ofMinutes_overflow() {
-        Seconds.ofMinutes((Integer.MAX_VALUE / 60) + 60);
+        assertThrows(ArithmeticException.class, () -> Seconds.ofMinutes((Integer.MAX_VALUE / 60) + 60));
     }
-    
+
     //-----------------------------------------------------------------------
     @DataProvider
     public static Object[][] data_valid() {
@@ -211,19 +210,19 @@ public class TestSeconds {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedSeconds) {
         assertEquals(Seconds.of(expectedSeconds), Seconds.parse(str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedSeconds) {
         assertEquals(Seconds.of(expectedSeconds), Seconds.parse("+" + str));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedSeconds) {
         assertEquals(Seconds.of(-expectedSeconds), Seconds.parse("-" + str));
@@ -249,17 +248,18 @@ public class TestSeconds {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Seconds.parse(str);
+        assertThrows(DateTimeParseException.class, () ->
+                Seconds.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Seconds.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Seconds.parse((CharSequence) null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_TemporalAmount_Seconds() {
@@ -270,22 +270,22 @@ public class TestSeconds {
         assertEquals(Seconds.of(Integer.MAX_VALUE), Seconds.of(Integer.MAX_VALUE - 1).plus(Seconds.of(1)));
         assertEquals(Seconds.of(Integer.MIN_VALUE), Seconds.of(Integer.MIN_VALUE + 1).plus(Seconds.of(-1)));
     }
-    
-    @Test(expected = ArithmeticException.class)
+
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Seconds.of(Integer.MAX_VALUE - 1).plus(Seconds.of(2));
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MAX_VALUE - 1).plus(Seconds.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Seconds.of(Integer.MIN_VALUE + 1).plus(Seconds.of(-2));
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).plus(Seconds.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Seconds.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).plus(null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_plus_int() {
@@ -297,16 +297,16 @@ public class TestSeconds {
         assertEquals(Seconds.of(Integer.MIN_VALUE), Seconds.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Seconds.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Seconds.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).plus(-2));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_minus_TemporalAmount_Seconds() {
@@ -318,21 +318,21 @@ public class TestSeconds {
         assertEquals(Seconds.of(Integer.MIN_VALUE), Seconds.of(Integer.MIN_VALUE + 1).minus(Seconds.of(1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Seconds.of(Integer.MAX_VALUE - 1).minus(Seconds.of(-2));
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MAX_VALUE - 1).minus(Seconds.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Seconds.of(Integer.MIN_VALUE + 1).minus(Seconds.of(2));
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).minus(Seconds.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Seconds.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).minus(null));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_minus_int() {
@@ -344,16 +344,16 @@ public class TestSeconds {
         assertEquals(Seconds.of(Integer.MIN_VALUE), Seconds.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Seconds.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Seconds.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).minus(2));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_multipliedBy() {
@@ -371,16 +371,16 @@ public class TestSeconds {
         assertEquals(Seconds.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Seconds.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Seconds.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_dividedBy() {
@@ -400,11 +400,11 @@ public class TestSeconds {
         assertEquals(Seconds.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Seconds.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Seconds.of(1).dividedBy(0));
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_negated() {
@@ -414,11 +414,11 @@ public class TestSeconds {
         assertEquals(Seconds.of(-Integer.MAX_VALUE), Seconds.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Seconds.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE).negated());
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_abs() {
@@ -429,11 +429,11 @@ public class TestSeconds {
         assertEquals(Seconds.of(Integer.MAX_VALUE), Seconds.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Seconds.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Seconds.of(Integer.MIN_VALUE).abs());
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_addTo() {
@@ -457,7 +457,7 @@ public class TestSeconds {
             assertEquals(Duration.ofSeconds(i), Seconds.of(i).toDuration());
         }
     }
-    
+
     //-----------------------------------------------------------------------
     @Test
     public void test_compareTo() {
@@ -468,10 +468,11 @@ public class TestSeconds {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Seconds test5 = Seconds.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------
@@ -513,5 +514,5 @@ public class TestSeconds {
         Seconds testM1 = Seconds.of(-1);
         assertEquals("PT-1S", testM1.toString());
     }
-    
+
 }

--- a/src/test/java/org/threeten/extra/TestSeconds.java
+++ b/src/test/java/org/threeten/extra/TestSeconds.java
@@ -251,8 +251,7 @@ public class TestSeconds {
     @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        assertThrows(DateTimeParseException.class, () ->
-                Seconds.parse(str));
+        assertThrows(DateTimeParseException.class, () -> Seconds.parse(str));
     }
 
     @Test
@@ -471,8 +470,7 @@ public class TestSeconds {
     @Test
     public void test_compareTo_null() {
         Seconds test5 = Seconds.of(5);
-        assertThrows(NullPointerException.class, () ->
-                test5.compareTo(null));
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestTemporals.java
+++ b/src/test/java/org/threeten/extra/TestTemporals.java
@@ -52,10 +52,11 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static java.time.temporal.IsoFields.QUARTER_YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -75,17 +76,15 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test Temporals.
  */
-@RunWith(DataProviderRunner.class)
 public class TestTemporals {
 
     //-----------------------------------------------------------------------
@@ -366,15 +365,15 @@ public class TestTemporals {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_parseFirstMatching")
     public void test_parseFirstMatching(String text, DateTimeFormatter fmt1, DateTimeFormatter fmt2) {
         assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching(text, LocalDate::from, fmt1, fmt2));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parseFirstMatching_zero() {
-        Temporals.parseFirstMatching("2016-09-06", LocalDate::from);
+        assertThrows(DateTimeParseException.class, () -> Temporals.parseFirstMatching("2016-09-06", LocalDate::from));
     }
 
     @Test
@@ -382,9 +381,9 @@ public class TestTemporals {
         assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching("2016-09-06", LocalDate::from, DateTimeFormatter.ISO_LOCAL_DATE));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parseFirstMatching_twoNoMatch() {
-        Temporals.parseFirstMatching("2016", LocalDate::from, DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.BASIC_ISO_DATE);
+        assertThrows(DateTimeParseException.class, () -> Temporals.parseFirstMatching("2016", LocalDate::from, DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.BASIC_ISO_DATE));
     }
 
     //-----------------------------------------------------------------------
@@ -403,31 +402,31 @@ public class TestTemporals {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_timeUnitConversion")
     public void test_timeUnit(ChronoUnit chronoUnit, TimeUnit timeUnit) {
         assertEquals(timeUnit, Temporals.timeUnit(chronoUnit));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_timeUnit_unknown() {
-        Temporals.timeUnit(ChronoUnit.MONTHS);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void test_timeUnit_null() {
-        Temporals.timeUnit(null);
+        assertThrows(IllegalArgumentException.class, () -> Temporals.timeUnit(ChronoUnit.MONTHS));
     }
 
     @Test
+    public void test_timeUnit_null() {
+        assertThrows(NullPointerException.class, () -> Temporals.timeUnit(null));
+    }
+
+    @ParameterizedTest
     @UseDataProvider("data_timeUnitConversion")
     public void test_chronoUnit(ChronoUnit chronoUnit, TimeUnit timeUnit) {
         assertEquals(chronoUnit, Temporals.chronoUnit(timeUnit));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_chronoUnit_null() {
-        Temporals.chronoUnit(null);
+        assertThrows(NullPointerException.class, () -> Temporals.chronoUnit(null));
     }
 
     //-----------------------------------------------------------------------
@@ -580,7 +579,7 @@ public class TestTemporals {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_convertAmount")
     public void test_convertAmount(
             long fromAmount, TemporalUnit fromUnit, TemporalUnit resultUnit,
@@ -590,7 +589,7 @@ public class TestTemporals {
         assertEquals(resultRemainder, result[1]);
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_convertAmount")
     public void test_convertAmount_negative(
             long fromAmount, TemporalUnit fromUnit, TemporalUnit resultUnit,
@@ -641,10 +640,10 @@ public class TestTemporals {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_convertAmountInvalid")
     public void test_convertAmountInvalid(TemporalUnit fromUnit, TemporalUnit resultUnit) {
-        Temporals.convertAmount(1, fromUnit, resultUnit);
+        assertThrows(DateTimeException.class, () -> Temporals.convertAmount(1, fromUnit, resultUnit));
     }
 
     @DataProvider
@@ -665,10 +664,10 @@ public class TestTemporals {
         };
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_convertAmountInvalidUnsupported")
     public void test_convertAmountInvalidUnsupported(TemporalUnit fromUnit, TemporalUnit resultUnit) {
-        Temporals.convertAmount(1, fromUnit, resultUnit);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Temporals.convertAmount(1, fromUnit, resultUnit));
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestWeeks.java
+++ b/src/test/java/org/threeten/extra/TestWeeks.java
@@ -473,8 +473,7 @@ public class TestWeeks {
     @Test
     public void test_compareTo_null() {
         Weeks test5 = Weeks.of(5);
-        assertThrows(NullPointerException.class, () ->
-                test5.compareTo(null));
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestWeeks.java
+++ b/src/test/java/org/threeten/extra/TestWeeks.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,17 +52,15 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestWeeks {
 
     //-----------------------------------------------------------------------
@@ -144,19 +143,19 @@ public class TestWeeks {
         assertEquals(Weeks.of(2), Weeks.from(Duration.ofDays(14)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_remainder() {
-        Weeks.from(Period.ofDays(3));
+        assertThrows(DateTimeException.class, () -> Weeks.from(Period.ofDays(3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_noConversion() {
-        Weeks.from(Period.ofMonths(2));
+        assertThrows(DateTimeException.class, () -> Weeks.from(Period.ofMonths(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_null() {
-        Weeks.from((TemporalAmount) null);
+        assertThrows(NullPointerException.class, () -> Weeks.from((TemporalAmount) null));
     }
 
     //-----------------------------------------------------------------------
@@ -188,15 +187,15 @@ public class TestWeeks {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Weeks.parse(str);
+        assertThrows(DateTimeParseException.class, () -> Weeks.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Weeks.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Weeks.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -205,14 +204,14 @@ public class TestWeeks {
         assertEquals(Weeks.of(104), Weeks.between(LocalDate.of(2019, 1, 1), LocalDate.of(2021, 1, 1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_date_null() {
-        Weeks.between(LocalDate.now(), (Temporal) null);
+        assertThrows(NullPointerException.class, () -> Weeks.between(LocalDate.now(), (Temporal) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_null_date() {
-        Weeks.between((Temporal) null, LocalDate.now());
+        assertThrows(NullPointerException.class, () -> Weeks.between((Temporal) null, LocalDate.now()));
     }
 
     //-----------------------------------------------------------------------
@@ -221,9 +220,9 @@ public class TestWeeks {
         assertEquals(6, Weeks.of(6).get(ChronoUnit.WEEKS));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_get_invalidType() {
-        Weeks.of(6).get(IsoFields.QUARTER_YEARS);
+        assertThrows(DateTimeException.class, () -> Weeks.of(6).get(IsoFields.QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -247,29 +246,29 @@ public class TestWeeks {
         assertEquals(Weeks.of(Integer.MIN_VALUE), Weeks.of(Integer.MIN_VALUE + 1).plus(Period.ofWeeks(-1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_PeriodMonths() {
-        Weeks.of(1).plus(Period.ofMonths(2));
+        assertThrows(DateTimeException.class, () -> Weeks.of(1).plus(Period.ofMonths(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_Duration() {
-        Weeks.of(1).plus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Weeks.of(1).plus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Weeks.of(Integer.MAX_VALUE - 1).plus(Weeks.of(2));
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MAX_VALUE - 1).plus(Weeks.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Weeks.of(Integer.MIN_VALUE + 1).plus(Weeks.of(-2));
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).plus(Weeks.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Weeks.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -283,14 +282,14 @@ public class TestWeeks {
         assertEquals(Weeks.of(Integer.MIN_VALUE), Weeks.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Weeks.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Weeks.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).plus(-2));
     }
 
     //-----------------------------------------------------------------------
@@ -314,29 +313,29 @@ public class TestWeeks {
         assertEquals(Weeks.of(Integer.MIN_VALUE), Weeks.of(Integer.MIN_VALUE + 1).minus(Period.ofWeeks(1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_PeriodMonths() {
-        Weeks.of(1).minus(Period.ofMonths(2));
+        assertThrows(DateTimeException.class, () -> Weeks.of(1).minus(Period.ofMonths(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_Duration() {
-        Weeks.of(1).minus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Weeks.of(1).minus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Weeks.of(Integer.MAX_VALUE - 1).minus(Weeks.of(-2));
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MAX_VALUE - 1).minus(Weeks.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Weeks.of(Integer.MIN_VALUE + 1).minus(Weeks.of(2));
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).minus(Weeks.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Weeks.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -350,14 +349,14 @@ public class TestWeeks {
         assertEquals(Weeks.of(Integer.MIN_VALUE), Weeks.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Weeks.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Weeks.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).minus(2));
     }
 
     //-----------------------------------------------------------------------
@@ -377,14 +376,14 @@ public class TestWeeks {
         assertEquals(Weeks.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Weeks.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Weeks.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
 
     //-----------------------------------------------------------------------
@@ -406,9 +405,9 @@ public class TestWeeks {
         assertEquals(Weeks.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Weeks.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Weeks.of(1).dividedBy(0));
     }
 
     //-----------------------------------------------------------------------
@@ -420,9 +419,9 @@ public class TestWeeks {
         assertEquals(Weeks.of(-Integer.MAX_VALUE), Weeks.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Weeks.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE).negated());
     }
 
     //-----------------------------------------------------------------------
@@ -435,9 +434,9 @@ public class TestWeeks {
         assertEquals(Weeks.of(Integer.MAX_VALUE), Weeks.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Weeks.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Weeks.of(Integer.MIN_VALUE).abs());
     }
 
     //-----------------------------------------------------------------------
@@ -471,10 +470,11 @@ public class TestWeeks {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Weeks test5 = Weeks.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestYearQuarter.java
+++ b/src/test/java/org/threeten/extra/TestYearQuarter.java
@@ -78,8 +78,9 @@ import static java.time.temporal.ChronoUnit.YEARS;
 import static java.time.temporal.IsoFields.DAY_OF_QUARTER;
 import static java.time.temporal.IsoFields.QUARTER_OF_YEAR;
 import static java.time.temporal.IsoFields.QUARTER_YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.threeten.extra.Quarter.Q1;
 import static org.threeten.extra.Quarter.Q2;
 import static org.threeten.extra.Quarter.Q3;
@@ -111,7 +112,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 /**
  * Test YearQuarter.
@@ -158,19 +160,19 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Year_Quarter_nullQuarter() {
-        YearQuarter.of(Year.of(2012), (Quarter) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of(Year.of(2012), (Quarter) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Year_Quarter_nullYear() {
-        YearQuarter.of((Year) null, Quarter.Q2);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of((Year) null, Quarter.Q2));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Year_Quarter_nullBoth() {
-        YearQuarter.of((Year) null, (Quarter) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of((Year) null, (Quarter) null));
     }
 
     //-----------------------------------------------------------------------
@@ -188,9 +190,9 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_Year_int_null() {
-        YearQuarter.of((Year) null, 2);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of((Year) null, 2));
     }
 
     //-----------------------------------------------------------------------
@@ -208,19 +210,19 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_Quarter_yearTooLow() {
-        YearQuarter.of(Year.MIN_VALUE - 1, Quarter.Q2);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(Year.MIN_VALUE - 1, Quarter.Q2));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_Quarter_yearTooHigh() {
-        YearQuarter.of(Year.MAX_VALUE + 1, Quarter.Q2);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(Year.MAX_VALUE + 1, Quarter.Q2));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_of_int_Quarter_null() {
-        YearQuarter.of(2012, (Quarter) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, (Quarter) null));
     }
 
     //-----------------------------------------------------------------------
@@ -240,24 +242,24 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_int_yearTooLow() {
-        YearQuarter.of(Year.MIN_VALUE - 1, 1);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(Year.MIN_VALUE - 1, 1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_int_yearTooHigh() {
-        YearQuarter.of(Year.MAX_VALUE + 1, 1);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(Year.MAX_VALUE + 1, 1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_int_quarterTooLow() {
-        YearQuarter.of(2012, 0);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(2012, 0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_int_int_quarterTooHigh() {
-        YearQuarter.of(2012, 5);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(2012, 5));
     }
 
     //-----------------------------------------------------------------------
@@ -285,14 +287,14 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessor_noDerive() {
-        YearQuarter.from(LocalTime.NOON);
+        assertThrows(DateTimeException.class, () -> YearQuarter.from(LocalTime.NOON));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        YearQuarter.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.from((TemporalAccessor) null));
     }
 
     //-----------------------------------------------------------------------
@@ -308,19 +310,19 @@ public class TestYearQuarter {
         assertEquals(YearQuarter.of(2012, Q3), YearQuarter.parse("2012-q3"));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequenceDate_invalidYear() {
-        YearQuarter.parse("12345-Q3");
+        assertThrows(DateTimeParseException.class, () -> YearQuarter.parse("12345-Q3"));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequenceDate_invalidQuarter() {
-        YearQuarter.parse("2012-Q0");
+        assertThrows(DateTimeParseException.class, () -> YearQuarter.parse("2012-Q0"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequenceDate_nullCharSequence() {
-        YearQuarter.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -332,21 +334,21 @@ public class TestYearQuarter {
         assertEquals(YearQuarter.of(2012, Q3), YearQuarter.parse("Q3 2012", f));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequenceDateDateTimeFormatter_invalidQuarter() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("'Q'Q uuuu");
-        YearQuarter.parse("Q0 2012", f);
+        assertThrows(DateTimeParseException.class, () -> YearQuarter.parse("Q0 2012", f));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullCharSequence() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("'Q'Q uuuu");
-        YearQuarter.parse((CharSequence) null, f);
+        assertThrows(NullPointerException.class, () -> YearQuarter.parse((CharSequence) null, f));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullDateTimeFormatter() {
-        YearQuarter.parse("", (DateTimeFormatter) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.parse("", (DateTimeFormatter) null));
     }
 
     //-----------------------------------------------------------------------
@@ -424,14 +426,14 @@ public class TestYearQuarter {
         assertEquals(ERA.range(), TEST.range(ERA));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_invalidField() {
-        TEST.range(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.range(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_range_null() {
-        TEST.range((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -445,14 +447,14 @@ public class TestYearQuarter {
         assertEquals(1, TEST.get(ERA));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_get_invalidField() {
-        TEST.get(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.get(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_get_null() {
-        TEST.get((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -466,14 +468,14 @@ public class TestYearQuarter {
         assertEquals(1L, TEST.getLong(ERA));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField() {
-        TEST.getLong(MONTH_OF_YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.getLong(MONTH_OF_YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getLong_null() {
-        TEST.getLong((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -574,14 +576,14 @@ public class TestYearQuarter {
         assertEquals(YearQuarter.of(2012, Q3), YearQuarter.of(2007, Q2).with(YearQuarter.of(2012, Q3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_with_TemporalAdjuster_LocalDate() {
-        YearQuarter.of(2007, Q2).with(LocalDate.of(2012, 6, 30));
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(2007, Q2).with(LocalDate.of(2012, 6, 30)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_with_TemporalAdjuster_null() {
-        YearQuarter.of(2007, Q2).with((TemporalAdjuster) null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of(2007, Q2).with((TemporalAdjuster) null));
     }
 
     //-----------------------------------------------------------------------
@@ -592,14 +594,14 @@ public class TestYearQuarter {
         assertEquals(YearQuarter.of(2012, Q2), YearQuarter.of(2007, Q2).withYear(2012));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withYear_int_quarterTooLow() {
-        TEST.withYear(Year.MIN_VALUE - 1);
+        assertThrows(DateTimeException.class, () -> TEST.withYear(Year.MIN_VALUE - 1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withYear_int_quarterTooHigh() {
-        TEST.withYear(Year.MAX_VALUE + 1);
+        assertThrows(DateTimeException.class, () -> TEST.withYear(Year.MAX_VALUE + 1));
     }
 
     //-----------------------------------------------------------------------
@@ -610,14 +612,14 @@ public class TestYearQuarter {
         assertEquals(YearQuarter.of(2007, Q1), YearQuarter.of(2007, Q2).withQuarter(1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withQuarter_int_quarterTooLow() {
-        TEST.withQuarter(0);
+        assertThrows(DateTimeException.class, () -> TEST.withQuarter(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withQuarter_int_quarterTooHigh() {
-        TEST.withQuarter(5);
+        assertThrows(DateTimeException.class, () -> TEST.withQuarter(5));
     }
 
     //-----------------------------------------------------------------------
@@ -741,9 +743,9 @@ public class TestYearQuarter {
         assertEquals(expected, YearQuarter.of(2012, Q1).adjustInto(base));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_adjustInto_Temporal_null() {
-        TEST.adjustInto((Temporal) null);
+        assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
     //-----------------------------------------------------------------------
@@ -782,27 +784,27 @@ public class TestYearQuarter {
         assertEquals(2, YearQuarter.of(2012, Q2).until(YearQuarter.of(2014, Q2), YEARS));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_until_TemporalTemporalUnit_nullTemporal() {
-        YearQuarter.of(2012, Q2).until(null, QUARTER_YEARS);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, Q2).until(null, QUARTER_YEARS));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_until_TemporalTemporalUnit_nullTemporalUnit() {
-        YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), null));
     }
 
     //-----------------------------------------------------------------------
     // quartersUntil(YearQuarter)
     //-----------------------------------------------------------------------
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_quartersUntil_null() {
-        YearQuarter.of(2012, Q2).quartersUntil(null);
+        assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, Q2).quartersUntil(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_quartersUntil_IllegalArgument() {
-        YearQuarter.of(2012, Q2).quartersUntil(YearQuarter.of(2012, Q1));
+        assertThrows(IllegalArgumentException.class, () -> YearQuarter.of(2012, Q2).quartersUntil(YearQuarter.of(2012, Q1)));
     }
 
     @Test
@@ -833,9 +835,9 @@ public class TestYearQuarter {
         assertEquals("Q1 2012", YearQuarter.of(2012, Q1).format(f));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_format_null() {
-        TEST.format((DateTimeFormatter) null);
+        assertThrows(NullPointerException.class, () -> TEST.format((DateTimeFormatter) null));
     }
 
     //-----------------------------------------------------------------------
@@ -866,29 +868,29 @@ public class TestYearQuarter {
         assertEquals(LocalDate.of(2012, 3, 31), YearQuarter.of(2012, Q1).atDay(91));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atDay_Q1_91_notLeap() {
-        YearQuarter.of(2011, Q1).atDay(91);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(2011, Q1).atDay(91));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atDay_Q1_92() {
-        YearQuarter.of(2012, Q1).atDay(92);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(2012, Q1).atDay(92));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atDay_Q2_92() {
-        YearQuarter.of(2012, Q2).atDay(92);
+        assertThrows(DateTimeException.class, () -> YearQuarter.of(2012, Q2).atDay(92));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atDay_tooLow() {
-        TEST.atDay(0);
+        assertThrows(DateTimeException.class, () -> TEST.atDay(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_atDay_tooHigh() {
-        TEST.atDay(93);
+        assertThrows(DateTimeException.class, () -> TEST.atDay(93));
     }
 
     //-----------------------------------------------------------------------
@@ -962,9 +964,9 @@ public class TestYearQuarter {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_nullYearQuarter() {
-        TEST.compareTo(null);
+        assertThrows(NullPointerException.class, () -> TEST.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -718,15 +718,13 @@ public class TestYearWeek {
     @Test
     public void test_parse_CharSequenceDateDateTimeFormatter_invalidWeek() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("E 'W'w YYYY").withLocale(Locale.ENGLISH);
-        assertThrows(DateTimeParseException.class, () ->
-                YearWeek.parse("Mon W99 2015", f));
+        assertThrows(DateTimeParseException.class, () -> YearWeek.parse("Mon W99 2015", f));
     }
 
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullCharSequence() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("E 'W'w YYYY").withLocale(Locale.ENGLISH);
-        assertThrows(NullPointerException.class, () ->
-                YearWeek.parse((CharSequence) null, f));
+        assertThrows(NullPointerException.class, () -> YearWeek.parse((CharSequence) null, f));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -72,9 +72,10 @@ import static java.time.temporal.IsoFields.DAY_OF_QUARTER;
 import static java.time.temporal.IsoFields.QUARTER_OF_YEAR;
 import static java.time.temporal.IsoFields.WEEK_BASED_YEAR;
 import static java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -109,14 +110,12 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.Locale;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
-@RunWith(DataProviderRunner.class)
 public class TestYearWeek {
 
     private static final YearWeek TEST_NON_LEAP = YearWeek.of(2014, 1);
@@ -345,9 +344,9 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     // now(ZoneId)
     //-----------------------------------------------------------------------
-    @Test(expected = NullPointerException.class)
+    @Test
     public void now_ZoneId_nullZoneId() {
-        YearWeek.now((ZoneId) null);
+        assertThrows(NullPointerException.class, () -> YearWeek.now((ZoneId) null));
     }
 
     @Test
@@ -377,15 +376,15 @@ public class TestYearWeek {
         assertEquals(52, test.getWeek());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void now_Clock_nullClock() {
-        YearWeek.now((Clock) null);
+        assertThrows(NullPointerException.class, () -> YearWeek.now((Clock) null));
     }
 
     //-----------------------------------------------------------------------
     // of(Year, int)
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleYearWeeks")
     public void test_of_Year_int(int year, int week) {
         YearWeek yearWeek = YearWeek.of(Year.of(year), week);
@@ -401,7 +400,7 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     // of(int, int)
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleYearWeeks")
     public void test_of(int year, int week) {
         YearWeek yearWeek = YearWeek.of(year, week);
@@ -414,24 +413,24 @@ public class TestYearWeek {
         assertTrue(YearWeek.of(2014, 53).equals(TEST));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_year_tooLow() {
-        YearWeek.of(Integer.MIN_VALUE, 1);
+        assertThrows(DateTimeException.class, () -> YearWeek.of(Integer.MIN_VALUE, 1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_year_tooHigh() {
-        YearWeek.of(Integer.MAX_VALUE, 1);
+        assertThrows(DateTimeException.class, () -> YearWeek.of(Integer.MAX_VALUE, 1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_invalidWeekValue() {
-        YearWeek.of(2015, 54);
+        assertThrows(DateTimeException.class, () -> YearWeek.of(2015, 54));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_of_invalidWeekValueZero() {
-        YearWeek.of(2015, 0);
+        assertThrows(DateTimeException.class, () -> YearWeek.of(2015, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -479,7 +478,7 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     // atDay(DayOfWeek)
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleAtDay")
     public void test_atDay(int weekBasedYear, int weekOfWeekBasedYear, DayOfWeek dayOfWeek, int year, int month, int dayOfMonth) {
         YearWeek yearWeek = YearWeek.of(weekBasedYear, weekOfWeekBasedYear);
@@ -503,15 +502,15 @@ public class TestYearWeek {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_atDay_null() {
-        TEST.atDay(null);
+        assertThrows(NullPointerException.class, () -> TEST.atDay(null));
     }
 
     //-----------------------------------------------------------------------
     // is53WeekYear()
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_53WeekYear")
     public void test_is53WeekYear(int year) {
         YearWeek yearWeek = YearWeek.of(year, 1);
@@ -573,15 +572,15 @@ public class TestYearWeek {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_nullYearWeek() {
-        TEST.compareTo(null);
+        assertThrows(NullPointerException.class, () -> TEST.compareTo(null));
     }
 
     //-----------------------------------------------------------------------
     // from(TemporalAccessor)
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleAtDay")
     public void test_from(int weekBasedYear, int weekOfWeekBasedYear, DayOfWeek dayOfWeek, int year, int month, int dayOfMonth) {
         YearWeek expected = YearWeek.of(weekBasedYear, weekOfWeekBasedYear);
@@ -591,14 +590,14 @@ public class TestYearWeek {
         assertEquals(expected, YearWeek.from(expected));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_TemporalAccessor_noDerive() {
-        YearWeek.from(LocalTime.NOON);
+        assertThrows(DateTimeException.class, () -> YearWeek.from(LocalTime.NOON));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_TemporalAccessor_null() {
-        YearWeek.from((TemporalAccessor) null);
+        assertThrows(NullPointerException.class, () -> YearWeek.from((TemporalAccessor) null));
     }
 
     //-----------------------------------------------------------------------
@@ -610,14 +609,14 @@ public class TestYearWeek {
         assertEquals(1, TEST.get(WEEK_OF_WEEK_BASED_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_get_invalidField() {
-        TEST.get(YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.get(YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_get_null() {
-        TEST.get((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -629,14 +628,14 @@ public class TestYearWeek {
         assertEquals(1L, TEST.getLong(WEEK_OF_WEEK_BASED_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_invalidField() {
-        TEST.getLong(YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.getLong(YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_getLong_null() {
-        TEST.getLong((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -657,23 +656,23 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2016, 1), TEST.with(IsoFields.WEEK_BASED_YEAR, 2016));
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_outOfBounds")
     public void test_with_outOfBounds(TemporalField field, long newValue) {
-        TEST.with(field, newValue);
+        assertThrows(DateTimeException.class, () -> TEST.with(field, newValue));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalAdjuster_unsupportedType() {
-        TEST.with(ChronoField.MONTH_OF_YEAR, 5);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.with(ChronoField.MONTH_OF_YEAR, 5));
     }
 
     //-----------------------------------------------------------------------
     // with(TemporalAdjuster)
     //-----------------------------------------------------------------------
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_unsupportedType() {
-        TEST.with(TemporalAdjusters.firstDayOfMonth());
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.with(TemporalAdjusters.firstDayOfMonth()));
     }
 
     //-----------------------------------------------------------------------
@@ -692,19 +691,19 @@ public class TestYearWeek {
         assertEquals(TEST, YearWeek.parse("2015-W01"));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequenceDate_invalidYear() {
-        YearWeek.parse("12345-W7");
+        assertThrows(DateTimeParseException.class, () -> YearWeek.parse("12345-W7"));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequenceDate_invalidWeek() {
-        YearWeek.parse("2015-W54");
+        assertThrows(DateTimeParseException.class, () -> YearWeek.parse("2015-W54"));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequenceDate_nullCharSequence() {
-        YearWeek.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> YearWeek.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -716,21 +715,23 @@ public class TestYearWeek {
         assertEquals(TEST, YearWeek.parse("Mon W1 2015", f));
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void test_parse_CharSequenceDateDateTimeFormatter_invalidWeek() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("E 'W'w YYYY").withLocale(Locale.ENGLISH);
-        YearWeek.parse("Mon W99 2015", f);
+        assertThrows(DateTimeParseException.class, () ->
+                YearWeek.parse("Mon W99 2015", f));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullCharSequence() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("E 'W'w YYYY").withLocale(Locale.ENGLISH);
-        YearWeek.parse((CharSequence) null, f);
+        assertThrows(NullPointerException.class, () ->
+                YearWeek.parse((CharSequence) null, f));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullDateTimeFormatter() {
-        YearWeek.parse("", (DateTimeFormatter) null);
+        assertThrows(NullPointerException.class, () -> YearWeek.parse("", (DateTimeFormatter) null));
     }
 
     //-----------------------------------------------------------------------
@@ -756,11 +757,11 @@ public class TestYearWeek {
         assertEquals(LocalDate.of(2016, 1, 9), yw.adjustInto(date));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjustInto_badChronology() {
         YearWeek yw = YearWeek.of(2016, 1);
         ThaiBuddhistDate date = ThaiBuddhistDate.from(LocalDate.of(2015, 6, 20));
-        yw.adjustInto(date);
+        assertThrows(DateTimeException.class, () -> yw.adjustInto(date));
     }
 
     //-----------------------------------------------------------------------
@@ -785,9 +786,9 @@ public class TestYearWeek {
         assertEquals(-1, TEST.until(YearWeek.of(2013, 2), IsoFields.WEEK_BASED_YEARS));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_unsupportedType() {
-        TEST.until(YearWeek.of(2016, 1), ChronoUnit.MONTHS);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.until(YearWeek.of(2016, 1), ChronoUnit.MONTHS));
     }
 
     //-----------------------------------------------------------------------
@@ -802,14 +803,14 @@ public class TestYearWeek {
         assertEquals(ValueRange.of(1, 53), TEST.range(WEEK_OF_WEEK_BASED_YEAR));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_invalidField() {
-        TEST.range(YEAR);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> TEST.range(YEAR));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_range_null() {
-        TEST.range((TemporalField) null);
+        assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
     //-----------------------------------------------------------------------
@@ -831,14 +832,14 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2014, 52), YearWeek.of(2015, 53).withYear(2014));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withYear_int_max() {
-        TEST.withYear(Integer.MAX_VALUE);
+        assertThrows(DateTimeException.class, () -> TEST.withYear(Integer.MAX_VALUE));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withYear_int_min() {
-        TEST.withYear(Integer.MIN_VALUE);
+        assertThrows(DateTimeException.class, () -> TEST.withYear(Integer.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -850,9 +851,9 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2016, 1), TEST.plus(1, IsoFields.WEEK_BASED_YEARS));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_unsupportedType() {
-        YearWeek.of(2014, 1).plus(1, ChronoUnit.DAYS);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> YearWeek.of(2014, 1).plus(1, ChronoUnit.DAYS));
     }
 
     //-----------------------------------------------------------------------
@@ -877,14 +878,14 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2014, 2), YearWeek.of(2014, 2).withWeek(2));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withWeek_int_max() {
-        TEST.withWeek(Integer.MAX_VALUE);
+        assertThrows(DateTimeException.class, () -> TEST.withWeek(Integer.MAX_VALUE));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_withWeek_int_min() {
-        TEST.withWeek(Integer.MIN_VALUE);
+        assertThrows(DateTimeException.class, () -> TEST.withWeek(Integer.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -907,14 +908,14 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2020, 53), YearWeek.of(2015, 53).plusYears(5));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plusYears_max_long() {
-        TEST.plusYears(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.plusYears(Long.MAX_VALUE));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plusYears_min_long() {
-        TEST.plusYears(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.plusYears(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -942,14 +943,14 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2009, 53), TEST.plusWeeks(-261));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plusWeeks_max_long() {
-        TEST.plusWeeks(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.plusWeeks(Long.MAX_VALUE));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plusWeeks_min_long() {
-        TEST.plusWeeks(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.plusWeeks(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -960,9 +961,9 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2014, 1), YearWeek.of(2014, 2).minus(1, ChronoUnit.WEEKS));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_overflow() {
-        TEST.minus(Long.MIN_VALUE, ChronoUnit.WEEKS);
+        assertThrows(ArithmeticException.class, () -> TEST.minus(Long.MIN_VALUE, ChronoUnit.WEEKS));
     }
 
     //-----------------------------------------------------------------------
@@ -993,14 +994,14 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2014, 52), YearWeek.of(2015, 53).minusYears(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minusYears_max_long() {
-        TEST.minusYears(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.minusYears(Long.MAX_VALUE));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minusYears_min_long() {
-        TEST.minusYears(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.minusYears(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -1028,14 +1029,14 @@ public class TestYearWeek {
         assertEquals(YearWeek.of(2021, 1), TEST.minusWeeks(-314));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minWeeks_max_long() {
-        TEST.plusWeeks(Long.MAX_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.plusWeeks(Long.MAX_VALUE));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minWeeks_min_long() {
-        TEST.plusWeeks(Long.MIN_VALUE);
+        assertThrows(ArithmeticException.class, () -> TEST.plusWeeks(Long.MIN_VALUE));
     }
 
     //-----------------------------------------------------------------------
@@ -1055,7 +1056,7 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     // equals() / hashCode()
     //-----------------------------------------------------------------------
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleYearWeeks")
     public void test_equalsAndHashCodeContract(int year, int week) {
         YearWeek a = YearWeek.of(year, week);
@@ -1098,7 +1099,7 @@ public class TestYearWeek {
             {-10000, 1, "-10000-W01"},};
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_sampleToString")
     public void test_toString(int year, int week, String expected) {
         YearWeek yearWeek = YearWeek.of(year, week);

--- a/src/test/java/org/threeten/extra/TestYears.java
+++ b/src/test/java/org/threeten/extra/TestYears.java
@@ -478,8 +478,7 @@ public class TestYears {
     @Test
     public void test_compareTo_null() {
         Years test5 = Years.of(5);
-        assertThrows(NullPointerException.class, () ->
-                test5.compareTo(null));
+        assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestYears.java
+++ b/src/test/java/org/threeten/extra/TestYears.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -51,17 +52,15 @@ import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAmount;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test class.
  */
-@RunWith(DataProviderRunner.class)
 public class TestYears {
 
     //-----------------------------------------------------------------------
@@ -149,19 +148,19 @@ public class TestYears {
         assertEquals(Years.of(19), Years.from(new MockDecadesMonths(2, -12)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_remainder() {
-        Years.from(Period.ofMonths(3));
+        assertThrows(DateTimeException.class, () -> Years.from(Period.ofMonths(3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_from_wrongUnit_noConversion() {
-        Years.from(Period.ofDays(2));
+        assertThrows(DateTimeException.class, () -> Years.from(Period.ofDays(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_from_null() {
-        Years.from((TemporalAmount) null);
+        assertThrows(NullPointerException.class, () -> Years.from((TemporalAmount) null));
     }
 
     //-----------------------------------------------------------------------
@@ -193,15 +192,15 @@ public class TestYears {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
-        Years.parse(str);
+        assertThrows(DateTimeParseException.class, () -> Years.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_parse_CharSequence_null() {
-        Years.parse((CharSequence) null);
+        assertThrows(NullPointerException.class, () -> Years.parse((CharSequence) null));
     }
 
     //-----------------------------------------------------------------------
@@ -210,14 +209,14 @@ public class TestYears {
         assertEquals(Years.of(2), Years.between(LocalDate.of(2019, 1, 1), LocalDate.of(2021, 1, 1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_date_null() {
-        Years.between(LocalDate.now(), (Temporal) null);
+        assertThrows(NullPointerException.class, () -> Years.between(LocalDate.now(), (Temporal) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_between_null_date() {
-        Years.between((Temporal) null, LocalDate.now());
+        assertThrows(NullPointerException.class, () -> Years.between((Temporal) null, LocalDate.now()));
     }
 
     //-----------------------------------------------------------------------
@@ -226,9 +225,9 @@ public class TestYears {
         assertEquals(6, Years.of(6).get(ChronoUnit.YEARS));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_get_invalidType() {
-        Years.of(6).get(IsoFields.QUARTER_YEARS);
+        assertThrows(DateTimeException.class, () -> Years.of(6).get(IsoFields.QUARTER_YEARS));
     }
 
     //-----------------------------------------------------------------------
@@ -252,29 +251,29 @@ public class TestYears {
         assertEquals(Years.of(Integer.MIN_VALUE), Years.of(Integer.MIN_VALUE + 1).plus(Period.ofYears(-1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_PeriodMonths() {
-        Years.of(1).plus(Period.ofMonths(2));
+        assertThrows(DateTimeException.class, () -> Years.of(1).plus(Period.ofMonths(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_TemporalAmount_Duration() {
-        Years.of(1).plus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Years.of(1).plus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooBig() {
-        Years.of(Integer.MAX_VALUE - 1).plus(Years.of(2));
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MAX_VALUE - 1).plus(Years.of(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_TemporalAmount_overflowTooSmall() {
-        Years.of(Integer.MIN_VALUE + 1).plus(Years.of(-2));
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE + 1).plus(Years.of(-2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_plus_TemporalAmount_null() {
-        Years.of(Integer.MIN_VALUE + 1).plus(null);
+        assertThrows(NullPointerException.class, () -> Years.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -288,14 +287,14 @@ public class TestYears {
         assertEquals(Years.of(Integer.MIN_VALUE), Years.of(Integer.MIN_VALUE + 1).plus(-1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooBig() {
-        Years.of(Integer.MAX_VALUE - 1).plus(2);
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MAX_VALUE - 1).plus(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_int_overflowTooSmall() {
-        Years.of(Integer.MIN_VALUE + 1).plus(-2);
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE + 1).plus(-2));
     }
 
     //-----------------------------------------------------------------------
@@ -319,29 +318,29 @@ public class TestYears {
         assertEquals(Years.of(Integer.MIN_VALUE), Years.of(Integer.MIN_VALUE + 1).minus(Period.ofYears(1)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_PeriodMonths() {
-        Years.of(1).minus(Period.ofMonths(2));
+        assertThrows(DateTimeException.class, () -> Years.of(1).minus(Period.ofMonths(2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_TemporalAmount_Duration() {
-        Years.of(1).minus(Duration.ofHours(2));
+        assertThrows(DateTimeException.class, () -> Years.of(1).minus(Duration.ofHours(2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooBig() {
-        Years.of(Integer.MAX_VALUE - 1).minus(Years.of(-2));
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MAX_VALUE - 1).minus(Years.of(-2)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_TemporalAmount_overflowTooSmall() {
-        Years.of(Integer.MIN_VALUE + 1).minus(Years.of(2));
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE + 1).minus(Years.of(2)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_minus_TemporalAmount_null() {
-        Years.of(Integer.MIN_VALUE + 1).minus(null);
+        assertThrows(NullPointerException.class, () -> Years.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
     //-----------------------------------------------------------------------
@@ -355,14 +354,14 @@ public class TestYears {
         assertEquals(Years.of(Integer.MIN_VALUE), Years.of(Integer.MIN_VALUE + 1).minus(1));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooBig() {
-        Years.of(Integer.MAX_VALUE - 1).minus(-2);
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MAX_VALUE - 1).minus(-2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_int_overflowTooSmall() {
-        Years.of(Integer.MIN_VALUE + 1).minus(2);
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE + 1).minus(2));
     }
 
     //-----------------------------------------------------------------------
@@ -382,14 +381,14 @@ public class TestYears {
         assertEquals(Years.of(-15), test5.multipliedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooBig() {
-        Years.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MAX_VALUE / 2 + 1).multipliedBy(2));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_multipliedBy_overflowTooSmall() {
-        Years.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2);
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE / 2 - 1).multipliedBy(2));
     }
 
     //-----------------------------------------------------------------------
@@ -411,9 +410,9 @@ public class TestYears {
         assertEquals(Years.of(-4), test12.dividedBy(-3));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_dividedBy_divideByZero() {
-        Years.of(1).dividedBy(0);
+        assertThrows(ArithmeticException.class, () -> Years.of(1).dividedBy(0));
     }
 
     //-----------------------------------------------------------------------
@@ -425,9 +424,9 @@ public class TestYears {
         assertEquals(Years.of(-Integer.MAX_VALUE), Years.of(Integer.MAX_VALUE).negated());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_negated_overflow() {
-        Years.of(Integer.MIN_VALUE).negated();
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE).negated());
     }
 
     //-----------------------------------------------------------------------
@@ -440,9 +439,9 @@ public class TestYears {
         assertEquals(Years.of(Integer.MAX_VALUE), Years.of(-Integer.MAX_VALUE).abs());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_abs_overflow() {
-        Years.of(Integer.MIN_VALUE).abs();
+        assertThrows(ArithmeticException.class, () -> Years.of(Integer.MIN_VALUE).abs());
     }
 
     //-----------------------------------------------------------------------
@@ -476,10 +475,11 @@ public class TestYears {
         assertEquals(1, test6.compareTo(test5));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_null() {
         Years test5 = Years.of(5);
-        test5.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                test5.compareTo(null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
@@ -53,9 +53,10 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
@@ -74,18 +75,15 @@ import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.function.IntPredicate;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestAccountingChronology {
 
     private static AccountingChronology INSTANCE = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST).
@@ -96,12 +94,12 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     @Test
     public void test_chronology_of_name() {
-        Assert.assertEquals("Accounting", INSTANCE.getId());
+        assertEquals("Accounting", INSTANCE.getId());
     }
 
     @Test
     public void test_chronology_of_name_id() {
-        Assert.assertEquals(null, INSTANCE.getCalendarType());
+        assertEquals(null, INSTANCE.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -143,55 +141,55 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_AccountingDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso, LocalDate.from(accounting));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_AccountingDate_from_LocalDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(accounting, AccountingDate.from(INSTANCE, iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_AccountingDate_chronology_dateEpochDay(AccountingDate accounting, LocalDate iso) {
         assertEquals(accounting, INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_AccountingDate_toEpochDay(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso.toEpochDay(), accounting.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_AccountingDate_until_CoptiDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(INSTANCE.period(0, 0, 0), accounting.until(accounting));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_AccountingDate_until_LocalDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(INSTANCE.period(0, 0, 0), accounting.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_CoptiDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(accounting));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(AccountingDate accounting, LocalDate iso) {
         assertEquals(accounting, INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso, LocalDate.from(accounting.plus(0, DAYS)));
@@ -201,7 +199,7 @@ public class TestAccountingChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(accounting.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso, LocalDate.from(accounting.minus(0, DAYS)));
@@ -211,7 +209,7 @@ public class TestAccountingChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(accounting.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(AccountingDate accounting, LocalDate iso) {
         assertEquals(0, accounting.until(iso.plusDays(0), DAYS));
@@ -263,45 +261,45 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        INSTANCE.date(year, month, dom);
+        assertThrows(DateTimeException.class, () -> INSTANCE.date(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        INSTANCE.dateYearDay(2001, 366);
+        assertThrows(DateTimeException.class, () -> INSTANCE.dateYearDay(2001, 366));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_date_create_no_chronology() {
-        AccountingDate.create(null, 2012, 1, 1);
+        assertThrows(NullPointerException.class, () -> AccountingDate.create(null, 2012, 1, 1));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_date_from_no_chronology() {
-        AccountingDate.from(null, LocalDate.of(2012, 1, 1));
+        assertThrows(NullPointerException.class, () -> AccountingDate.from(null, LocalDate.of(2012, 1, 1)));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_date_now_no_chronology() {
-        AccountingDate.now(null);
+        assertThrows(NullPointerException.class, () -> AccountingDate.now(null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_date_of_no_chronology() {
-        AccountingDate.of(null, 2012, 1, 1);
+        assertThrows(NullPointerException.class, () -> AccountingDate.of(null, 2012, 1, 1));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_date_ofEpochDay_no_chronology() {
-        AccountingDate.ofEpochDay(null, 0);
+        assertThrows(NullPointerException.class, () -> AccountingDate.ofEpochDay(null, 0));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_date_ofYearDay_no_chronology() {
-        AccountingDate.ofYearDay(null, 0, 1);
+        assertThrows(NullPointerException.class, () -> AccountingDate.ofYearDay(null, 0, 1));
     }
 
     //-----------------------------------------------------------------------
@@ -364,7 +362,7 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, INSTANCE.date(year, month, 1).lengthOfMonth());
@@ -413,9 +411,9 @@ public class TestAccountingChronology {
         assertEquals(-3, INSTANCE.prolepticYear(AccountingEra.BCE, 4));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void test_prolepticYear_badEra() {
-        INSTANCE.prolepticYear(IsoEra.CE, 4);
+        assertThrows(ClassCastException.class, () -> INSTANCE.prolepticYear(IsoEra.CE, 4));
     }
 
     @Test
@@ -424,9 +422,9 @@ public class TestAccountingChronology {
         assertEquals(AccountingEra.BCE, INSTANCE.eraOf(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> INSTANCE.eraOf(2));
     }
 
     @Test
@@ -479,15 +477,15 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), INSTANCE.date(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        INSTANCE.date(2012, 6, 28).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> INSTANCE.date(2012, 6, 28).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -514,15 +512,15 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, INSTANCE.date(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        INSTANCE.date(2012, 6, 28).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> INSTANCE.date(2012, 6, 28).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -566,7 +564,7 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -574,9 +572,9 @@ public class TestAccountingChronology {
         assertEquals(INSTANCE.date(expectedYear, expectedMonth, expectedDom), INSTANCE.date(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        INSTANCE.date(2012, 6, 28).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> INSTANCE.date(2012, 6, 28).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -606,10 +604,10 @@ public class TestAccountingChronology {
         assertEquals(INSTANCE.date(2012, 12, 5), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         AccountingDate accounting = INSTANCE.date(2000, 1, 4);
-        accounting.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> accounting.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -660,7 +658,7 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -668,7 +666,7 @@ public class TestAccountingChronology {
         assertEquals(INSTANCE.date(expectedYear, expectedMonth, expectedDom), INSTANCE.date(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -677,9 +675,9 @@ public class TestAccountingChronology {
         assertEquals(INSTANCE.date(expectedYear, expectedMonth, expectedDom), INSTANCE.date(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        INSTANCE.date(2012, 6, 28).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> INSTANCE.date(2012, 6, 28).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -714,7 +712,7 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -725,11 +723,11 @@ public class TestAccountingChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         AccountingDate start = INSTANCE.date(2012, 6, 28);
         AccountingDate end = INSTANCE.date(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -738,9 +736,9 @@ public class TestAccountingChronology {
         assertEquals(INSTANCE.date(2014, 8, 1), INSTANCE.date(2014, 5, 26).plus(INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(INSTANCE.date(2014, 7, 26), INSTANCE.date(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> INSTANCE.date(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -748,9 +746,9 @@ public class TestAccountingChronology {
         assertEquals(INSTANCE.date(2014, 3, 23), INSTANCE.date(2014, 5, 26).minus(INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(INSTANCE.date(2014, 3, 26), INSTANCE.date(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> INSTANCE.date(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -794,7 +792,7 @@ public class TestAccountingChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(AccountingDate accounting, String expected) {
         assertEquals(expected, accounting.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
@@ -32,7 +32,8 @@
 package org.threeten.extra.chrono;
 
 import static java.time.temporal.ChronoUnit.DAYS;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
@@ -44,17 +45,14 @@ import java.time.temporal.ValueRange;
 import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestAccountingChronologyBuilder {
 
     //-----------------------------------------------------------------------
@@ -85,7 +83,7 @@ public class TestAccountingChronologyBuilder {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_isLeapYear_inLastWeekOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
@@ -106,7 +104,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_isLeapYear_nearestEndOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
@@ -127,7 +125,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_previousLeapYears_inLastWeekOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
@@ -157,7 +155,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_previousLeapYears_nearestEndOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
@@ -187,7 +185,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_date_int_int_int_inLastWeekOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
@@ -203,7 +201,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_date_int_int_int_nearestEndOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
@@ -269,7 +267,7 @@ public class TestAccountingChronologyBuilder {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_range")
     public void test_range(AccountingYearDivision division, int leapWeekInMonth,
             ValueRange expectedWeekOfMonthRange, ValueRange expectedDayOfMonthRange, ValueRange expectedMonthRange, ValueRange expectedProlepticMonthRange) {
@@ -284,7 +282,7 @@ public class TestAccountingChronologyBuilder {
         assertEquals(expectedProlepticMonthRange, chronology.range(ChronoField.PROLEPTIC_MONTH));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_date_dayOfMonth_range(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
@@ -299,7 +297,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_date_dayOfYear_inLastWeekOf_range(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
@@ -320,7 +318,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_yearEnding")
     public void test_date_dayOfYear_nearestEndOf_range(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
@@ -373,7 +371,7 @@ public class TestAccountingChronologyBuilder {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_getWeeksInMonth(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
@@ -386,7 +384,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_getWeeksAtStartOf(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
@@ -399,7 +397,7 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_getMonthFromElapsedWeeks(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
@@ -417,33 +415,36 @@ public class TestAccountingChronologyBuilder {
         }
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_negativeWeeks_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         assertEquals(1, division.getMonthFromElapsedWeeks(0));
-        division.getMonthFromElapsedWeeks(-1);
+        assertThrows(DateTimeException.class, () ->
+                division.getMonthFromElapsedWeeks(-1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_extraWeeks_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         int elapsedWeeks = 0;
         for (int month = 1; month <= weeksInMonth.length; month++) {
             elapsedWeeks += weeksInMonth[month - 1];
         }
-        assertEquals(weeksInMonth.length, division.getMonthFromElapsedWeeks(elapsedWeeks));
-        division.getMonthFromElapsedWeeks(elapsedWeeks + 1);
+        int finalElapsedWeeks = elapsedWeeks;
+        assertThrows(DateTimeException.class, () -> division.getMonthFromElapsedWeeks(finalElapsedWeeks));
+        assertThrows(DateTimeException.class, () -> division.getMonthFromElapsedWeeks(finalElapsedWeeks + 1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_weeksInMonth")
     public void test_extraWeeksLeap_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         int elapsedWeeks = 1;
         for (int month = 1; month <= weeksInMonth.length; month++) {
             elapsedWeeks += weeksInMonth[month - 1];
         }
-        assertEquals(weeksInMonth.length, division.getMonthFromElapsedWeeks(elapsedWeeks, leapWeekInMonth));
-        division.getMonthFromElapsedWeeks(elapsedWeeks + 1, leapWeekInMonth);
+        int finalElapsedWeeks = elapsedWeeks;
+        assertThrows(DateTimeException.class, () -> division.getMonthFromElapsedWeeks(finalElapsedWeeks, leapWeekInMonth));
+        assertThrows(DateTimeException.class, () -> division.getMonthFromElapsedWeeks(finalElapsedWeeks + 1, leapWeekInMonth));
     }
 
     //-----------------------------------------------------------------------
@@ -465,20 +466,22 @@ public class TestAccountingChronologyBuilder {
         };
     }
 
-    @Test(expected = IllegalStateException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badChronology")
     public void test_badChronology_nearestEndOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
+        assertThrows(IllegalStateException.class, () ->
         new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
-                .toChronology();
+                        .toChronology());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badChronology")
     public void test_badChronology_inLastWeekOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
+        assertThrows(IllegalStateException.class, () ->
         new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
-                .toChronology();
+                        .toChronology());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
@@ -419,8 +419,7 @@ public class TestAccountingChronologyBuilder {
     @UseDataProvider("data_weeksInMonth")
     public void test_negativeWeeks_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         assertEquals(1, division.getMonthFromElapsedWeeks(0));
-        assertThrows(DateTimeException.class, () ->
-                division.getMonthFromElapsedWeeks(-1));
+        assertThrows(DateTimeException.class, () -> division.getMonthFromElapsedWeeks(-1));
     }
 
     @ParameterizedTest

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
@@ -468,19 +468,17 @@ public class TestAccountingChronologyBuilder {
     @ParameterizedTest
     @UseDataProvider("data_badChronology")
     public void test_badChronology_nearestEndOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
-        assertThrows(IllegalStateException.class, () ->
-        new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
+        assertThrows(IllegalStateException.class, () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
-                        .toChronology());
+                .toChronology());
     }
 
     @ParameterizedTest
     @UseDataProvider("data_badChronology")
     public void test_badChronology_inLastWeekOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
-        assertThrows(IllegalStateException.class, () ->
-        new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
+        assertThrows(IllegalStateException.class, () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
-                        .toChronology());
+                .toChronology());
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
@@ -1035,8 +1035,7 @@ public class TestBritishCutoverChronology {
     public void test_until_TemporalUnit_unsupported() {
         BritishCutoverDate start = BritishCutoverDate.of(2012, 6, 30);
         BritishCutoverDate end = BritishCutoverDate.of(2012, 7, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
@@ -53,9 +53,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -83,18 +85,15 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestBritishCutoverChronology {
 
     //-----------------------------------------------------------------------
@@ -103,10 +102,10 @@ public class TestBritishCutoverChronology {
     @Test
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("BritishCutover");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(BritishCutoverChronology.INSTANCE, chrono);
-        Assert.assertEquals("BritishCutover", chrono.getId());
-        Assert.assertEquals(null, chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(BritishCutoverChronology.INSTANCE, chrono);
+        assertEquals("BritishCutover", chrono.getId());
+        assertEquals(null, chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -157,55 +156,55 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso, LocalDate.from(cutover));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_from_LocalDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(cutover, BritishCutoverDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_chronology_dateEpochDay(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(cutover, BritishCutoverChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_toEpochDay(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso.toEpochDay(), cutover.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_until_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(BritishCutoverChronology.INSTANCE.period(0, 0, 0), cutover.until(cutover));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_BritishCutoverDate_until_LocalDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(BritishCutoverChronology.INSTANCE.period(0, 0, 0), cutover.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(cutover));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(cutover, BritishCutoverChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso, LocalDate.from(cutover.plus(0, DAYS)));
@@ -215,7 +214,7 @@ public class TestBritishCutoverChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(cutover.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso, LocalDate.from(cutover.minus(0, DAYS)));
@@ -225,7 +224,7 @@ public class TestBritishCutoverChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(cutover.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(0, cutover.until(iso.plusDays(0), DAYS));
@@ -277,15 +276,15 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        BritishCutoverDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> BritishCutoverDate.of(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_dateYearDay_badDate() {
-        BritishCutoverChronology.INSTANCE.dateYearDay(2001, 366);
+        assertThrows(DateTimeException.class, () -> BritishCutoverChronology.INSTANCE.dateYearDay(2001, 366));
     }
 
     //-----------------------------------------------------------------------
@@ -399,7 +398,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, BritishCutoverDate.of(year, month, 1).lengthOfMonth());
@@ -440,13 +439,13 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfYear")
     public void test_lengthOfYear_atStart(int year, int length) {
         assertEquals(length, BritishCutoverDate.of(year, 1, 1).lengthOfYear());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfYear")
     public void test_lengthOfYear_atEnd(int year, int length) {
         assertEquals(length, BritishCutoverDate.of(year, 12, 31).lengthOfYear());
@@ -507,9 +506,9 @@ public class TestBritishCutoverChronology {
         assertEquals(-3, BritishCutoverChronology.INSTANCE.prolepticYear(JulianEra.BC, 4));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void test_prolepticYear_badEra() {
-        BritishCutoverChronology.INSTANCE.prolepticYear(IsoEra.CE, 4);
+        assertThrows(ClassCastException.class, () -> BritishCutoverChronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
     }
 
     @Test
@@ -518,9 +517,9 @@ public class TestBritishCutoverChronology {
         assertEquals(JulianEra.BC, BritishCutoverChronology.INSTANCE.eraOf(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        BritishCutoverChronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> BritishCutoverChronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -633,15 +632,15 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), BritishCutoverDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        BritishCutoverDate.of(2012, 6, 30).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> BritishCutoverDate.of(2012, 6, 30).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -695,15 +694,15 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, BritishCutoverDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        BritishCutoverDate.of(2012, 6, 30).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> BritishCutoverDate.of(2012, 6, 30).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -807,7 +806,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -815,9 +814,9 @@ public class TestBritishCutoverChronology {
         assertEquals(BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom), BritishCutoverDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        BritishCutoverDate.of(2012, 6, 30).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> BritishCutoverDate.of(2012, 6, 30).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -835,7 +834,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lastDayOfMonth")
     public void test_adjust_lastDayOfMonth(BritishCutoverDate input, BritishCutoverDate expected) {
         BritishCutoverDate test = input.with(TemporalAdjusters.lastDayOfMonth());
@@ -856,17 +855,17 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_withLocalDate")
     public void test_adjust_LocalDate(BritishCutoverDate input, LocalDate local, BritishCutoverDate expected) {
         BritishCutoverDate test = input.with(local);
         assertEquals(expected, test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         BritishCutoverDate cutover = BritishCutoverDate.of(2000, 1, 4);
-        cutover.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> cutover.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -941,7 +940,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -949,7 +948,7 @@ public class TestBritishCutoverChronology {
         assertEquals(BritishCutoverDate.of(expectedYear, expectedMonth, expectedDom), BritishCutoverDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -960,9 +959,9 @@ public class TestBritishCutoverChronology {
         }
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        BritishCutoverDate.of(2012, 6, 30).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> BritishCutoverDate.of(2012, 6, 30).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -1021,7 +1020,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -1032,11 +1031,12 @@ public class TestBritishCutoverChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         BritishCutoverDate start = BritishCutoverDate.of(2012, 6, 30);
         BritishCutoverDate end = BritishCutoverDate.of(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -1053,10 +1053,9 @@ public class TestBritishCutoverChronology {
             BritishCutoverDate.of(2014, 5, 26).plus(BritishCutoverChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(
-            BritishCutoverDate.of(2014, 7, 26),
+        assertThrows(DateTimeException.class, () ->
             BritishCutoverDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
@@ -1070,10 +1069,9 @@ public class TestBritishCutoverChronology {
             BritishCutoverDate.of(2014, 5, 26).minus(BritishCutoverChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(
-            BritishCutoverDate.of(2014, 3, 26),
+        assertThrows(DateTimeException.class, () ->
             BritishCutoverDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
@@ -1224,7 +1222,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_untilCLD")
     public void test_until_CLD(
             int year1, int month1, int dom1,
@@ -1238,7 +1236,7 @@ public class TestBritishCutoverChronology {
             c);
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_untilCLD")
     public void test_until_CLD_plus(
             int year1, int month1, int dom1,
@@ -1264,9 +1262,9 @@ public class TestBritishCutoverChronology {
         assertEquals(test, test2);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_atTime_null() {
-        BritishCutoverDate.of(2014, 5, 26).atTime(null);
+        assertThrows(NullPointerException.class, () -> BritishCutoverDate.of(2014, 5, 26).atTime(null));
     }
 
     //-----------------------------------------------------------------------
@@ -1325,7 +1323,7 @@ public class TestBritishCutoverChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(BritishCutoverDate cutover, String expected) {
         assertEquals(expected, cutover.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
@@ -1055,8 +1055,7 @@ public class TestBritishCutoverChronology {
 
     @Test
     public void test_plus_Period_ISO() {
-        assertThrows(DateTimeException.class, () ->
-            BritishCutoverDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> BritishCutoverDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -1071,8 +1070,7 @@ public class TestBritishCutoverChronology {
 
     @Test
     public void test_minus_Period_ISO() {
-        assertThrows(DateTimeException.class, () ->
-            BritishCutoverDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> BritishCutoverDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
@@ -53,9 +53,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -72,18 +74,15 @@ import java.time.temporal.ValueRange;
 import java.time.temporal.WeekFields;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestCopticChronology {
 
     //-----------------------------------------------------------------------
@@ -92,19 +91,19 @@ public class TestCopticChronology {
     @Test
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Coptic");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(CopticChronology.INSTANCE, chrono);
-        Assert.assertEquals("Coptic", chrono.getId());
-        Assert.assertEquals("coptic", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(CopticChronology.INSTANCE, chrono);
+        assertEquals("Coptic", chrono.getId());
+        assertEquals("coptic", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("coptic");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(CopticChronology.INSTANCE, chrono);
-        Assert.assertEquals("Coptic", chrono.getId());
-        Assert.assertEquals("coptic", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(CopticChronology.INSTANCE, chrono);
+        assertEquals("Coptic", chrono.getId());
+        assertEquals("coptic", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -138,55 +137,55 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_CopticDate(CopticDate coptic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(coptic));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_CopticDate_from_LocalDate(CopticDate coptic, LocalDate iso) {
         assertEquals(coptic, CopticDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_CopticDate_chronology_dateEpochDay(CopticDate coptic, LocalDate iso) {
         assertEquals(coptic, CopticChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_CopticDate_toEpochDay(CopticDate coptic, LocalDate iso) {
         assertEquals(iso.toEpochDay(), coptic.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_CopticDate_until_CopticDate(CopticDate coptic, LocalDate iso) {
         assertEquals(CopticChronology.INSTANCE.period(0, 0, 0), coptic.until(coptic));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_CopticDate_until_LocalDate(CopticDate coptic, LocalDate iso) {
         assertEquals(CopticChronology.INSTANCE.period(0, 0, 0), coptic.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_CopticDate(CopticDate coptic, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(coptic));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(CopticDate coptic, LocalDate iso) {
         assertEquals(coptic, CopticChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(CopticDate coptic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(coptic.plus(0, DAYS)));
@@ -196,7 +195,7 @@ public class TestCopticChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(coptic.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(CopticDate coptic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(coptic.minus(0, DAYS)));
@@ -206,7 +205,7 @@ public class TestCopticChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(coptic.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(CopticDate coptic, LocalDate iso) {
         assertEquals(0, coptic.until(iso.plusDays(0), DAYS));
@@ -247,15 +246,15 @@ public class TestCopticChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        CopticDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> CopticDate.of(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        CopticChronology.INSTANCE.dateYearDay(1728, 366);
+        assertThrows(DateTimeException.class, () -> CopticChronology.INSTANCE.dateYearDay(1728, 366));
     }
 
     //-----------------------------------------------------------------------
@@ -309,7 +308,7 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, CopticDate.of(year, month, 1).lengthOfMonth());
@@ -364,9 +363,9 @@ public class TestCopticChronology {
         assertEquals(CopticEra.BEFORE_AM, CopticChronology.INSTANCE.eraOf(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        CopticChronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> CopticChronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -420,15 +419,15 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), CopticDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        CopticDate.of(1727, 6, 30).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> CopticDate.of(1727, 6, 30).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -455,15 +454,15 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, CopticDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        CopticDate.of(1727, 6, 30).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> CopticDate.of(1727, 6, 30).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -505,7 +504,7 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -513,9 +512,9 @@ public class TestCopticChronology {
         assertEquals(CopticDate.of(expectedYear, expectedMonth, expectedDom), CopticDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        CopticDate.of(1727, 6, 30).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> CopticDate.of(1727, 6, 30).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -545,10 +544,10 @@ public class TestCopticChronology {
         assertEquals(CopticDate.of(1728, 10, 29), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         CopticDate coptic = CopticDate.of(1726, 1, 4);
-        coptic.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> coptic.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -599,7 +598,7 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -607,7 +606,7 @@ public class TestCopticChronology {
         assertEquals(CopticDate.of(expectedYear, expectedMonth, expectedDom), CopticDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -616,9 +615,9 @@ public class TestCopticChronology {
         assertEquals(CopticDate.of(expectedYear, expectedMonth, expectedDom), CopticDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        CopticDate.of(1727, 6, 30).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> CopticDate.of(1727, 6, 30).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -627,9 +626,9 @@ public class TestCopticChronology {
         assertEquals(CopticDate.of(1727, 7, 29), CopticDate.of(1727, 5, 26).plus(CopticChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(CopticDate.of(1727, 7, 26), CopticDate.of(1727, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> CopticDate.of(1727, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -637,9 +636,9 @@ public class TestCopticChronology {
         assertEquals(CopticDate.of(1727, 3, 23), CopticDate.of(1727, 5, 26).minus(CopticChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(CopticDate.of(1727, 3, 26), CopticDate.of(1727, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> CopticDate.of(1727, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -672,7 +671,7 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -683,11 +682,11 @@ public class TestCopticChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         CopticDate start = CopticDate.of(1726, 6, 30);
         CopticDate end = CopticDate.of(1726, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -727,7 +726,7 @@ public class TestCopticChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(CopticDate coptic, String expected) {
         assertEquals(expected, coptic.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
@@ -54,9 +54,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -75,18 +77,15 @@ import java.time.temporal.ValueRange;
 import java.util.List;
 import java.util.function.IntPredicate;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestDiscordianChronology {
 
     //-----------------------------------------------------------------------
@@ -95,19 +94,19 @@ public class TestDiscordianChronology {
     @Test
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Discordian");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(DiscordianChronology.INSTANCE, chrono);
-        Assert.assertEquals("Discordian", chrono.getId());
-        Assert.assertEquals("discordian", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(DiscordianChronology.INSTANCE, chrono);
+        assertEquals("Discordian", chrono.getId());
+        assertEquals("discordian", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("discordian");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(DiscordianChronology.INSTANCE, chrono);
-        Assert.assertEquals("Discordian", chrono.getId());
-        Assert.assertEquals("discordian", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(DiscordianChronology.INSTANCE, chrono);
+        assertEquals("Discordian", chrono.getId());
+        assertEquals("discordian", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -154,55 +153,55 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(discordian));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_from_LocalDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(discordian, DiscordianDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_chronology_dateEpochDay(DiscordianDate discordian, LocalDate iso) {
         assertEquals(discordian, DiscordianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_toEpochDay(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso.toEpochDay(), discordian.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_until_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(DiscordianChronology.INSTANCE.period(0, 0, 0), discordian.until(discordian));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_DiscordianDate_until_LocalDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(DiscordianChronology.INSTANCE.period(0, 0, 0), discordian.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(discordian));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(DiscordianDate discordian, LocalDate iso) {
         assertEquals(discordian, DiscordianChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(discordian.plus(0, DAYS)));
@@ -212,7 +211,7 @@ public class TestDiscordianChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(discordian.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(discordian.minus(0, DAYS)));
@@ -222,7 +221,7 @@ public class TestDiscordianChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(discordian.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(DiscordianDate discordian, LocalDate iso) {
         assertEquals(0, discordian.until(iso.plusDays(0), DAYS));
@@ -257,15 +256,15 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        DiscordianDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> DiscordianDate.of(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        DiscordianChronology.INSTANCE.dateYearDay(2001, 366);
+        assertThrows(DateTimeException.class, () -> DiscordianChronology.INSTANCE.dateYearDay(2001, 366));
     }
 
     //-----------------------------------------------------------------------
@@ -321,7 +320,7 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, DiscordianDate.of(year, month, 1).lengthOfMonth());
@@ -369,9 +368,9 @@ public class TestDiscordianChronology {
         assertEquals(1, DiscordianChronology.INSTANCE.prolepticYear(DiscordianEra.YOLD, 1));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void test_prolepticYear_badEra() {
-        DiscordianChronology.INSTANCE.prolepticYear(IsoEra.CE, 4);
+        assertThrows(ClassCastException.class, () -> DiscordianChronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
     }
 
     @Test
@@ -379,10 +378,10 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianEra.YOLD, DiscordianChronology.INSTANCE.eraOf(1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        DiscordianChronology.INSTANCE.eraOf(2);
-        DiscordianChronology.INSTANCE.eraOf(0);
+        assertThrows(DateTimeException.class, () -> DiscordianChronology.INSTANCE.eraOf(2));
+        assertThrows(DateTimeException.class, () -> DiscordianChronology.INSTANCE.eraOf(0));
     }
 
     @Test
@@ -457,15 +456,15 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), DiscordianDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        DiscordianDate.of(2012, 5, 30).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> DiscordianDate.of(2012, 5, 30).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -511,15 +510,15 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, DiscordianDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        DiscordianDate.of(2012, 1, 30).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> DiscordianDate.of(2012, 1, 30).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -600,7 +599,7 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -633,15 +632,15 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
-        DiscordianDate.of(year, month, dom).with(field, value);
+        assertThrows(DateTimeException.class, () -> DiscordianDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        DiscordianDate.of(2012, 5, 30).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> DiscordianDate.of(2012, 5, 30).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -671,10 +670,10 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(3178, 3, 41), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         DiscordianDate discordian = DiscordianDate.of(2000, 1, 4);
-        discordian.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> discordian.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -766,7 +765,7 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -774,7 +773,7 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leap")
     public void test_plus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -782,7 +781,7 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -791,7 +790,7 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_minus_leap")
     public void test_minus_leap_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -800,9 +799,9 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        DiscordianDate.of(2012, 5, 30).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> DiscordianDate.of(2012, 5, 30).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -920,7 +919,7 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -931,7 +930,7 @@ public class TestDiscordianChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
@@ -943,11 +942,12 @@ public class TestDiscordianChronology {
         assertEquals(period, start.until(end));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         DiscordianDate start = DiscordianDate.of(2012, 1, 30);
         DiscordianDate end = DiscordianDate.of(2012, 2, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -956,9 +956,9 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(2015, 2, 29), DiscordianDate.of(2014, 5, 26).plus(DiscordianChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(DiscordianDate.of(2015, 2, 26), DiscordianDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> DiscordianDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -966,9 +966,9 @@ public class TestDiscordianChronology {
         assertEquals(DiscordianDate.of(2014, 3, 23), DiscordianDate.of(2014, 5, 26).minus(DiscordianChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(DiscordianDate.of(2014, 3, 26), DiscordianDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> DiscordianDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -1006,7 +1006,7 @@ public class TestDiscordianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(DiscordianDate discordian, String expected) {
         assertEquals(expected, discordian.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
@@ -946,8 +946,7 @@ public class TestDiscordianChronology {
     public void test_until_TemporalUnit_unsupported() {
         DiscordianDate start = DiscordianDate.of(2012, 1, 30);
         DiscordianDate end = DiscordianDate.of(2012, 2, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
@@ -711,8 +711,7 @@ public class TestEthiopicChronology {
     public void test_until_TemporalUnit_unsupported() {
         EthiopicDate start = EthiopicDate.of(2006, 6, 30);
         EthiopicDate end = EthiopicDate.of(2006, 7, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
@@ -53,9 +53,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -72,18 +74,15 @@ import java.time.temporal.ValueRange;
 import java.time.temporal.WeekFields;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestEthiopicChronology {
 
     //-----------------------------------------------------------------------
@@ -92,19 +91,19 @@ public class TestEthiopicChronology {
     @Test
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Ethiopic");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(EthiopicChronology.INSTANCE, chrono);
-        Assert.assertEquals("Ethiopic", chrono.getId());
-        Assert.assertEquals("ethiopic", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(EthiopicChronology.INSTANCE, chrono);
+        assertEquals("Ethiopic", chrono.getId());
+        assertEquals("ethiopic", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("ethiopic");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(EthiopicChronology.INSTANCE, chrono);
-        Assert.assertEquals("Ethiopic", chrono.getId());
-        Assert.assertEquals("ethiopic", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(EthiopicChronology.INSTANCE, chrono);
+        assertEquals("Ethiopic", chrono.getId());
+        assertEquals("ethiopic", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -139,55 +138,55 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(ethiopic));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_from_LocalDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(ethiopic, EthiopicDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_chronology_dateEpochDay(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(ethiopic, EthiopicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_toEpochDay(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso.toEpochDay(), ethiopic.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_until_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(EthiopicChronology.INSTANCE.period(0, 0, 0), ethiopic.until(ethiopic));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_EthiopicDate_until_LocalDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(EthiopicChronology.INSTANCE.period(0, 0, 0), ethiopic.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(ethiopic));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(ethiopic, EthiopicChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(ethiopic.plus(0, DAYS)));
@@ -197,7 +196,7 @@ public class TestEthiopicChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(ethiopic.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(ethiopic.minus(0, DAYS)));
@@ -207,7 +206,7 @@ public class TestEthiopicChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(ethiopic.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(0, ethiopic.until(iso.plusDays(0), DAYS));
@@ -248,15 +247,15 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        EthiopicDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> EthiopicDate.of(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        EthiopicChronology.INSTANCE.dateYearDay(2008, 366);
+        assertThrows(DateTimeException.class, () -> EthiopicChronology.INSTANCE.dateYearDay(2008, 366));
     }
 
     //-----------------------------------------------------------------------
@@ -310,7 +309,7 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, EthiopicDate.of(year, month, 1).lengthOfMonth());
@@ -365,9 +364,9 @@ public class TestEthiopicChronology {
         assertEquals(EthiopicEra.BEFORE_INCARNATION, EthiopicChronology.INSTANCE.eraOf(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        EthiopicChronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> EthiopicChronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -421,15 +420,15 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), EthiopicDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        EthiopicDate.of(2007, 6, 30).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> EthiopicDate.of(2007, 6, 30).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -456,15 +455,15 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, EthiopicDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        EthiopicDate.of(2007, 6, 30).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> EthiopicDate.of(2007, 6, 30).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -509,7 +508,7 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -532,15 +531,15 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
-        EthiopicDate.of(year, month, dom).with(field, value);
+        assertThrows(DateTimeException.class, () -> EthiopicDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        EthiopicDate.of(2006, 6, 30).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> EthiopicDate.of(2006, 6, 30).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -570,10 +569,10 @@ public class TestEthiopicChronology {
         assertEquals(EthiopicDate.of(2004, 2, 5), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         EthiopicDate ethiopic = EthiopicDate.of(2004, 1, 4);
-        ethiopic.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> ethiopic.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -624,7 +623,7 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -632,7 +631,7 @@ public class TestEthiopicChronology {
         assertEquals(EthiopicDate.of(expectedYear, expectedMonth, expectedDom), EthiopicDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -641,9 +640,9 @@ public class TestEthiopicChronology {
         assertEquals(EthiopicDate.of(expectedYear, expectedMonth, expectedDom), EthiopicDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        EthiopicDate.of(2006, 6, 30).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> EthiopicDate.of(2006, 6, 30).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -652,9 +651,9 @@ public class TestEthiopicChronology {
         assertEquals(EthiopicDate.of(2006, 7, 29), EthiopicDate.of(2006, 5, 26).plus(EthiopicChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(EthiopicDate.of(2006, 7, 26), EthiopicDate.of(2006, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> EthiopicDate.of(2006, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -662,9 +661,9 @@ public class TestEthiopicChronology {
         assertEquals(EthiopicDate.of(2006, 3, 23), EthiopicDate.of(2006, 5, 26).minus(EthiopicChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(EthiopicDate.of(2006, 3, 26), EthiopicDate.of(2006, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> EthiopicDate.of(2006, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -697,7 +696,7 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -708,11 +707,12 @@ public class TestEthiopicChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         EthiopicDate start = EthiopicDate.of(2006, 6, 30);
         EthiopicDate end = EthiopicDate.of(2006, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -752,7 +752,7 @@ public class TestEthiopicChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(EthiopicDate ethiopic, String expected) {
         assertEquals(expected, ethiopic.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -54,10 +54,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -76,18 +77,16 @@ import java.time.temporal.ValueRange;
 import java.util.List;
 import java.util.function.IntPredicate;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
 @SuppressWarnings({"static-method", "javadoc"})
-@RunWith(DataProviderRunner.class)
 public class TestInternationalFixedChronology {
 
     //-----------------------------------------------------------------------
@@ -152,55 +151,55 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso, LocalDate.from(fixed));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_from_LocalDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(fixed, InternationalFixedDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_chronology_dateEpochDay(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(fixed, InternationalFixedChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_toEpochDay(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso.toEpochDay(), fixed.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_until_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(InternationalFixedChronology.INSTANCE.period(0, 0, 0), fixed.until(fixed));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_InternationalFixedDate_until_LocalDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(InternationalFixedChronology.INSTANCE.period(0, 0, 0), fixed.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(fixed));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(fixed, InternationalFixedChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso, LocalDate.from(fixed.plus(0, DAYS)));
@@ -212,7 +211,7 @@ public class TestInternationalFixedChronology {
         }
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso, LocalDate.from(fixed.minus(0, DAYS)));
@@ -225,7 +224,7 @@ public class TestInternationalFixedChronology {
     }
 
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(0, fixed.until(iso.plusDays(0), DAYS));
@@ -277,10 +276,10 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        InternationalFixedDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(year, month, dom));
     }
 
     @DataProvider
@@ -294,15 +293,15 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badLeapDates")
     public void badLeapDayDates(int year) {
-        InternationalFixedDate.of(year, 6, 29);
+        assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(year, 6, 29));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        InternationalFixedChronology.INSTANCE.dateYearDay(2001, 366);
+        assertThrows(DateTimeException.class, () -> InternationalFixedChronology.INSTANCE.dateYearDay(2001, 366));
     }
 
     //-----------------------------------------------------------------------
@@ -355,13 +354,13 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
         assertEquals(length, InternationalFixedDate.of(year, month, day).lengthOfMonth());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
         assertEquals(length, InternationalFixedDate.of(year, month, 1).lengthOfMonth());
@@ -422,15 +421,15 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_prolepticYear_bad")
     public void test_prolepticYearBad(int year) {
-        InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, year);
+        assertThrows(DateTimeException.class, () -> InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, year));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void test_prolepticYear_badEra() {
-        InternationalFixedChronology.INSTANCE.prolepticYear(IsoEra.CE, 4);
+        assertThrows(ClassCastException.class, () -> InternationalFixedChronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
     }
 
     @Test
@@ -438,9 +437,9 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedEra.CE, InternationalFixedChronology.INSTANCE.eraOf(1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        InternationalFixedChronology.INSTANCE.eraOf(0);
+        assertThrows(DateTimeException.class, () -> InternationalFixedChronology.INSTANCE.eraOf(0));
     }
 
     @Test
@@ -533,15 +532,15 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
         assertEquals(range, InternationalFixedDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        InternationalFixedDate.of(2012, 6, 28).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> InternationalFixedDate.of(2012, 6, 28).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -615,15 +614,15 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, InternationalFixedDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        InternationalFixedDate.of(2012, 6, 28).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> InternationalFixedDate.of(2012, 6, 28).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -763,7 +762,7 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -830,15 +829,15 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
-        InternationalFixedDate.of(year, month, dom).with(field, value);
+        assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        InternationalFixedDate.of(2012, 6, 28).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> InternationalFixedDate.of(2012, 6, 28).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -855,7 +854,7 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_temporalAdjusters_lastDayOfMonth")
     public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
         InternationalFixedDate base = InternationalFixedDate.of(year, month, day);
@@ -874,10 +873,10 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(2012, 7, 19), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         InternationalFixedDate fixed = InternationalFixedDate.of(2000, 1, 4);
-        fixed.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> fixed.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -1022,7 +1021,7 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -1030,7 +1029,7 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leap_and_year_day")
     public void test_plus_leap_and_year_day_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -1038,7 +1037,7 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -1047,7 +1046,7 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_minus_leap_and_year_day")
     public void test_minus_leap_and_year_day_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -1056,9 +1055,9 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        InternationalFixedDate.of(2012, 6, 28).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> InternationalFixedDate.of(2012, 6, 28).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -1272,7 +1271,7 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -1283,7 +1282,7 @@ public class TestInternationalFixedChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
@@ -1295,11 +1294,11 @@ public class TestInternationalFixedChronology {
         assertEquals(period, start.until(end));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         InternationalFixedDate start = InternationalFixedDate.of(2012, 6, 28);
         InternationalFixedDate end = InternationalFixedDate.of(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -1310,9 +1309,9 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(2014, 8, 1), InternationalFixedDate.of(2014, 5, 26).plus(InternationalFixedChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(InternationalFixedDate.of(2014, 7, 26), InternationalFixedDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -1320,9 +1319,9 @@ public class TestInternationalFixedChronology {
         assertEquals(InternationalFixedDate.of(2014, 3, 23), InternationalFixedDate.of(2014, 5, 26).minus(InternationalFixedChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(InternationalFixedDate.of(2014, 3, 26), InternationalFixedDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -1340,7 +1339,7 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_equals")
     public void test_equals(InternationalFixedDate a1, InternationalFixedDate b, InternationalFixedDate c,
                                     InternationalFixedDate d) {
@@ -1368,7 +1367,7 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(InternationalFixedDate date, String expected) {
         assertEquals(expected, date.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
@@ -53,9 +53,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -73,18 +75,15 @@ import java.time.temporal.ValueRange;
 import java.time.temporal.WeekFields;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
-@RunWith(DataProviderRunner.class)
 public class TestJulianChronology {
 
     //-----------------------------------------------------------------------
@@ -93,19 +92,19 @@ public class TestJulianChronology {
     @Test
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Julian");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(JulianChronology.INSTANCE, chrono);
-        Assert.assertEquals("Julian", chrono.getId());
-        Assert.assertEquals("julian", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(JulianChronology.INSTANCE, chrono);
+        assertEquals("Julian", chrono.getId());
+        assertEquals("julian", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("julian");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(JulianChronology.INSTANCE, chrono);
-        Assert.assertEquals("Julian", chrono.getId());
-        Assert.assertEquals("julian", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(JulianChronology.INSTANCE, chrono);
+        assertEquals("Julian", chrono.getId());
+        assertEquals("julian", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -147,55 +146,55 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_JulianDate(JulianDate julian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(julian));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_JulianDate_from_LocalDate(JulianDate julian, LocalDate iso) {
         assertEquals(julian, JulianDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_JulianDate_chronology_dateEpochDay(JulianDate julian, LocalDate iso) {
         assertEquals(julian, JulianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_JulianDate_toEpochDay(JulianDate julian, LocalDate iso) {
         assertEquals(iso.toEpochDay(), julian.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_JulianDate_until_JulianDate(JulianDate julian, LocalDate iso) {
         assertEquals(JulianChronology.INSTANCE.period(0, 0, 0), julian.until(julian));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_JulianDate_until_LocalDate(JulianDate julian, LocalDate iso) {
         assertEquals(JulianChronology.INSTANCE.period(0, 0, 0), julian.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_JulianDate(JulianDate julian, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(julian));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(JulianDate julian, LocalDate iso) {
         assertEquals(julian, JulianChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(JulianDate julian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(julian.plus(0, DAYS)));
@@ -205,7 +204,7 @@ public class TestJulianChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(julian.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(JulianDate julian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(julian.minus(0, DAYS)));
@@ -215,7 +214,7 @@ public class TestJulianChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(julian.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(JulianDate julian, LocalDate iso) {
         assertEquals(0, julian.until(iso.plusDays(0), DAYS));
@@ -267,15 +266,15 @@ public class TestJulianChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        JulianDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> JulianDate.of(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        JulianChronology.INSTANCE.dateYearDay(2001, 366);
+        assertThrows(DateTimeException.class, () -> JulianChronology.INSTANCE.dateYearDay(2001, 366));
     }
 
     //-----------------------------------------------------------------------
@@ -334,7 +333,7 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, JulianDate.of(year, month, 1).lengthOfMonth());
@@ -383,9 +382,9 @@ public class TestJulianChronology {
         assertEquals(-3, JulianChronology.INSTANCE.prolepticYear(JulianEra.BC, 4));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void test_prolepticYear_badEra() {
-        JulianChronology.INSTANCE.prolepticYear(IsoEra.CE, 4);
+        assertThrows(ClassCastException.class, () -> JulianChronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
     }
 
     @Test
@@ -394,9 +393,9 @@ public class TestJulianChronology {
         assertEquals(JulianEra.BC, JulianChronology.INSTANCE.eraOf(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        JulianChronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> JulianChronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -447,15 +446,15 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), JulianDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        JulianDate.of(2012, 6, 30).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> JulianDate.of(2012, 6, 30).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -482,15 +481,15 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, JulianDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        JulianDate.of(2012, 6, 30).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> JulianDate.of(2012, 6, 30).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -533,7 +532,7 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -541,9 +540,9 @@ public class TestJulianChronology {
         assertEquals(JulianDate.of(expectedYear, expectedMonth, expectedDom), JulianDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        JulianDate.of(2012, 6, 30).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> JulianDate.of(2012, 6, 30).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -573,10 +572,10 @@ public class TestJulianChronology {
         assertEquals(JulianDate.of(2012, 6, 23), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         JulianDate julian = JulianDate.of(2000, 1, 4);
-        julian.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> julian.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -627,7 +626,7 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -635,7 +634,7 @@ public class TestJulianChronology {
         assertEquals(JulianDate.of(expectedYear, expectedMonth, expectedDom), JulianDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -644,9 +643,9 @@ public class TestJulianChronology {
         assertEquals(JulianDate.of(expectedYear, expectedMonth, expectedDom), JulianDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        JulianDate.of(2012, 6, 30).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> JulianDate.of(2012, 6, 30).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -681,7 +680,7 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -692,11 +691,12 @@ public class TestJulianChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         JulianDate start = JulianDate.of(2012, 6, 30);
         JulianDate end = JulianDate.of(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -705,9 +705,9 @@ public class TestJulianChronology {
         assertEquals(JulianDate.of(2014, 7, 29), JulianDate.of(2014, 5, 26).plus(JulianChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(JulianDate.of(2014, 7, 26), JulianDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> JulianDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -715,9 +715,9 @@ public class TestJulianChronology {
         assertEquals(JulianDate.of(2014, 3, 23), JulianDate.of(2014, 5, 26).minus(JulianChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(JulianDate.of(2014, 3, 26), JulianDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> JulianDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -754,7 +754,7 @@ public class TestJulianChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(JulianDate julian, String expected) {
         assertEquals(expected, julian.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
@@ -695,8 +695,7 @@ public class TestJulianChronology {
     public void test_until_TemporalUnit_unsupported() {
         JulianDate start = JulianDate.of(2012, 6, 30);
         JulianDate end = JulianDate.of(2012, 7, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
@@ -859,8 +859,7 @@ public class TestPaxChronology {
 
     @Test
     public void test_plus_Period_ISO() {
-        assertThrows(DateTimeException.class, () ->
-                PaxDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> PaxDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -870,8 +869,7 @@ public class TestPaxChronology {
 
     @Test
     public void test_minus_Period_ISO() {
-        assertThrows(DateTimeException.class, () ->
-                PaxDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> PaxDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
@@ -847,8 +847,7 @@ public class TestPaxChronology {
     public void test_until_TemporalUnit_unsupported() {
         PaxDate start = PaxDate.of(2012, 6, 28);
         PaxDate end = PaxDate.of(2012, 7, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
@@ -53,9 +53,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -75,19 +77,16 @@ import java.time.temporal.WeekFields;
 import java.util.List;
 import java.util.function.IntPredicate;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
 @SuppressWarnings({"static-method", "javadoc"})
-@RunWith(DataProviderRunner.class)
 public class TestPaxChronology {
 
     //-----------------------------------------------------------------------
@@ -96,19 +95,19 @@ public class TestPaxChronology {
     @Test
     public void test_chronology_of_name() {
         Chronology chrono = Chronology.of("Pax");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(PaxChronology.INSTANCE, chrono);
-        Assert.assertEquals("Pax", chrono.getId());
-        Assert.assertEquals("pax", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(PaxChronology.INSTANCE, chrono);
+        assertEquals("Pax", chrono.getId());
+        assertEquals("pax", chrono.getCalendarType());
     }
 
     @Test
     public void test_chronology_of_name_id() {
         Chronology chrono = Chronology.of("pax");
-        Assert.assertNotNull(chrono);
-        Assert.assertEquals(PaxChronology.INSTANCE, chrono);
-        Assert.assertEquals("Pax", chrono.getId());
-        Assert.assertEquals("pax", chrono.getCalendarType());
+        assertNotNull(chrono);
+        assertEquals(PaxChronology.INSTANCE, chrono);
+        assertEquals("Pax", chrono.getId());
+        assertEquals("pax", chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -179,55 +178,55 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_PaxDate(PaxDate pax, LocalDate iso) {
         assertEquals(iso, LocalDate.from(pax));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_PaxDate_from_LocalDate(PaxDate pax, LocalDate iso) {
         assertEquals(pax, PaxDate.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_PaxDate_chronology_dateEpochDay(PaxDate pax, LocalDate iso) {
         assertEquals(pax, PaxChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_PaxDate_toEpochDay(PaxDate pax, LocalDate iso) {
         assertEquals(iso.toEpochDay(), pax.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_PaxDate_until_PaxDate(PaxDate pax, LocalDate iso) {
         assertEquals(PaxChronology.INSTANCE.period(0, 0, 0), pax.until(pax));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_PaxDate_until_LocalDate(PaxDate pax, LocalDate iso) {
         assertEquals(PaxChronology.INSTANCE.period(0, 0, 0), pax.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_PaxDate(PaxDate pax, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(pax));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(PaxDate pax, LocalDate iso) {
         assertEquals(pax, PaxChronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(PaxDate pax, LocalDate iso) {
         assertEquals(iso, LocalDate.from(pax.plus(0, DAYS)));
@@ -237,7 +236,7 @@ public class TestPaxChronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(pax.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(PaxDate pax, LocalDate iso) {
         assertEquals(iso, LocalDate.from(pax.minus(0, DAYS)));
@@ -247,7 +246,7 @@ public class TestPaxChronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(pax.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(PaxDate pax, LocalDate iso) {
         assertEquals(0, pax.until(iso.plusDays(0), DAYS));
@@ -303,15 +302,15 @@ public class TestPaxChronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        PaxDate.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> PaxDate.of(year, month, dom));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        PaxChronology.INSTANCE.dateYearDay(2001, 365);
+        assertThrows(DateTimeException.class, () -> PaxChronology.INSTANCE.dateYearDay(2001, 365));
     }
 
     //-----------------------------------------------------------------------
@@ -383,7 +382,7 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, PaxDate.of(year, month, 1).lengthOfMonth());
@@ -432,9 +431,9 @@ public class TestPaxChronology {
         assertEquals(-3, PaxChronology.INSTANCE.prolepticYear(PaxEra.BCE, 4));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     public void test_prolepticYear_badEra() {
-        PaxChronology.INSTANCE.prolepticYear(IsoEra.CE, 4);
+        assertThrows(ClassCastException.class, () -> PaxChronology.INSTANCE.prolepticYear(IsoEra.CE, 4));
     }
 
     @Test
@@ -443,9 +442,9 @@ public class TestPaxChronology {
         assertEquals(PaxEra.BCE, PaxChronology.INSTANCE.eraOf(0));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        PaxChronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> PaxChronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -502,15 +501,15 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), PaxDate.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        PaxDate.of(2012, 6, 28).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> PaxDate.of(2012, 6, 28).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -537,15 +536,15 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, PaxDate.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        PaxDate.of(2012, 6, 28).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> PaxDate.of(2012, 6, 28).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -588,7 +587,7 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -596,9 +595,9 @@ public class TestPaxChronology {
         assertEquals(PaxDate.of(expectedYear, expectedMonth, expectedDom), PaxDate.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        PaxDate.of(2012, 6, 28).with(MINUTE_OF_DAY, 0);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> PaxDate.of(2012, 6, 28).with(MINUTE_OF_DAY, 0));
     }
 
     //-----------------------------------------------------------------------
@@ -628,10 +627,10 @@ public class TestPaxChronology {
         assertEquals(PaxDate.of(2012, 7, 27), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         PaxDate pax = PaxDate.of(2000, 1, 4);
-        pax.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> pax.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -710,7 +709,7 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -718,7 +717,7 @@ public class TestPaxChronology {
         assertEquals(PaxDate.of(expectedYear, expectedMonth, expectedDom), PaxDate.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leap")
     public void test_plus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -726,7 +725,7 @@ public class TestPaxChronology {
         test_plus_TemporalUnit(year, month, dom, amount, unit, expectedYear, expectedMonth, expectedDom);
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -735,7 +734,7 @@ public class TestPaxChronology {
         assertEquals(PaxDate.of(expectedYear, expectedMonth, expectedDom), PaxDate.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_minus_leap")
     public void test_minus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -743,9 +742,9 @@ public class TestPaxChronology {
         test_minus_TemporalUnit(year, month, dom, amount, unit, expectedYear, expectedMonth, expectedDom);
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        PaxDate.of(2012, 6, 10).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> PaxDate.of(2012, 6, 10).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -821,7 +820,7 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -832,7 +831,7 @@ public class TestPaxChronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
@@ -844,11 +843,12 @@ public class TestPaxChronology {
         assertEquals(period, start.until(end));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         PaxDate start = PaxDate.of(2012, 6, 28);
         PaxDate end = PaxDate.of(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -857,9 +857,10 @@ public class TestPaxChronology {
         assertEquals(PaxDate.of(2014, 7, 28), PaxDate.of(2014, 5, 26).plus(PaxChronology.INSTANCE.period(0, 2, 2)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(PaxDate.of(2014, 7, 26), PaxDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () ->
+                PaxDate.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -867,9 +868,10 @@ public class TestPaxChronology {
         assertEquals(PaxDate.of(2014, 3, 23), PaxDate.of(2014, 5, 26).minus(PaxChronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(PaxDate.of(2014, 3, 26), PaxDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () ->
+                PaxDate.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -906,7 +908,7 @@ public class TestPaxChronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(PaxDate pax, String expected) {
         assertEquals(expected, pax.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
@@ -55,10 +55,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -80,18 +81,16 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
 @SuppressWarnings({"static-method", "javadoc"})
-@RunWith(DataProviderRunner.class)
 public class TestSymmetry010Chronology {
 
     //-----------------------------------------------------------------------
@@ -146,55 +145,55 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym010));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_from_LocalDate(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(sym010, Symmetry010Date.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_chronology_dateEpochDay(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(sym010, Symmetry010Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_toEpochDay(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso.toEpochDay(), sym010.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_until_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(Symmetry010Chronology.INSTANCE.period(0, 0, 0), sym010.until(sym010));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry010Date_until_LocalDate(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(Symmetry010Chronology.INSTANCE.period(0, 0, 0), sym010.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(sym010, Symmetry010Chronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(sym010));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym010.plus(0, DAYS)));
@@ -204,7 +203,7 @@ public class TestSymmetry010Chronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(sym010.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym010.minus(0, DAYS)));
@@ -214,7 +213,7 @@ public class TestSymmetry010Chronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(sym010.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(0, sym010.until(iso.plusDays(0), DAYS));
@@ -256,10 +255,10 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        Symmetry010Date.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> Symmetry010Date.of(year, month, dom));
     }
 
     @DataProvider
@@ -272,10 +271,10 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badLeapDates")
     public void badLeapDayDates(int year) {
-        Symmetry010Date.of(year, 12, 37);
+        assertThrows(DateTimeException.class, () -> Symmetry010Date.of(year, 12, 37));
     }
 
     //-----------------------------------------------------------------------
@@ -326,13 +325,13 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
         assertEquals(length, Symmetry010Date.of(year, month, day).lengthOfMonth());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
         assertEquals(length, Symmetry010Date.of(year, month, 1).lengthOfMonth());
@@ -422,10 +421,10 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test(expected = ClassCastException.class)
+    @ParameterizedTest
     @UseDataProvider("data_prolepticYear_badEra")
     public void test_prolepticYear_badEra(Era era) {
-        Symmetry010Chronology.INSTANCE.prolepticYear(era, 4);
+        assertThrows(ClassCastException.class, () -> Symmetry010Chronology.INSTANCE.prolepticYear(era, 4));
     }
 
     @Test
@@ -434,9 +433,9 @@ public class TestSymmetry010Chronology {
         assertEquals(IsoEra.CE, Symmetry010Chronology.INSTANCE.eraOf(1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        Symmetry010Chronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> Symmetry010Chronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -516,15 +515,15 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
         assertEquals(range, Symmetry010Date.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        Symmetry010Date.of(2012, 6, 28).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry010Date.of(2012, 6, 28).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -565,15 +564,15 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, Symmetry010Date.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        Symmetry010Date.of(2012, 6, 28).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry010Date.of(2012, 6, 28).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -655,7 +654,7 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -702,15 +701,15 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
-        Symmetry010Date.of(year, month, dom).with(field, value);
+        assertThrows(DateTimeException.class, () -> Symmetry010Date.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        Symmetry010Date.of(2012, 6, 28).with(MINUTE_OF_DAY, 10);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry010Date.of(2012, 6, 28).with(MINUTE_OF_DAY, 10));
     }
 
     //-----------------------------------------------------------------------
@@ -735,7 +734,7 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_temporalAdjusters_lastDayOfMonth")
     public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
         Symmetry010Date base = Symmetry010Date.of(year, month, day);
@@ -754,10 +753,10 @@ public class TestSymmetry010Chronology {
         assertEquals(Symmetry010Date.of(2012, 7, 5), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         Symmetry010Date sym010 = Symmetry010Date.of(2000, 1, 4);
-        sym010.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> sym010.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -837,7 +836,7 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -845,7 +844,7 @@ public class TestSymmetry010Chronology {
         assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leapWeek")
     public void test_plus_leapWeek_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -853,7 +852,7 @@ public class TestSymmetry010Chronology {
         assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -862,7 +861,7 @@ public class TestSymmetry010Chronology {
         assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leapWeek")
     public void test_minus_leapWeek_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -871,9 +870,9 @@ public class TestSymmetry010Chronology {
         assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        Symmetry010Date.of(2012, 6, 28).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry010Date.of(2012, 6, 28).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -922,7 +921,7 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -933,7 +932,7 @@ public class TestSymmetry010Chronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
@@ -945,11 +944,12 @@ public class TestSymmetry010Chronology {
         assertEquals(period, start.until(end));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         Symmetry010Date start = Symmetry010Date.of(2012, 6, 28);
         Symmetry010Date end = Symmetry010Date.of(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -961,10 +961,9 @@ public class TestSymmetry010Chronology {
                 Symmetry010Date.of(2014, 5, 21).plus(Symmetry010Chronology.INSTANCE.period(0, 2, 8)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(Symmetry010Date.of(2014, 7, 26),
-                Symmetry010Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> Symmetry010Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -973,9 +972,9 @@ public class TestSymmetry010Chronology {
                 Symmetry010Date.of(2014, 5, 26).minus(Symmetry010Chronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(Symmetry010Date.of(2014, 3, 26), Symmetry010Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> Symmetry010Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -990,7 +989,7 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_equals")
     public void test_equals(Symmetry010Date a1, Symmetry010Date b, Symmetry010Date c, Symmetry010Date d) {
         assertTrue(a1.equals(a1));
@@ -1015,7 +1014,7 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(Symmetry010Date date, String expected) {
         assertEquals(expected, date.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
@@ -948,8 +948,7 @@ public class TestSymmetry010Chronology {
     public void test_until_TemporalUnit_unsupported() {
         Symmetry010Date start = Symmetry010Date.of(2012, 6, 28);
         Symmetry010Date end = Symmetry010Date.of(2012, 7, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -430,8 +430,7 @@ public class TestSymmetry454Chronology {
     @ParameterizedTest
     @UseDataProvider("data_prolepticYear_badEra")
     public void test_prolepticYear_badEra(Era era) {
-        assertThrows(ClassCastException.class, () ->
-                Symmetry454Chronology.INSTANCE.prolepticYear(era, 4));
+        assertThrows(ClassCastException.class, () -> Symmetry454Chronology.INSTANCE.prolepticYear(era, 4));
     }
 
     @Test
@@ -957,8 +956,7 @@ public class TestSymmetry454Chronology {
     public void test_until_TemporalUnit_unsupported() {
         Symmetry454Date start = Symmetry454Date.of(2012, 6, 28);
         Symmetry454Date end = Symmetry454Date.of(2012, 7, 1);
-        assertThrows(UnsupportedTemporalTypeException.class, () ->
-                start.until(end, MINUTES));
+        assertThrows(UnsupportedTemporalTypeException.class, () -> start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -55,10 +55,11 @@ import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -80,18 +81,16 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test.
  */
 @SuppressWarnings({"static-method", "javadoc"})
-@RunWith(DataProviderRunner.class)
 public class TestSymmetry454Chronology {
 
     //-----------------------------------------------------------------------
@@ -146,55 +145,55 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_from_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym454));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_from_LocalDate(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(sym454, Symmetry454Date.from(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_chronology_dateEpochDay(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(sym454, Symmetry454Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_toEpochDay(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso.toEpochDay(), sym454.toEpochDay());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_until_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(Symmetry454Chronology.INSTANCE.period(0, 0, 0), sym454.until(sym454));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Symmetry454Date_until_LocalDate(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(Symmetry454Chronology.INSTANCE.period(0, 0, 0), sym454.until(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_Chronology_date_Temporal(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(sym454, Symmetry454Chronology.INSTANCE.date(iso));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_LocalDate_until_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(sym454));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_plusDays(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym454.plus(0, DAYS)));
@@ -204,7 +203,7 @@ public class TestSymmetry454Chronology {
         assertEquals(iso.plusDays(-60), LocalDate.from(sym454.plus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_minusDays(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym454.minus(0, DAYS)));
@@ -214,7 +213,7 @@ public class TestSymmetry454Chronology {
         assertEquals(iso.minusDays(-60), LocalDate.from(sym454.minus(-60, DAYS)));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_samples")
     public void test_until_DAYS(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(0, sym454.until(iso.plusDays(0), DAYS));
@@ -256,10 +255,10 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badDates")
     public void test_badDates(int year, int month, int dom) {
-        Symmetry454Date.of(year, month, dom);
+        assertThrows(DateTimeException.class, () -> Symmetry454Date.of(year, month, dom));
     }
 
     @DataProvider
@@ -272,15 +271,15 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badLeapDates")
     public void test_badLeapDayDates(int year) {
-        Symmetry454Date.of(year, 12, 29);
+        assertThrows(DateTimeException.class, () -> Symmetry454Date.of(year, 12, 29));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_chronology_dateYearDay_badDate() {
-        Symmetry454Chronology.INSTANCE.dateYearDay(2000, 365);
+        assertThrows(DateTimeException.class, () -> Symmetry454Chronology.INSTANCE.dateYearDay(2000, 365));
     }
 
     //-----------------------------------------------------------------------
@@ -331,13 +330,13 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
         assertEquals(length, Symmetry454Date.of(year, month, day).lengthOfMonth());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
         assertEquals(length, Symmetry454Date.of(year, month, 1).lengthOfMonth());
@@ -428,10 +427,11 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test(expected = ClassCastException.class)
+    @ParameterizedTest
     @UseDataProvider("data_prolepticYear_badEra")
     public void test_prolepticYear_badEra(Era era) {
-        Symmetry454Chronology.INSTANCE.prolepticYear(era, 4);
+        assertThrows(ClassCastException.class, () ->
+                Symmetry454Chronology.INSTANCE.prolepticYear(era, 4));
     }
 
     @Test
@@ -440,9 +440,9 @@ public class TestSymmetry454Chronology {
         assertEquals(IsoEra.CE, Symmetry454Chronology.INSTANCE.eraOf(1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        Symmetry454Chronology.INSTANCE.eraOf(2);
+        assertThrows(DateTimeException.class, () -> Symmetry454Chronology.INSTANCE.eraOf(2));
     }
 
     @Test
@@ -522,15 +522,15 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
         assertEquals(range, Symmetry454Date.of(year, month, dom).range(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_range_unsupported() {
-        Symmetry454Date.of(2012, 6, 28).range(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry454Date.of(2012, 6, 28).range(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -571,15 +571,15 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, Symmetry454Date.of(year, month, dom).getLong(field));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_getLong_unsupported() {
-        Symmetry454Date.of(2012, 6, 28).getLong(MINUTE_OF_DAY);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry454Date.of(2012, 6, 28).getLong(MINUTE_OF_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -661,7 +661,7 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
@@ -710,15 +710,15 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test(expected = DateTimeException.class)
+    @ParameterizedTest
     @UseDataProvider("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
-        Symmetry454Date.of(year, month, dom).with(field, value);
+        assertThrows(DateTimeException.class, () -> Symmetry454Date.of(year, month, dom).with(field, value));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_with_TemporalField_unsupported() {
-        Symmetry454Date.of(2012, 6, 28).with(MINUTE_OF_DAY, 10);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry454Date.of(2012, 6, 28).with(MINUTE_OF_DAY, 10));
     }
 
     //-----------------------------------------------------------------------
@@ -743,7 +743,7 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_temporalAdjusters_lastDayOfMonth")
     public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
         Symmetry454Date base = Symmetry454Date.of(year, month, day);
@@ -762,10 +762,10 @@ public class TestSymmetry454Chronology {
         assertEquals(Symmetry454Date.of(2012, 7, 5), test);
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_adjust_toMonth() {
         Symmetry454Date sym454 = Symmetry454Date.of(2000, 1, 4);
-        sym454.with(Month.APRIL);
+        assertThrows(DateTimeException.class, () -> sym454.with(Month.APRIL));
     }
 
     //-----------------------------------------------------------------------
@@ -845,7 +845,7 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -853,7 +853,7 @@ public class TestSymmetry454Chronology {
         assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leapWeek")
     public void test_plus_leapWeek_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
@@ -861,7 +861,7 @@ public class TestSymmetry454Chronology {
         assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).plus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -870,7 +870,7 @@ public class TestSymmetry454Chronology {
         assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus_leapWeek")
     public void test_minus_leapWeek_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
@@ -879,9 +879,9 @@ public class TestSymmetry454Chronology {
         assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).minus(amount, unit));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_plus_TemporalUnit_unsupported() {
-        Symmetry454Date.of(2012, 6, 28).plus(0, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () -> Symmetry454Date.of(2012, 6, 28).plus(0, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -930,7 +930,7 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
@@ -941,7 +941,7 @@ public class TestSymmetry454Chronology {
         assertEquals(expected, start.until(end, unit));
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
@@ -953,11 +953,12 @@ public class TestSymmetry454Chronology {
         assertEquals(period, start.until(end));
     }
 
-    @Test(expected = UnsupportedTemporalTypeException.class)
+    @Test
     public void test_until_TemporalUnit_unsupported() {
         Symmetry454Date start = Symmetry454Date.of(2012, 6, 28);
         Symmetry454Date end = Symmetry454Date.of(2012, 7, 1);
-        start.until(end, MINUTES);
+        assertThrows(UnsupportedTemporalTypeException.class, () ->
+                start.until(end, MINUTES));
     }
 
     //-----------------------------------------------------------------------
@@ -969,9 +970,9 @@ public class TestSymmetry454Chronology {
                 Symmetry454Date.of(2014, 5, 21).plus(Symmetry454Chronology.INSTANCE.period(0, 2, 8)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_plus_Period_ISO() {
-        assertEquals(Symmetry454Date.of(2014, 7, 26),
+        assertThrows(DateTimeException.class, () ->
                 Symmetry454Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
@@ -981,9 +982,10 @@ public class TestSymmetry454Chronology {
                 Symmetry454Date.of(2014, 5, 26).minus(Symmetry454Chronology.INSTANCE.period(0, 2, 3)));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_minus_Period_ISO() {
-        assertEquals(Symmetry454Date.of(2014, 3, 26), Symmetry454Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () ->
+                Symmetry454Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------
@@ -998,7 +1000,7 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_equals")
     public void test_equals(Symmetry454Date a1, Symmetry454Date b, Symmetry454Date c, Symmetry454Date d) {
         assertTrue(a1.equals(a1));
@@ -1023,7 +1025,7 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(Symmetry454Date date, String expected) {
         assertEquals(expected, date.toString());

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -972,8 +972,7 @@ public class TestSymmetry454Chronology {
 
     @Test
     public void test_plus_Period_ISO() {
-        assertThrows(DateTimeException.class, () ->
-                Symmetry454Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> Symmetry454Date.of(2014, 5, 26).plus(Period.ofMonths(2)));
     }
 
     @Test
@@ -984,8 +983,7 @@ public class TestSymmetry454Chronology {
 
     @Test
     public void test_minus_Period_ISO() {
-        assertThrows(DateTimeException.class, () ->
-                Symmetry454Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
+        assertThrows(DateTimeException.class, () -> Symmetry454Date.of(2014, 5, 26).minus(Period.ofMonths(2)));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
@@ -34,7 +34,6 @@ package org.threeten.extra.scale;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -229,16 +228,11 @@ public class TestTaiInstant {
     public void test_withNano(long tai, long nanos, int newNano, Long expectedTai, Long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos);
         if (expectedTai != null) {
-            i = i.withNano(newNano);
-            assertEquals(expectedTai.longValue(), i.getTaiSeconds());
-            assertEquals(expectedNanos.longValue(), i.getNano());
+            TaiInstant withNano = i.withNano(newNano);
+            assertEquals(expectedTai.longValue(), withNano.getTaiSeconds());
+            assertEquals(expectedNanos.longValue(), withNano.getNano());
         } else {
-            try {
-                i = i.withNano(newNano);
-                fail();
-            } catch (IllegalArgumentException ex) {
-                // expected
-            }
+            assertThrows(IllegalArgumentException.class, () -> i.withNano(newNano));
         }
     }
 

--- a/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
@@ -435,15 +435,13 @@ public class TestTaiInstant {
     @Test
     public void test_plus_overflowTooBig() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MAX_VALUE, 999999999);
-        assertThrows(ArithmeticException.class, () ->
-                i.plus(Duration.ofSeconds(0, 1)));
+        assertThrows(ArithmeticException.class, () -> i.plus(Duration.ofSeconds(0, 1)));
     }
 
     @Test
     public void test_plus_overflowTooSmall() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MIN_VALUE, 0);
-        assertThrows(ArithmeticException.class, () ->
-                i.plus(Duration.ofSeconds(-1, 999999999)));
+        assertThrows(ArithmeticException.class, () -> i.plus(Duration.ofSeconds(-1, 999999999)));
     }
 
     //-----------------------------------------------------------------------
@@ -645,15 +643,13 @@ public class TestTaiInstant {
     @Test
     public void test_minus_overflowTooSmall() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MIN_VALUE, 0);
-        assertThrows(ArithmeticException.class, () ->
-                i.minus(Duration.ofSeconds(0, 1)));
+        assertThrows(ArithmeticException.class, () -> i.minus(Duration.ofSeconds(0, 1)));
     }
 
     @Test
     public void test_minus_overflowTooBig() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MAX_VALUE, 999999999);
-        assertThrows(ArithmeticException.class, () ->
-                i.minus(Duration.ofSeconds(-1, 999999999)));
+        assertThrows(ArithmeticException.class, () -> i.minus(Duration.ofSeconds(-1, 999999999)));
     }
 
     //-----------------------------------------------------------------------
@@ -758,16 +754,14 @@ public class TestTaiInstant {
     @Test
     public void test_compareTo_ObjectNull() {
         TaiInstant a = TaiInstant.ofTaiSeconds(0L, 0);
-        assertThrows(NullPointerException.class, () ->
-                a.compareTo(null));
+        assertThrows(NullPointerException.class, () -> a.compareTo(null));
     }
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_compareToNonTaiInstant() {
         Comparable c = TaiInstant.ofTaiSeconds(0L, 2);
-        assertThrows(ClassCastException.class, () ->
-                c.compareTo(new Object()));
+        assertThrows(ClassCastException.class, () -> c.compareTo(new Object()));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
@@ -31,9 +31,10 @@
  */
 package org.threeten.extra.scale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -44,17 +45,15 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test TaiInstant.
  */
-@RunWith(DataProviderRunner.class)
 public class TestTaiInstant {
 
     //-----------------------------------------------------------------------
@@ -110,9 +109,9 @@ public class TestTaiInstant {
         assertEquals(999999999, test.getNano());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void factory_ofTaiSeconds_long_long_tooBig() {
-        TaiInstant.ofTaiSeconds(Long.MAX_VALUE, 1000000000);
+        assertThrows(ArithmeticException.class, () -> TaiInstant.ofTaiSeconds(Long.MAX_VALUE, 1000000000));
     }
 
     //-----------------------------------------------------------------------
@@ -125,9 +124,9 @@ public class TestTaiInstant {
         assertEquals(2, test.getNano());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void factory_of_Instant_null() {
-        TaiInstant.of((Instant) null);
+        assertThrows(NullPointerException.class, () -> TaiInstant.of((Instant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -144,9 +143,9 @@ public class TestTaiInstant {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void factory_of_UtcInstant_null() {
-        TaiInstant.of((UtcInstant) null);
+        assertThrows(NullPointerException.class, () -> TaiInstant.of((UtcInstant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -176,15 +175,15 @@ public class TestTaiInstant {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badParse")
     public void factory_parse_CharSequence_invalid(String str) {
-        TaiInstant.parse(str);
+        assertThrows(DateTimeParseException.class, () -> TaiInstant.parse(str));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void factory_parse_CharSequence_null() {
-        TaiInstant.parse((String) null);
+        assertThrows(NullPointerException.class, () -> TaiInstant.parse((String) null));
     }
 
     //-----------------------------------------------------------------------
@@ -202,7 +201,7 @@ public class TestTaiInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_withTAISeconds")
     public void test_withTAISeconds(long tai, long nanos, long newTai, Long expectedTai, Long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos).withTaiSeconds(newTai);
@@ -225,7 +224,7 @@ public class TestTaiInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_withNano")
     public void test_withNano(long tai, long nanos, int newNano, Long expectedTai, Long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos);
@@ -431,7 +430,7 @@ public class TestTaiInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus(long seconds, int nanos, long plusSeconds, int plusNanos, long expectedSeconds, int expectedNanoOfSecond) {
         TaiInstant i = TaiInstant.ofTaiSeconds(seconds, nanos).plus(Duration.ofSeconds(plusSeconds, plusNanos));
@@ -439,16 +438,18 @@ public class TestTaiInstant {
         assertEquals(expectedNanoOfSecond, i.getNano());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_overflowTooBig() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MAX_VALUE, 999999999);
-        i.plus(Duration.ofSeconds(0, 1));
+        assertThrows(ArithmeticException.class, () ->
+                i.plus(Duration.ofSeconds(0, 1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_overflowTooSmall() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MIN_VALUE, 0);
-        i.plus(Duration.ofSeconds(-1, 999999999));
+        assertThrows(ArithmeticException.class, () ->
+                i.plus(Duration.ofSeconds(-1, 999999999)));
     }
 
     //-----------------------------------------------------------------------
@@ -639,7 +640,7 @@ public class TestTaiInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_minus")
     public void test_minus(long seconds, int nanos, long minusSeconds, int minusNanos, long expectedSeconds, int expectedNanoOfSecond) {
         TaiInstant i = TaiInstant.ofTaiSeconds(seconds, nanos).minus(Duration.ofSeconds(minusSeconds, minusNanos));
@@ -647,16 +648,18 @@ public class TestTaiInstant {
         assertEquals(expectedNanoOfSecond, i.getNano());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_overflowTooSmall() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MIN_VALUE, 0);
-        i.minus(Duration.ofSeconds(0, 1));
+        assertThrows(ArithmeticException.class, () ->
+                i.minus(Duration.ofSeconds(0, 1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_overflowTooBig() {
         TaiInstant i = TaiInstant.ofTaiSeconds(Long.MAX_VALUE, 999999999);
-        i.minus(Duration.ofSeconds(-1, 999999999));
+        assertThrows(ArithmeticException.class, () ->
+                i.minus(Duration.ofSeconds(-1, 999999999)));
     }
 
     //-----------------------------------------------------------------------
@@ -758,17 +761,19 @@ public class TestTaiInstant {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_ObjectNull() {
         TaiInstant a = TaiInstant.ofTaiSeconds(0L, 0);
-        a.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                a.compareTo(null));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_compareToNonTaiInstant() {
         Comparable c = TaiInstant.ofTaiSeconds(0L, 2);
-        c.compareTo(new Object());
+        assertThrows(ClassCastException.class, () ->
+                c.compareTo(new Object()));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
@@ -31,10 +31,11 @@
  */
 package org.threeten.extra.scale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -46,17 +47,15 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test UtcInstant.
  */
-@RunWith(DataProviderRunner.class)
 public class TestUtcInstant {
 
     private static final long MJD_1972_12_30 = 41681;
@@ -132,19 +131,19 @@ public class TestUtcInstant {
         assertEquals("1972-12-31T23:59:60.999999999Z", t.toString());
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void factory_ofModifiedJulianDay_long_long_nanosNegative() {
-        UtcInstant.ofModifiedJulianDay(MJD_1973_01_01, -1);
+        assertThrows(DateTimeException.class, () -> UtcInstant.ofModifiedJulianDay(MJD_1973_01_01, -1));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void factory_ofModifiedJulianDay_long_long_nanosTooBig_notLeap() {
-        UtcInstant.ofModifiedJulianDay(MJD_1973_01_01, NANOS_PER_DAY);
+        assertThrows(DateTimeException.class, () -> UtcInstant.ofModifiedJulianDay(MJD_1973_01_01, NANOS_PER_DAY));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void factory_ofModifiedJulianDay_long_long_nanosTooBig_leap() {
-        UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_LEAP_DAY);
+        assertThrows(DateTimeException.class, () -> UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_LEAP_DAY));
     }
 
     //-----------------------------------------------------------------------
@@ -157,9 +156,9 @@ public class TestUtcInstant {
         assertEquals(2, test.getNanoOfDay());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void factory_of_Instant_null() {
-        UtcInstant.of((Instant) null);
+        assertThrows(NullPointerException.class, () -> UtcInstant.of((Instant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -176,9 +175,9 @@ public class TestUtcInstant {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void factory_of_TaiInstant_null() {
-        UtcInstant.of((TaiInstant) null);
+        assertThrows(NullPointerException.class, () -> UtcInstant.of((TaiInstant) null));
     }
 
     //-----------------------------------------------------------------------
@@ -199,20 +198,20 @@ public class TestUtcInstant {
         };
     }
 
-    @Test(expected = DateTimeParseException.class)
+    @ParameterizedTest
     @UseDataProvider("data_badParse")
     public void factory_parse_CharSequence_invalid(String str) {
-        UtcInstant.parse(str);
+        assertThrows(DateTimeException.class, () -> UtcInstant.parse(str));
     }
 
-    @Test(expected = DateTimeException.class)
+    @Test
     public void factory_parse_CharSequence_invalidLeapSecond() {
-        UtcInstant.parse("1972-11-11T23:59:60Z");  // leap second but not leap day
+        assertThrows(DateTimeException.class, () -> UtcInstant.parse("1972-11-11T23:59:60Z")); // leap second but not leap day
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void factory_parse_CharSequence_null() {
-        UtcInstant.parse((String) null);
+        assertThrows(NullPointerException.class, () -> UtcInstant.parse((String) null));
     }
 
     //-----------------------------------------------------------------------
@@ -234,7 +233,7 @@ public class TestUtcInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_withModifiedJulianDay")
     public void test_withModifiedJulianDay(long mjd, long nanos, long newMjd, Long expectedMjd, Long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
@@ -277,7 +276,7 @@ public class TestUtcInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_withNanoOfDay")
     public void test_withNanoOfDay(long mjd, long nanos, long newNanoOfDay, Long expectedMjd, Long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
@@ -333,7 +332,7 @@ public class TestUtcInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_plus")
     public void test_plus(long mjd, long nanos, long plusSeconds, int plusNanos, long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos).plus(Duration.ofSeconds(plusSeconds, plusNanos));
@@ -341,16 +340,18 @@ public class TestUtcInstant {
         assertEquals(expectedNanos, i.getNanoOfDay());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_overflowTooBig() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MAX_VALUE, NANOS_PER_DAY - 1);
-        i.plus(Duration.ofNanos(1));
+        assertThrows(ArithmeticException.class, () ->
+                i.plus(Duration.ofNanos(1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_plus_overflowTooSmall() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MIN_VALUE, 0);
-        i.plus(Duration.ofNanos(-1));
+        assertThrows(ArithmeticException.class, () ->
+                i.plus(Duration.ofNanos(-1)));
     }
 
     //-----------------------------------------------------------------------
@@ -391,7 +392,7 @@ public class TestUtcInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_minus")
     public void test_minus(long mjd, long nanos, long minusSeconds, int minusNanos, long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos).minus(Duration.ofSeconds(minusSeconds, minusNanos));
@@ -399,16 +400,18 @@ public class TestUtcInstant {
         assertEquals(expectedNanos, i.getNanoOfDay());
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_overflowTooSmall() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MIN_VALUE, 0);
-        i.minus(Duration.ofNanos(1));
+        assertThrows(ArithmeticException.class, () ->
+                i.minus(Duration.ofNanos(1)));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_minus_overflowTooBig() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MAX_VALUE, NANOS_PER_DAY - 1);
-        i.minus(Duration.ofNanos(-1));
+        assertThrows(ArithmeticException.class, () ->
+                i.minus(Duration.ofNanos(-1)));
     }
 
     //-----------------------------------------------------------------------
@@ -456,10 +459,11 @@ public class TestUtcInstant {
         }
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void test_toTaiInstant_maxInvalid() {
         UtcInstant utc = UtcInstant.ofModifiedJulianDay(Long.MAX_VALUE, 0);
-        utc.toTaiInstant();
+        assertThrows(ArithmeticException.class, () ->
+                utc.toTaiInstant());
     }
 
     //-----------------------------------------------------------------------
@@ -517,17 +521,19 @@ public class TestUtcInstant {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_compareTo_ObjectNull() {
         UtcInstant a = UtcInstant.ofModifiedJulianDay(0L, 0);
-        a.compareTo(null);
+        assertThrows(NullPointerException.class, () ->
+                a.compareTo(null));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_compareToNonUtcInstant() {
         Comparable c = UtcInstant.ofModifiedJulianDay(0L, 2);
-        c.compareTo(new Object());
+        assertThrows(ClassCastException.class, () ->
+                c.compareTo(new Object()));
     }
 
     //-----------------------------------------------------------------------
@@ -613,13 +619,13 @@ public class TestUtcInstant {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString(long mjd, long nod, String expected) {
         assertEquals(expected, UtcInstant.ofModifiedJulianDay(mjd, nod).toString());
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_toString")
     public void test_toString_parse(long mjd, long nod, String str) {
         assertEquals(UtcInstant.ofModifiedJulianDay(mjd, nod), UtcInstant.parse(str));

--- a/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -238,16 +237,11 @@ public class TestUtcInstant {
     public void test_withModifiedJulianDay(long mjd, long nanos, long newMjd, Long expectedMjd, Long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
-            i = i.withModifiedJulianDay(newMjd);
-            assertEquals(expectedMjd.longValue(), i.getModifiedJulianDay());
-            assertEquals(expectedNanos.longValue(), i.getNanoOfDay());
+            UtcInstant withModifiedJulianDay = i.withModifiedJulianDay(newMjd);
+            assertEquals(expectedMjd.longValue(), withModifiedJulianDay.getModifiedJulianDay());
+            assertEquals(expectedNanos.longValue(), withModifiedJulianDay.getNanoOfDay());
         } else {
-            try {
-                i = i.withModifiedJulianDay(newMjd);
-                fail();
-            } catch (DateTimeException ex) {
-                // expected
-            }
+            assertThrows(DateTimeException.class, () -> i.withModifiedJulianDay(newMjd));
         }
     }
 
@@ -281,16 +275,11 @@ public class TestUtcInstant {
     public void test_withNanoOfDay(long mjd, long nanos, long newNanoOfDay, Long expectedMjd, Long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
-            i = i.withNanoOfDay(newNanoOfDay);
-            assertEquals(expectedMjd.longValue(), i.getModifiedJulianDay());
-            assertEquals(expectedNanos.longValue(), i.getNanoOfDay());
+            UtcInstant withNanoOfDay = i.withNanoOfDay(newNanoOfDay);
+            assertEquals(expectedMjd.longValue(), withNanoOfDay.getModifiedJulianDay());
+            assertEquals(expectedNanos.longValue(), withNanoOfDay.getNanoOfDay());
         } else {
-            try {
-                i = i.withNanoOfDay(newNanoOfDay);
-                fail();
-            } catch (DateTimeException ex) {
-                // expected
-            }
+            assertThrows(DateTimeException.class, () -> i.withNanoOfDay(newNanoOfDay));
         }
     }
 

--- a/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
@@ -332,15 +332,13 @@ public class TestUtcInstant {
     @Test
     public void test_plus_overflowTooBig() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MAX_VALUE, NANOS_PER_DAY - 1);
-        assertThrows(ArithmeticException.class, () ->
-                i.plus(Duration.ofNanos(1)));
+        assertThrows(ArithmeticException.class, () -> i.plus(Duration.ofNanos(1)));
     }
 
     @Test
     public void test_plus_overflowTooSmall() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MIN_VALUE, 0);
-        assertThrows(ArithmeticException.class, () ->
-                i.plus(Duration.ofNanos(-1)));
+        assertThrows(ArithmeticException.class, () -> i.plus(Duration.ofNanos(-1)));
     }
 
     //-----------------------------------------------------------------------
@@ -392,15 +390,13 @@ public class TestUtcInstant {
     @Test
     public void test_minus_overflowTooSmall() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MIN_VALUE, 0);
-        assertThrows(ArithmeticException.class, () ->
-                i.minus(Duration.ofNanos(1)));
+        assertThrows(ArithmeticException.class, () -> i.minus(Duration.ofNanos(1)));
     }
 
     @Test
     public void test_minus_overflowTooBig() {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(Long.MAX_VALUE, NANOS_PER_DAY - 1);
-        assertThrows(ArithmeticException.class, () ->
-                i.minus(Duration.ofNanos(-1)));
+        assertThrows(ArithmeticException.class, () -> i.minus(Duration.ofNanos(-1)));
     }
 
     //-----------------------------------------------------------------------
@@ -451,8 +447,7 @@ public class TestUtcInstant {
     @Test
     public void test_toTaiInstant_maxInvalid() {
         UtcInstant utc = UtcInstant.ofModifiedJulianDay(Long.MAX_VALUE, 0);
-        assertThrows(ArithmeticException.class, () ->
-                utc.toTaiInstant());
+        assertThrows(ArithmeticException.class, () -> utc.toTaiInstant());
     }
 
     //-----------------------------------------------------------------------
@@ -513,16 +508,14 @@ public class TestUtcInstant {
     @Test
     public void test_compareTo_ObjectNull() {
         UtcInstant a = UtcInstant.ofModifiedJulianDay(0L, 0);
-        assertThrows(NullPointerException.class, () ->
-                a.compareTo(null));
+        assertThrows(NullPointerException.class, () -> a.compareTo(null));
     }
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_compareToNonUtcInstant() {
         Comparable c = UtcInstant.ofModifiedJulianDay(0L, 2);
-        assertThrows(ClassCastException.class, () ->
-                c.compareTo(new Object()));
+        assertThrows(ClassCastException.class, () -> c.compareTo(new Object()));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/scale/TestUtcRules.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcRules.java
@@ -31,9 +31,10 @@
  */
 package org.threeten.extra.scale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -49,23 +50,21 @@ import java.time.ZoneOffset;
 import java.time.temporal.JulianFields;
 import java.util.Arrays;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test SystemLeapSecondRules.
  */
-@RunWith(DataProviderRunner.class)
 public class TestUtcRules {
 
     SystemUtcRules rules;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         Constructor<SystemUtcRules> con = SystemUtcRules.class.getDeclaredConstructor();
         con.setAccessible(true);
@@ -237,7 +236,7 @@ public class TestUtcRules {
         };
     }
 
-    @Test
+    @ParameterizedTest
     @UseDataProvider("data_leapSeconds")
     public void test_leapSeconds(long mjd, int adjust, int offset, String checkDate) {
         assertEquals(LocalDate.parse(checkDate).getLong(JulianFields.MODIFIED_JULIAN_DAY), mjd);
@@ -349,14 +348,14 @@ public class TestUtcRules {
         assertEquals(tai, rules.convertToTai(expected)); // check reverse
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_convertToUtc_TaiInstant_null() {
-        rules.convertToUtc((TaiInstant) null);
+        assertThrows(NullPointerException.class, () -> rules.convertToUtc((TaiInstant) null));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void test_convertToTai_UtcInstant_null() {
-        rules.convertToTai((UtcInstant) null);
+        assertThrows(NullPointerException.class, () -> rules.convertToTai((UtcInstant) null));
     }
 
     //-------------------------------------------------------------------------
@@ -518,42 +517,42 @@ public class TestUtcRules {
         assertEquals(adj, rules.getLeapSecondAdjustment(mjd));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_registerLeapSecond_equalLastDate_differentLeap() {
         long[] dates = rules.getLeapSecondDates();
         long mjd = dates[dates.length - 1];
         int adj = rules.getLeapSecondAdjustment(mjd);
-        rules.register(mjd, -adj);
+        assertThrows(IllegalArgumentException.class, () -> rules.register(mjd, -adj));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_registerLeapSecond_equalEarlierDate_differentLeap() {
         long[] dates = rules.getLeapSecondDates();
         long mjd = dates[dates.length - 2];
         int adj = rules.getLeapSecondAdjustment(mjd);
-        rules.register(mjd, -adj);
+        assertThrows(IllegalArgumentException.class, () -> rules.register(mjd, -adj));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_registerLeapSecond_beforeLastDate() {
         long[] dates = rules.getLeapSecondDates();
         long mjd = dates[dates.length - 1] - 1;
-        rules.register(mjd, 1);
+        assertThrows(IllegalArgumentException.class, () -> rules.register(mjd, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_registerLeapSecond_invalidAdjustment_zero() {
-        rules.register(MJD_2100, 0);
+        assertThrows(IllegalArgumentException.class, () -> rules.register(MJD_2100, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_registerLeapSecond_invalidAdjustment_minusTwo() {
-        rules.register(MJD_2100, -2);
+        assertThrows(IllegalArgumentException.class, () -> rules.register(MJD_2100, -2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test_registerLeapSecond_invalidAdjustment_three() {
-        rules.register(MJD_2100, 3);
+        assertThrows(IllegalArgumentException.class, () -> rules.register(MJD_2100, 3));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Upgrades to JUnit 5, per #172.

I figure as I've done several JUnit 5 migrations in my day job that this would be a straightforward way to contribute back to this project.

## JUnit dataprovider

There were [multiple migration paths suggested](https://github.com/TNG/junit-dataprovider/wiki/Migration-guides#migration-to-junit5) for the [JUnit dataprovider](https://github.com/TNG/junit-dataprovider) library.  I went with the one that utilizes the [JUnit 5 Parameterized Tests feature](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests).  I followed the provided [migration guide](https://github.com/TNG/junit-dataprovider/wiki/Migration-from-JUnit4-to-JUnit-Jupiter-Parameterized-Tests).

Aside from the library version change and imports, this involved changing all `@UseDataProvider` tests to be annotated with `@ParameterizedTest` rather than `@Test`, and removing `@RunWith(DataProviderRunner.class)`.

## JUnit 5 changes

Aside from imports, the bulk of the changes changes was JUnit 5's removal of [`expected`](https://junit.org/junit4/javadoc/latest/org/junit/Test.html#expected()) from the `@Test` annotation in favor of [`assertThrows`](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/Assertions.html#assertThrows(java.lang.Class,org.junit.jupiter.api.function.Executable)).

This had the benefit of improving some tests to more precisely declare _where_ the exception is to be thrown.  Additionally, some existing weren't fully executing, since the first call that threw the expected exception stopped the running of the test.  For example, the second `eraOf` call wouldn't have run in the following:

```diff
-    @Test(expected = DateTimeException.class)
+    @Test
     public void test_Chronology_eraOf_invalid() {
-        DiscordianChronology.INSTANCE.eraOf(2);
-        DiscordianChronology.INSTANCE.eraOf(0);
+        assertThrows(DateTimeException.class, () -> DiscordianChronology.INSTANCE.eraOf(2));
+        assertThrows(DateTimeException.class, () -> DiscordianChronology.INSTANCE.eraOf(0));
     }
```

I also took the extra step of changing any location in the code that used `fail()` within a try/catch block to instead use `assertThrows`.

```diff
-                try {
-                    sample.range(field);
-                    fail("Failed on " + sample + " " + field);
-                } catch (DateTimeException ex) {
-                    // expected
-                }
+                assertThrows(DateTimeException.class, () -> sample.range(field), "Failed on " + sample + " " + field);
```

## Maven dependency versions

This is now declaring the JUnit version three times in the pom file:

```xml
    <dependency>
      <groupId>org.junit.jupiter</groupId>
      <artifactId>junit-jupiter-api</artifactId>
      <version>5.7.1</version>
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>org.junit.jupiter</groupId>
      <artifactId>junit-jupiter-params</artifactId>
      <version>5.7.1</version>
      <scope>test</scope>
    </dependency>
    <dependency>
      <groupId>org.junit.jupiter</groupId>
      <artifactId>junit-jupiter-engine</artifactId>
      <version>5.7.1</version>
      <scope>test</scope>
    </dependency>
```

I wasn't sure how you would want the duplication handled, so I left it duplicated for now.  The three options I see are:
1. Keep it duplicated
2. Use a [Maven property](https://maven.apache.org/pom.html#Properties)
3. Use the [JUnit BOM](https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-bom)
   ```xml
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>5.7.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
   ```