### PR TITLE
Add Interval.containedBy(Start|End) for checking the separate parts of the con…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,10 @@
       <url>https://github.com/Clockwork-Muse</url>
     </contributor>
     <contributor>
+      <name>Johannes Jensen</name>
+      <url>https://github.com/spand</url>
+    </contributor>
+    <contributor>
       <name>M. Justin</name>
       <url>https://github.com/mjustin</url>
     </contributor>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
       <url>https://github.com/Clockwork-Muse</url>
     </contributor>
     <contributor>
-      <name>Johannes Jensen</name>
+      <name>Johannes Rohde</name>
       <url>https://github.com/spand</url>
     </contributor>
     <contributor>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -8,6 +8,10 @@
   <body>
     <!-- types are add, fix, remove, update -->
     <release version="1.6.1" date="SNAPSHOT" description="v1.6.1">
+      <action dev="spand" type="add">
+        Additional comparison methods on Interval.
+        Fixes #174.
+      </action>
       <action dev="stevenpaligo" type="add">
         Cache UtcInstant::toString().
         Fixes #177.

--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -327,52 +327,6 @@ public final class Interval
 
     //-----------------------------------------------------------------------
     /**
-     * Checks if this interval contains the specified instant.
-     * <p>
-     * This checks if the specified instant is within the bounds of this interval.
-     * If this range has an unbounded start then {@code contains(Instant#MIN)} returns true.
-     * If this range has an unbounded end then {@code contains(Instant#MAX)} returns true.
-     * If this range is empty then this method always returns false.
-     *
-     * @param instant  the instant, not null
-     * @return true if this interval contains the instant
-     */
-    public boolean contains(Instant instant) {
-        Objects.requireNonNull(instant, "instant");
-        return start.compareTo(instant) <= 0 && (instant.compareTo(end) < 0 || isUnboundedEnd());
-    }
-
-    /**
-     * Checks if this intervals start contains the specified instant. In essence the start part of {@code contains(Instant)}
-     * <p>
-     * This checks if the specified instant is within the bounds of the start of this interval.
-     * If this range has an unbounded start then {@code containsFloor(Instant#MIN)} returns true.
-     * If this range has an unbounded end then {@code containsFloor(Instant#MAX)} returns true.
-     *
-     * @param instant  the instant, not null
-     * @return true if this interval start contains the instant
-     */
-    public boolean containedByStart(Instant instant) {
-        Objects.requireNonNull(instant, "instant");
-        return start.compareTo(instant) <= 0;
-    }
-
-    /**
-     * Checks if this intervals end contains the specified instant. In essence the end part of {@code contains(Instant)}
-     * <p>
-     * This checks if the specified instant is within the bounds of the end of this interval.
-     * If this range has an unbounded start then {@code containsHigher(Instant#MIN)} returns true.
-     * If this range has an unbounded end then {@code containsHigher(Instant#MAX)} returns true.
-     *
-     * @param instant  the instant, not null
-     * @return true if this intervals end contains the instant
-     */
-    public boolean containedByEnd(Instant instant) {
-        Objects.requireNonNull(instant, "instant");
-        return instant.compareTo(end) < 0 || isUnboundedEnd();
-    }
-
-    /**
      * Checks if this interval encloses the specified interval.
      * <p>
      * This checks if the bounds of the specified interval are within the bounds of this interval.
@@ -509,35 +463,6 @@ public final class Interval
 
     //-------------------------------------------------------------------------
     /**
-     * Checks if this interval is after the specified instant.
-     * <p>
-     * The result is true if this interval starts after the specified instant.
-     * An empty interval behaves as though it is an instant for comparison purposes.
-     *
-     * @param instant  the other instant to compare to, not null
-     * @return true if the start of this interval is after the specified instant
-     */
-    public boolean isAfter(Instant instant) {
-        return start.compareTo(instant) > 0;
-    }
-
-    /**
-     * Checks if this interval is before the specified instant.
-     * <p>
-     * The result is true if this interval ends before the specified instant.
-     * Since intervals do not include their end points, this will return true if the
-     * instant equals the end of the interval.
-     * An empty interval behaves as though it is an instant for comparison purposes.
-     *
-     * @param instant  the other instant to compare to, not null
-     * @return true if the end of this interval is before or equal to the specified instant
-     */
-    public boolean isBefore(Instant instant) {
-        return end.compareTo(instant) <= 0 && start.compareTo(instant) < 0;
-    }
-
-    //-------------------------------------------------------------------------
-    /**
      * Checks if this interval is after the specified interval.
      * <p>
      * The result is true if this interval starts after the end of the specified interval.
@@ -565,6 +490,170 @@ public final class Interval
      */
     public boolean isBefore(Interval interval) {
         return end.compareTo(interval.start) <= 0 && !interval.equals(this);
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Checks if this interval starts on or before the specified instant.
+     * <p>
+     * This method compares the start of the interval to the instant.
+     * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval starts before the instant
+     */
+    public boolean startsBefore(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return start.compareTo(instant) < 0;
+    }
+
+    /**
+     * Checks if this interval starts at or before the specified instant.
+     * <p>
+     * This method compares the start of the interval to the instant.
+     * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval starts at or before the instant
+     */
+    public boolean startsAtOrBefore(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return start.compareTo(instant) <= 0;
+    }
+
+    /**
+     * Checks if this interval starts on or after the specified instant.
+     * <p>
+     * This method compares the start of the interval to the instant.
+     * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval starts after the instant
+     */
+    public boolean startsAfter(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return start.compareTo(instant) > 0;
+    }
+
+    /**
+     * Checks if this interval starts at or after the specified instant.
+     * <p>
+     * This method compares the start of the interval to the instant.
+     * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval starts at or after the instant
+     */
+    public boolean startsAtOrAfter(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return start.compareTo(instant) >= 0;
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Checks if this interval ends before the specified instant.
+     * <p>
+     * This method compares the end of the interval to the instant.
+     * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval ends before the instant
+     */
+    public boolean endsBefore(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return end.compareTo(instant) < 0 && !isUnboundedEnd();
+    }
+
+    /**
+     * Checks if this interval ends at or before the specified instant.
+     * <p>
+     * This method compares the end of the interval to the instant.
+     * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval ends at or before the instant
+     */
+    public boolean endsAtOrBefore(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return end.compareTo(instant) <= 0 && !isUnboundedEnd();
+    }
+
+    /**
+     * Checks if this interval ends after the specified instant.
+     * <p>
+     * This method compares the end of the interval to the instant.
+     * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval ends after the instant
+     */
+    public boolean endsAfter(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return end.compareTo(instant) > 0 || isUnboundedEnd();
+    }
+
+    /**
+     * Checks if this interval ends after the specified instant.
+     * <p>
+     * This method compares the end of the interval to the instant.
+     * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval ends at or after the instant
+     */
+    public boolean endsAtOrAfter(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return end.compareTo(instant) >= 0 || isUnboundedEnd();
+    }
+
+    //-------------------------------------------------------------------------
+    /**
+     * Checks if this interval contains the specified instant.
+     * <p>
+     * This checks if the specified instant is within the bounds of this interval.
+     * If this interval has an unbounded start then {@code contains(Instant#MIN)} returns true.
+     * If this interval has an unbounded end then {@code contains(Instant#MAX)} returns true.
+     * If this interval is empty then this method always returns false.
+     * <p>
+     * This is equivalent to {@link #startsAtOrBefore(Instant)} {@code &&} {@link #endsAfter(Instant)}.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval contains the instant
+     */
+    public boolean contains(Instant instant) {
+        return startsAtOrBefore(instant) && endsAfter(instant);
+    }
+
+    /**
+     * Checks if this interval is after the specified instant.
+     * <p>
+     * The result is true if this interval starts after the specified instant.
+     * An empty interval behaves as though it is an instant for comparison purposes.
+     * <p>
+     * This is equivalent to {@link #startsAfter(Instant)}.
+     *
+     * @param instant  the other instant to compare to, not null
+     * @return true if the start of this interval is after the specified instant
+     */
+    public boolean isAfter(Instant instant) {
+        return startsAfter(instant);
+    }
+
+    /**
+     * Checks if this interval is before the specified instant.
+     * <p>
+     * The result is true if this interval ends before the specified instant.
+     * Since intervals do not include their end points, this will return true if the
+     * instant equals the end of the interval.
+     * An empty interval behaves as though it is an instant for comparison purposes.
+     * <p>
+     * This is equivalent to {@link #endsAtOrBefore(Instant)} {@code &&} {@link #startsBefore(Instant)}.
+     *
+     * @param instant  the other instant to compare to, not null
+     * @return true if the end of this interval is before or equal to the specified instant
+     */
+    public boolean isBefore(Instant instant) {
+        return endsAtOrBefore(instant) && startsBefore(instant);
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -343,6 +343,36 @@ public final class Interval
     }
 
     /**
+     * Checks if this intervals start contains the specified instant. In essence the start part of {@code contains(Instant)}
+     * <p>
+     * This checks if the specified instant is within the bounds of the start of this interval.
+     * If this range has an unbounded start then {@code containsFloor(Instant#MIN)} returns true.
+     * If this range has an unbounded end then {@code containsFloor(Instant#MAX)} returns true.
+     *
+     * @param instant  the instant, not null
+     * @return true if this interval start contains the instant
+     */
+    public boolean containedByStart(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return start.compareTo(instant) <= 0;
+    }
+
+    /**
+     * Checks if this intervals end contains the specified instant. In essence the end part of {@code contains(Instant)}
+     * <p>
+     * This checks if the specified instant is within the bounds of the end of this interval.
+     * If this range has an unbounded start then {@code containsHigher(Instant#MIN)} returns true.
+     * If this range has an unbounded end then {@code containsHigher(Instant#MAX)} returns true.
+     *
+     * @param instant  the instant, not null
+     * @return true if this intervals end contains the instant
+     */
+    public boolean containedByEnd(Instant instant) {
+        Objects.requireNonNull(instant, "instant");
+        return instant.compareTo(end) < 0 || isUnboundedEnd();
+    }
+
+    /**
      * Checks if this interval encloses the specified interval.
      * <p>
      * This checks if the bounds of the specified interval are within the bounds of this interval.

--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -470,7 +470,7 @@ public final class Interval
      * two intervals abut.
      * An empty interval behaves as though it is an instant for comparison purposes.
      *
-     * @param interval  the other interval to compare to, not null
+     * @param interval the other interval to compare to, not null
      * @return true if this interval is after the specified interval
      */
     public boolean isAfter(Interval interval) {
@@ -485,7 +485,7 @@ public final class Interval
      * two intervals abut.
      * An empty interval behaves as though it is an instant for comparison purposes.
      *
-     * @param interval  the other interval to compare to, not null
+     * @param interval the other interval to compare to, not null
      * @return true if this interval is before the specified interval
      */
     public boolean isBefore(Interval interval) {
@@ -499,7 +499,7 @@ public final class Interval
      * This method compares the start of the interval to the instant.
      * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval starts before the instant
      */
     public boolean startsBefore(Instant instant) {
@@ -510,10 +510,12 @@ public final class Interval
     /**
      * Checks if this interval starts at or before the specified instant.
      * <p>
+     * This method constitutes the <b>start</b> part of {@link #contains(Instant)}.
+     * <p>
      * This method compares the start of the interval to the instant.
      * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval starts at or before the instant
      */
     public boolean startsAtOrBefore(Instant instant) {
@@ -527,7 +529,7 @@ public final class Interval
      * This method compares the start of the interval to the instant.
      * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval starts after the instant
      */
     public boolean startsAfter(Instant instant) {
@@ -541,7 +543,7 @@ public final class Interval
      * This method compares the start of the interval to the instant.
      * An interval with an unbounded start is considered to start at {@code Instant.MIN}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval starts at or after the instant
      */
     public boolean startsAtOrAfter(Instant instant) {
@@ -556,7 +558,7 @@ public final class Interval
      * This method compares the end of the interval to the instant.
      * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval ends before the instant
      */
     public boolean endsBefore(Instant instant) {
@@ -570,7 +572,7 @@ public final class Interval
      * This method compares the end of the interval to the instant.
      * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval ends at or before the instant
      */
     public boolean endsAtOrBefore(Instant instant) {
@@ -581,10 +583,12 @@ public final class Interval
     /**
      * Checks if this interval ends after the specified instant.
      * <p>
+     * This method constitutes the <b>end</b> part of {@link #contains(Instant)}.
+     * <p>
      * This method compares the end of the interval to the instant.
      * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval ends after the instant
      */
     public boolean endsAfter(Instant instant) {
@@ -598,7 +602,7 @@ public final class Interval
      * This method compares the end of the interval to the instant.
      * An interval with an unbounded end is considered to end after {@code Instant.MAX}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval ends at or after the instant
      */
     public boolean endsAtOrAfter(Instant instant) {
@@ -617,7 +621,7 @@ public final class Interval
      * <p>
      * This is equivalent to {@link #startsAtOrBefore(Instant)} {@code &&} {@link #endsAfter(Instant)}.
      *
-     * @param instant  the instant, not null
+     * @param instant the instant, not null
      * @return true if this interval contains the instant
      */
     public boolean contains(Instant instant) {
@@ -632,7 +636,7 @@ public final class Interval
      * <p>
      * This is equivalent to {@link #startsAfter(Instant)}.
      *
-     * @param instant  the other instant to compare to, not null
+     * @param instant the other instant to compare to, not null
      * @return true if the start of this interval is after the specified instant
      */
     public boolean isAfter(Instant instant) {
@@ -649,7 +653,7 @@ public final class Interval
      * <p>
      * This is equivalent to {@link #endsAtOrBefore(Instant)} {@code &&} {@link #startsBefore(Instant)}.
      *
-     * @param instant  the other instant to compare to, not null
+     * @param instant the other instant to compare to, not null
      * @return true if the end of this interval is before or equal to the specified instant
      */
     public boolean isBefore(Instant instant) {

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -53,6 +53,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.tngtech.junit.dataprovider.DataProvider;
 import com.tngtech.junit.dataprovider.UseDataProvider;
@@ -66,6 +67,12 @@ public class TestInterval {
     static Instant NOW2 = NOW1.plusSeconds(60);
     static Instant NOW3 = NOW2.plusSeconds(60);
     static Instant NOW4 = NOW3.plusSeconds(60);
+    static Instant NOW11 = NOW1.plusSeconds(11);
+    static Instant NOW12 = NOW1.plusSeconds(12);
+    static Instant NOW13 = NOW1.plusSeconds(13);
+    static Instant NOW14 = NOW1.plusSeconds(14);
+    static Instant NOW15 = NOW1.plusSeconds(15);
+    static Instant NOW16 = NOW1.plusSeconds(16);
 
     //-----------------------------------------------------------------------
     @Test
@@ -292,97 +299,6 @@ public class TestInterval {
     public void test_contains_Instant_null() {
         Interval base = Interval.of(NOW1, NOW2);
         assertThrows(NullPointerException.class, () -> base.contains((Instant) null));
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    public void test_containedByStart_Instant() {
-        Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(false, test.containedByStart(NOW1.minusSeconds(1)));
-        assertEquals(true, test.containedByStart(NOW1));
-        assertEquals(true, test.containedByStart(NOW1.plusSeconds(1)));
-        assertEquals(true, test.containedByStart(NOW2.minusSeconds(1)));
-        assertEquals(true, test.containedByStart(NOW2));
-    }
-
-    @Test
-    public void test_containedByStart_Instant_baseEmpty() {
-        Interval test = Interval.of(NOW1, NOW1);
-        assertEquals(false, test.containedByStart(NOW1.minusSeconds(1)));
-        assertEquals(true, test.containedByStart(NOW1));
-        assertEquals(true, test.containedByStart(NOW1.plusSeconds(1)));
-    }
-
-    @Test
-    public void test_containedByStart_min(){
-        Interval test = Interval.of(Instant.MIN, NOW2);
-        assertEquals(true, test.containedByStart(Instant.MIN));
-        assertEquals(true, test.containedByStart(NOW1));
-        assertEquals(true, test.containedByStart(NOW2));
-        assertEquals(true, test.containedByStart(NOW3));
-        assertEquals(true, test.containedByStart(Instant.MAX));
-    }
-
-    @Test
-    public void test_containedByStart_max(){
-        Interval test = Interval.of(NOW2, Instant.MAX);
-        assertEquals(false, test.containedByStart(Instant.MIN));
-        assertEquals(false, test.containedByStart(NOW1));
-        assertEquals(true, test.containedByStart(NOW2));
-        assertEquals(true, test.containedByStart(NOW3));
-        assertEquals(true, test.containedByStart(Instant.MAX));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void test_containedByStart_Instant_null() {
-        Interval base = Interval.of(NOW1, NOW2);
-        base.containedByStart((Instant) null);
-    }
-
-    //-----------------------------------------------------------------------
-    @Test
-    public void test_containedByEnd_Instant() {
-        Interval test = Interval.of(NOW1, NOW2);
-        assertEquals(true, test.containedByEnd(NOW1.minusSeconds(1)));
-        assertEquals(true, test.containedByEnd(NOW1));
-        assertEquals(true, test.containedByEnd(NOW1.plusSeconds(1)));
-        assertEquals(true, test.containedByEnd(NOW2.minusSeconds(1)));
-        assertEquals(false, test.containedByEnd(NOW2));
-        assertEquals(false, test.containedByEnd(NOW3));
-    }
-
-    @Test
-    public void test_containedByEnd_Instant_baseEmpty() {
-        Interval test = Interval.of(NOW1, NOW1);
-        assertEquals(true, test.containedByEnd(NOW1.minusSeconds(1)));
-        assertEquals(false, test.containedByEnd(NOW1));
-        assertEquals(false, test.containedByEnd(NOW1.plusSeconds(1)));
-    }
-
-    @Test
-    public void test_containedByEnd_min(){
-        Interval test = Interval.of(Instant.MIN, NOW2);
-        assertEquals(true, test.containedByEnd(Instant.MIN));
-        assertEquals(true, test.containedByEnd(NOW1));
-        assertEquals(false, test.containedByEnd(NOW2));
-        assertEquals(false, test.containedByEnd(NOW3));
-        assertEquals(false, test.containedByEnd(Instant.MAX));
-    }
-
-    @Test
-    public void test_containedByEnd_max(){
-        Interval test = Interval.of(NOW2, Instant.MAX);
-        assertEquals(true, test.containedByEnd(Instant.MIN));
-        assertEquals(true, test.containedByEnd(NOW1));
-        assertEquals(true, test.containedByEnd(NOW2));
-        assertEquals(true, test.containedByEnd(NOW3));
-        assertEquals(true, test.containedByEnd(Instant.MAX));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void test_containedByEnd_Instant_null() {
-        Interval base = Interval.of(NOW1, NOW2);
-        base.containedByEnd((Instant) null);
     }
 
     //-----------------------------------------------------------------------
@@ -681,6 +597,112 @@ public class TestInterval {
         Interval test = Interval.of(NOW2, NOW4);
         assertEquals(test, test.union(test));
         assertEquals(test, test.span(test));
+    }
+
+    //-----------------------------------------------------------------------
+    static Object[][] data_starts() {
+        return new Object[][] {
+            // normal
+            {Interval.of(NOW12, NOW14), NOW11, false, false, true, true},
+            {Interval.of(NOW12, NOW14), NOW12, false, true, false, true},
+            {Interval.of(NOW12, NOW14), NOW13, true, true, false, false},
+            {Interval.of(NOW12, NOW14), NOW14, true, true, false, false},
+            {Interval.of(NOW12, NOW14), NOW15, true, true, false, false},
+            // empty interval
+            {Interval.of(NOW12, NOW12), NOW11, false, false, true, true},
+            {Interval.of(NOW12, NOW12), NOW12, false, true, false, true},
+            {Interval.of(NOW12, NOW12), NOW13, true, true, false, false},
+            // unbounded start
+            {Interval.of(Instant.MIN, NOW12), Instant.MIN, false, true, false, true},
+            {Interval.of(Instant.MIN, NOW12), NOW11, true, true, false, false},
+            {Interval.of(Instant.MIN, NOW12), NOW12, true, true, false, false},
+            {Interval.of(Instant.MIN, NOW12), NOW13, true, true, false, false},
+            {Interval.of(Instant.MIN, NOW12), Instant.MAX, true, true, false, false},
+            // unbounded end
+            {Interval.of(NOW12, Instant.MAX), Instant.MIN, false, false, true, true},
+            {Interval.of(NOW12, Instant.MAX), NOW11, false, false, true, true},
+            {Interval.of(NOW12, Instant.MAX), NOW12, false, true, false, true},
+            {Interval.of(NOW12, Instant.MAX), NOW13, true, true, false, false},
+            {Interval.of(NOW12, Instant.MAX), Instant.MAX, true, true, false, false},
+        };
+    }
+    
+    @ParameterizedTest
+    @MethodSource("data_starts")
+    public void test_starts_Instant(
+            Interval test, 
+            Instant instant, 
+            boolean expectedStartsBefore,
+            boolean expectedStartsAtOrBefore,
+            boolean expectedStartsAfter,
+            boolean expectedStartsAtOrAfter) {
+        
+        assertEquals(expectedStartsBefore, test.startsBefore(instant));
+        assertEquals(expectedStartsAtOrBefore, test.startsAtOrBefore(instant));
+        assertEquals(expectedStartsAfter, test.startsAfter(instant));
+        assertEquals(expectedStartsAtOrAfter, test.startsAtOrAfter(instant));
+    }
+
+    @Test
+    public void test_starts_Instant_null() {
+        Interval base = Interval.of(NOW12, NOW14);
+        assertThrows(NullPointerException.class, () -> base.startsBefore((Instant) null));
+        assertThrows(NullPointerException.class, () -> base.startsAtOrBefore((Instant) null));
+        assertThrows(NullPointerException.class, () -> base.startsAfter((Instant) null));
+        assertThrows(NullPointerException.class, () -> base.startsAtOrAfter((Instant) null));
+    }
+
+    //-----------------------------------------------------------------------
+    static Object[][] data_ends() {
+        return new Object[][] {
+            // normal
+            {Interval.of(NOW12, NOW14), NOW11, false, false, true, true},
+            {Interval.of(NOW12, NOW14), NOW12, false, false, true, true},
+            {Interval.of(NOW12, NOW14), NOW13, false, false, true, true},
+            {Interval.of(NOW12, NOW14), NOW14, false, true, false, true},
+            {Interval.of(NOW12, NOW14), NOW15, true, true, false, false},
+            // empty interval
+            {Interval.of(NOW12, NOW12), NOW11, false, false, true, true},
+            {Interval.of(NOW12, NOW12), NOW12, false, true, false, true},
+            {Interval.of(NOW12, NOW12), NOW13, true, true, false, false},
+            // unbounded start
+            {Interval.of(Instant.MIN, NOW12), Instant.MIN, false, false, true, true},
+            {Interval.of(Instant.MIN, NOW12), NOW11, false, false, true, true},
+            {Interval.of(Instant.MIN, NOW12), NOW12, false, true, false, true},
+            {Interval.of(Instant.MIN, NOW12), NOW13, true, true, false, false},
+            {Interval.of(Instant.MIN, NOW12), Instant.MAX, true, true, false, false},
+            // unbounded end
+            {Interval.of(NOW12, Instant.MAX), Instant.MIN, false, false, true, true},
+            {Interval.of(NOW12, Instant.MAX), NOW11, false, false, true, true},
+            {Interval.of(NOW12, Instant.MAX), NOW12, false, false, true, true},
+            {Interval.of(NOW12, Instant.MAX), NOW13, false, false, true, true},
+            {Interval.of(NOW12, Instant.MAX), Instant.MAX, false, false, true, true},
+        };
+    }
+    
+    @ParameterizedTest
+    @MethodSource("data_ends")
+    public void test_ends_Instant(
+            Interval test, 
+            Instant instant, 
+            boolean expectedEndsBefore,
+            boolean expectedEndsAtOrBefore,
+            boolean expectedEndsAfter,
+            boolean expectedEndsAtOrAfter) {
+        
+        assertEquals(expectedEndsBefore, test.endsBefore(instant));
+        assertEquals(expectedEndsAtOrBefore, test.endsAtOrBefore(instant));
+        assertEquals(expectedEndsAfter, test.endsAfter(instant));
+        assertEquals(expectedEndsAtOrAfter, test.endsAtOrAfter(instant));
+    }
+
+    @Test
+    public void test_ends_Instant_null() {
+        Interval base = Interval.of(NOW12, NOW14);
+//        assertThrows(NullPointerException.class, () -> base.endsBefore((Instant) null));
+//        assertThrows(NullPointerException.class, () -> base.endsOnOrBefore((Instant) null));
+        assertThrows(NullPointerException.class, () -> base.endsAfter((Instant) null));
+//        assertThrows(NullPointerException.class, () -> base.endsOnOrAfter((Instant) null));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -296,6 +296,97 @@ public class TestInterval {
 
     //-----------------------------------------------------------------------
     @Test
+    public void test_containedByStart_Instant() {
+        Interval test = Interval.of(NOW1, NOW2);
+        assertEquals(false, test.containedByStart(NOW1.minusSeconds(1)));
+        assertEquals(true, test.containedByStart(NOW1));
+        assertEquals(true, test.containedByStart(NOW1.plusSeconds(1)));
+        assertEquals(true, test.containedByStart(NOW2.minusSeconds(1)));
+        assertEquals(true, test.containedByStart(NOW2));
+    }
+
+    @Test
+    public void test_containedByStart_Instant_baseEmpty() {
+        Interval test = Interval.of(NOW1, NOW1);
+        assertEquals(false, test.containedByStart(NOW1.minusSeconds(1)));
+        assertEquals(true, test.containedByStart(NOW1));
+        assertEquals(true, test.containedByStart(NOW1.plusSeconds(1)));
+    }
+
+    @Test
+    public void test_containedByStart_min(){
+        Interval test = Interval.of(Instant.MIN, NOW2);
+        assertEquals(true, test.containedByStart(Instant.MIN));
+        assertEquals(true, test.containedByStart(NOW1));
+        assertEquals(true, test.containedByStart(NOW2));
+        assertEquals(true, test.containedByStart(NOW3));
+        assertEquals(true, test.containedByStart(Instant.MAX));
+    }
+
+    @Test
+    public void test_containedByStart_max(){
+        Interval test = Interval.of(NOW2, Instant.MAX);
+        assertEquals(false, test.containedByStart(Instant.MIN));
+        assertEquals(false, test.containedByStart(NOW1));
+        assertEquals(true, test.containedByStart(NOW2));
+        assertEquals(true, test.containedByStart(NOW3));
+        assertEquals(true, test.containedByStart(Instant.MAX));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_containedByStart_Instant_null() {
+        Interval base = Interval.of(NOW1, NOW2);
+        base.containedByStart((Instant) null);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_containedByEnd_Instant() {
+        Interval test = Interval.of(NOW1, NOW2);
+        assertEquals(true, test.containedByEnd(NOW1.minusSeconds(1)));
+        assertEquals(true, test.containedByEnd(NOW1));
+        assertEquals(true, test.containedByEnd(NOW1.plusSeconds(1)));
+        assertEquals(true, test.containedByEnd(NOW2.minusSeconds(1)));
+        assertEquals(false, test.containedByEnd(NOW2));
+        assertEquals(false, test.containedByEnd(NOW3));
+    }
+
+    @Test
+    public void test_containedByEnd_Instant_baseEmpty() {
+        Interval test = Interval.of(NOW1, NOW1);
+        assertEquals(true, test.containedByEnd(NOW1.minusSeconds(1)));
+        assertEquals(false, test.containedByEnd(NOW1));
+        assertEquals(false, test.containedByEnd(NOW1.plusSeconds(1)));
+    }
+
+    @Test
+    public void test_containedByEnd_min(){
+        Interval test = Interval.of(Instant.MIN, NOW2);
+        assertEquals(true, test.containedByEnd(Instant.MIN));
+        assertEquals(true, test.containedByEnd(NOW1));
+        assertEquals(false, test.containedByEnd(NOW2));
+        assertEquals(false, test.containedByEnd(NOW3));
+        assertEquals(false, test.containedByEnd(Instant.MAX));
+    }
+
+    @Test
+    public void test_containedByEnd_max(){
+        Interval test = Interval.of(NOW2, Instant.MAX);
+        assertEquals(true, test.containedByEnd(Instant.MIN));
+        assertEquals(true, test.containedByEnd(NOW1));
+        assertEquals(true, test.containedByEnd(NOW2));
+        assertEquals(true, test.containedByEnd(NOW3));
+        assertEquals(true, test.containedByEnd(Instant.MAX));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_containedByEnd_Instant_null() {
+        Interval base = Interval.of(NOW1, NOW2);
+        base.containedByEnd((Instant) null);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
     public void test_encloses_Interval() {
         Interval test = Interval.of(NOW1, NOW2);
         // completely before


### PR DESCRIPTION
…tains check.

I see my developers often having problems with the closed/open properties of Intervals. In this case there is no built in function to point them to leading the developers to "duplicate" the inclusive/exclusive properties into call sites of `getStart()`/`getEnd()`.

The concrete use case they ran into was filtering a list of intervals that preceded or overlapped an instant leading them to duplicating the inclusiveness of start like: `list.filter { it.start <= now }`.

I dont think the name is 100% spot on but.. yeah :)