### PR TITLE
Fix for #183 Interval toString/parse support for unbounded intervals

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -183,6 +183,9 @@ public final class Interval
             }
         }
         // instant followed by instant or duration
+        if (isUnbounded(startStr)) {
+            return parseEndDateTime(Instant.MIN, ZoneOffset.UTC, endStr);
+        }
         OffsetDateTime start;
         try {
             start = OffsetDateTime.parse(startStr);
@@ -197,6 +200,10 @@ public final class Interval
             }
         }
         return parseEndDateTime(start.toInstant(), start.getOffset(), endStr);
+    }
+
+    private static boolean isUnbounded(CharSequence sequence) {
+        return sequence.length() == 2 && sequence.charAt(0) == '.' && sequence.charAt(1) == '.';
     }
 
     // handle case where Instant is outside the bounds of OffsetDateTime
@@ -219,6 +226,10 @@ public final class Interval
 
     // parse when there are two date-times
     private static Interval parseEndDateTime(Instant start, ZoneOffset offset, CharSequence endStr) {
+        if (isUnbounded(endStr)) {
+            return Interval.of(start, Instant.MAX);
+        }
+
         try {
             TemporalAccessor temporal = DateTimeFormatter.ISO_DATE_TIME.parseBest(endStr, OffsetDateTime::from, LocalDateTime::from);
             if (temporal instanceof OffsetDateTime) {
@@ -708,13 +719,15 @@ public final class Interval
      * <p>
      * The output will be the ISO-8601 format formed by combining the
      * {@code toString()} methods of the two instants, separated by a forward slash.
+     * Unbounded intervals will have its open end represented by two periods, as in
+     * {@code 2007-12-03T10:15:30/..}.
      *
-     * @return a string representation of this instant, not null
+     * @return a string representation of this interval, not null
      */
     @Override
     @ToString
     public String toString() {
-        return start.toString() + '/' + end.toString();
+        return (isUnboundedStart() ? ".." : getStart()) + "/" + (isUnboundedEnd() ? ".." : getEnd());
     }
 
 }

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -196,8 +196,11 @@ public class TestInterval {
             {NOW1.atOffset(ZoneOffset.ofHours(2)) + "/" + NOW2.atOffset(ZoneOffset.ofHours(2)).toLocalDateTime(), NOW1, NOW2},
             {MIN_OFFSET_DATE_TIME.toString() + "/" + MAX_OFFSET_DATE_TIME, MIN_OFFSET_DATE_TIME, MAX_OFFSET_DATE_TIME},
             {NOW1 + "/" + Instant.MAX, NOW1, Instant.MAX},
-            {Instant.MIN.toString() + "/" + NOW2, Instant.MIN, NOW2},
-            {Instant.MIN.toString() + "/" + Instant.MAX, Instant.MIN, Instant.MAX}
+            {Instant.MIN + "/" + NOW2, Instant.MIN, NOW2},
+            {Instant.MIN + "/" + Instant.MAX, Instant.MIN, Instant.MAX},
+            {"../" + NOW2, Instant.MIN, NOW2},
+            {NOW1 + "/..", NOW1, Instant.MAX},
+            {"../..", Instant.MIN, Instant.MAX}
         };
     }
 
@@ -212,6 +215,16 @@ public class TestInterval {
     @Test
     public void test_parse_CharSequence_badOrder() {
         assertThrows(DateTimeException.class, () -> Interval.parse(NOW2 + "/" + NOW1));
+    }
+
+    @Test
+    public void test_parse_CharSequence_illegalOpenStartDuration() {
+        assertThrows(DateTimeException.class, () -> Interval.parse("../P1H"));
+    }
+
+    @Test
+    public void test_parse_CharSequence_illegalDurationOpenEnd() {
+        assertThrows(DateTimeException.class, () -> Interval.parse("P1H/.."));
     }
 
     @Test
@@ -841,6 +854,22 @@ public class TestInterval {
     public void test_toString() {
         Interval test = Interval.of(NOW1, NOW2);
         assertEquals(NOW1 + "/" + NOW2, test.toString());
+    }
+
+    @Test
+    public void test_toString_open_end() {
+        Interval test = Interval.ALL.withStart(NOW1);
+        assertEquals(NOW1 + "/..", test.toString());
+    }
+    @Test
+    public void test_toString_open_start() {
+        Interval test = Interval.ALL.withEnd(NOW2);
+        assertEquals("../" + NOW2, test.toString());
+    }
+    @Test
+    public void test_toString_open_all() {
+        Interval test = Interval.ALL;
+        assertEquals("../..", test.toString());
     }
 
 }


### PR DESCRIPTION
Allows open ends in intervals to be represented by "..". 
I think I added test cases for all relevant combinations, but you probably want to double-check. 😀

To me, combinations of duration and open ends (ie. "PT1H/.." or "../P1M") does not make sense, these will throw exceptions. 