### PR TITLE
Interval.ofNullable factory method.

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -108,6 +108,20 @@ public final class Interval
     }
 
     /**
+     * Obtains an instance of {@code Interval} from the start and end instant with null as unbounded for either.
+     * <p>
+     * The end instant must not be before the start instant.
+     *
+     * @param startInclusive  the start instant, inclusive, {@link Instant#MIN} treated as unbounded
+     * @param endExclusive  the end instant, exclusive, {@link Instant#MAX} treated as unbounded
+     * @return the half-open interval, not null
+     * @throws DateTimeException if the end is before the start
+     */
+    public static Interval ofNullable(Instant startInclusive, Instant endExclusive) {
+        return of(startInclusive == null ? Instant.MIN : startInclusive, endExclusive == null ? Instant.MAX : endExclusive);
+    }
+
+    /**
      * Obtains an instance of {@code Interval} from the start and a duration.
      * <p>
      * The end instant is calculated as the start plus the duration.

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -136,6 +136,52 @@ public class TestInterval {
 
     //-----------------------------------------------------------------------
     @Test
+    public void test_ofNullable_Instant_Instant() {
+        Interval test = Interval.ofNullable(NOW1, NOW2);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW2, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+    }
+
+    @Test
+    public void test_ofNullable_Instant_Instant_empty() {
+        Interval test = Interval.ofNullable(NOW1, NOW1);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW1, test.getEnd());
+        assertEquals(true, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+    }
+
+    @Test
+    public void test_ofNullable_Instant_Instant_nullStart() {
+        Interval test = Interval.ofNullable(null, NOW2);
+        assertEquals(Instant.MIN, test.getStart());
+        assertEquals(NOW2, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(true, test.isUnboundedStart());
+        assertEquals(false, test.isUnboundedEnd());
+    }
+
+    @Test
+    public void test_ofNullable_Instant_Instant_nullEnd() {
+        Interval test = Interval.ofNullable(NOW1, (Instant) null);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(Instant.MAX, test.getEnd());
+        assertEquals(false, test.isEmpty());
+        assertEquals(false, test.isUnboundedStart());
+        assertEquals(true, test.isUnboundedEnd());
+    }
+
+    @Test(expected = DateTimeException.class)
+    public void test_ofNullable_Instant_Instant_badOrder() {
+        Interval.ofNullable(NOW2, NOW1);
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
     public void test_of_Instant_Duration() {
         Interval test = Interval.of(NOW1, Duration.ofSeconds(60));
         assertEquals(NOW1, test.getStart());


### PR DESCRIPTION
Interval.ofNullable factory method for converting between null and unbounded intervals.

The motivating usecase is that we use null as the unbounded/unknown marker when mapping start,end in and out of Intervals. Instead of littering the code with `of(startInclusive == null ? Instant.MIN : startInclusive, endExclusive == null ? Instant.MAX : endExclusive);` it would be much nicer to keep this as a factory method. I would guess we are not the only ones with this need.