### PR TITLE
Empty interval should not register as enclosed if starts at getEnd()

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -353,7 +353,10 @@ public final class Interval
      */
     public boolean encloses(Interval other) {
         Objects.requireNonNull(other, "other");
-        return start.compareTo(other.start) <= 0 && other.end.compareTo(end) <= 0;
+        return start.compareTo(other.start) <= 0
+          // if other is empty, it must start before this ends, unless this is also empty
+          && (other.isEmpty() ? other.start.compareTo(end) < 0 || isEmpty() : true)
+          && other.end.compareTo(end) <= 0;
     }
 
     /**

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -301,6 +301,8 @@ public class TestInterval {
         // completely before
         assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(2), NOW1.minusSeconds(1))));
         assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW1)));
+        // empty interval before
+        assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW1.minusSeconds(1))));
         // partly before
         assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW2)));
         assertEquals(false, test.encloses(Interval.of(NOW1.minusSeconds(1), NOW2.minusSeconds(1))));
@@ -308,12 +310,18 @@ public class TestInterval {
         assertEquals(true, test.encloses(Interval.of(NOW1, NOW2.minusSeconds(1))));
         assertEquals(true, test.encloses(Interval.of(NOW1, NOW2)));
         assertEquals(true, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW2)));
+        // empty interval contained
+        assertEquals(true, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW1.plusSeconds(1))));
+        assertEquals(true, test.encloses(Interval.of(NOW2.minusSeconds(1), NOW2.minusSeconds(1))));
         // partly after
         assertEquals(false, test.encloses(Interval.of(NOW1, NOW2.plusSeconds(1))));
         assertEquals(false, test.encloses(Interval.of(NOW1.plusSeconds(1), NOW2.plusSeconds(1))));
         // completely after
         assertEquals(false, test.encloses(Interval.of(NOW2, NOW2.plusSeconds(1))));
         assertEquals(false, test.encloses(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(2))));
+        // empty interval completely after
+        assertEquals(false, test.encloses(Interval.of(NOW2, NOW2)));
+        assertEquals(false, test.encloses(Interval.of(NOW2.plusSeconds(1), NOW2.plusSeconds(1))));
     }
 
     @Test
@@ -566,7 +574,8 @@ public class TestInterval {
         Interval test2 = Interval.of(start2, end2);
         Interval expected = Interval.of(expStart, expEnd);
         assertEquals(true, expected.encloses(test1));
-        assertEquals(true, expected.encloses(test2));
+        // if test2 is empty and starts at the end of expected, then it won't be enclosed
+        assertEquals(true, expected.encloses(test2) || test2.isEmpty() && expEnd.equals(start2));
     }
 
     @Test


### PR DESCRIPTION
Since the end of an interval is exclusive, it seems wrong to say it encloses intervals that start at the end.

For example, currently

```java
        Interval test = Interval.of(NOW1, NOW2);
        assertEquals(true, test.encloses(Interval.of(NOW2, NOW2)));
```

I was expecting

```java
        Interval test = Interval.of(NOW1, NOW2);
        assertEquals(false, test.encloses(Interval.of(NOW2, NOW2)));
```
