### PR TITLE
Fix for #184 A more natural way to create unbounded Intervals

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -133,10 +133,9 @@ public final class Interval
      * Obtains an instance of {@code Interval} with the specified start instant and unbounded end.
      *
      * @param startInclusive the start instant, inclusive, not null
-     *
      * @return a new {@code Instant} with the specified start instant.
      */
-    public static Interval startingAt(final Instant startInclusive) {
+    public static Interval startingAt(Instant startInclusive) {
         Objects.requireNonNull(startInclusive, "startInclusive");
         return Interval.ALL.withStart(startInclusive);
     }
@@ -145,10 +144,9 @@ public final class Interval
      * Obtains an instance of {@code Interval} with unbounded start and the specified end instant.
      *
      * @param endExclusive the end instant, exclusive, not null
-     *
      * @return a new {@code Instant} with the specified end instant.
      */
-    public static Interval endingAt(final Instant endExclusive) {
+    public static Interval endingAt(Instant endExclusive) {
         Objects.requireNonNull(endExclusive, "endExclusive");
         return Interval.ALL.withEnd(endExclusive);
     }

--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -129,6 +129,30 @@ public final class Interval
         return new Interval(startInclusive, startInclusive.plus(duration));
     }
 
+    /**
+     * Obtains an instance of {@code Interval} with the specified start instant and unbounded end.
+     *
+     * @param startInclusive the start instant, inclusive, not null
+     *
+     * @return a new {@code Instant} with the specified start instant.
+     */
+    public static Interval startingAt(final Instant startInclusive) {
+        Objects.requireNonNull(startInclusive, "startInclusive");
+        return Interval.ALL.withStart(startInclusive);
+    }
+
+    /**
+     * Obtains an instance of {@code Interval} with unbounded start and the specified end instant.
+     *
+     * @param endExclusive the end instant, exclusive, not null
+     *
+     * @return a new {@code Instant} with the specified end instant.
+     */
+    public static Interval endingAt(final Instant endExclusive) {
+        Objects.requireNonNull(endExclusive, "endExclusive");
+        return Interval.ALL.withEnd(endExclusive);
+    }
+
     //-----------------------------------------------------------------------
     /**
      * Obtains an instance of {@code Interval} from a text string such as

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -190,6 +190,13 @@ public class TestInterval {
     }
 
     @Test
+    public void test_startingAt_InstantMIN_isALL() {
+        Interval interval = Interval.startingAt(Instant.MIN);
+
+        assertEquals(Interval.ALL, interval);
+    }
+
+    @Test
     public void test_startingAt_null() {
         assertThrows(NullPointerException.class, () -> Interval.startingAt(null));
     }
@@ -211,6 +218,13 @@ public class TestInterval {
         assertEquals(Instant.MIN, interval.getEnd());
         assertTrue(interval.isUnboundedStart());
         assertTrue(interval.isEmpty());
+    }
+
+    @Test
+    public void test_endingAt_InstantMAX_isALL() {
+        Interval interval = Interval.endingAt(Instant.MAX);
+
+        assertEquals(Interval.ALL, interval);
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -170,6 +170,54 @@ public class TestInterval {
         assertThrows(NullPointerException.class, () -> Interval.of(NOW1, (Duration) null));
     }
 
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_startingAt_Instant_createsUnboundedEnd() {
+        Interval interval = Interval.startingAt(NOW1);
+
+        assertEquals(NOW1, interval.getStart());
+        assertTrue(interval.isUnboundedEnd());
+        assertFalse(interval.isEmpty());
+    }
+
+    @Test
+    public void test_startingAt_InstantMAX_createsUnboundedEndEmpty() {
+        Interval interval = Interval.startingAt(Instant.MAX);
+
+        assertEquals(Instant.MAX, interval.getStart());
+        assertTrue(interval.isUnboundedEnd());
+        assertTrue(interval.isEmpty());
+    }
+
+    @Test
+    public void test_startingAt_null() {
+        assertThrows(NullPointerException.class, () -> Interval.startingAt(null));
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_endingAt_createsUnboundedStart() {
+        Interval interval = Interval.endingAt(NOW1);
+
+        assertEquals(NOW1, interval.getEnd());
+        assertTrue(interval.isUnboundedStart());
+        assertFalse(interval.isEmpty());
+    }
+
+    @Test
+    public void test_sendingAt_InstantMIN_createsUnboundedStartEmpty() {
+        Interval interval = Interval.endingAt(Instant.MIN);
+
+        assertEquals(Instant.MIN, interval.getEnd());
+        assertTrue(interval.isUnboundedStart());
+        assertTrue(interval.isEmpty());
+    }
+
+    @Test
+    public void test_endingAt_null() {
+        assertThrows(NullPointerException.class, () -> Interval.endingAt(null));
+    }
+
     /* Lower and upper bound for Intervals */
     private static final Instant MIN_OFFSET_DATE_TIME = OffsetDateTime.MIN.plusDays(1L).toInstant();
     private static final Instant MAX_OFFSET_DATE_TIME = OffsetDateTime.MAX.minusDays(1L).toInstant();


### PR DESCRIPTION
Added `startingAt` and `endingAt` methods to create open-ended intervals + tests. 

I did not address the none/never (empty/null-value) interval in this PR. 

The `endingAt(Instant.MIN)/startingAt(Instant.MAX)` tests are  mostly to document this somewhat surprising behavior, but perhaps not strictly necessary. Could also test that `endingAt(Instant.MAX)/startingAt(Instant.MIN) == Interval.ALL`, but not sure about the value. 