### PR TITLE
Test for unbounded start .contains(Interval.MIN) + document current behavior

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -613,7 +613,7 @@ public final class Interval
      * This checks if the specified instant is within the bounds of this interval.
      * If this interval has an unbounded start then {@code contains(Instant#MIN)} returns true.
      * If this interval has an unbounded end then {@code contains(Instant#MAX)} returns true.
-     * If this interval is empty then this method always returns false.
+     * Otherwise, if this interval is empty then this method returns false.
      * <p>
      * This is equivalent to {@link #startsAtOrBefore(Instant)} {@code &&} {@link #endsAfter(Instant)}.
      *

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -286,6 +286,14 @@ public class TestInterval {
     }
 
     @Test
+    public void test_contains_min() {
+        Interval test = Interval.of(Instant.MIN, NOW2);
+        assertEquals(true, test.contains(Instant.MIN));
+        assertEquals(true, test.contains(NOW1));
+        assertEquals(false, test.contains(NOW2));
+    }
+
+    @Test
     public void test_contains_max() {
         Interval test = Interval.of(NOW2, Instant.MAX);
         assertEquals(false, test.contains(Instant.MIN));


### PR DESCRIPTION
A minor change to the API doc that better describes the current behavior (not necessarily the correct one). 
Also adding a test that wasn't there, for completeness. 

I don't have very strong feelings if you decide to close this one, but I think it is an improvement (though a tiny one). 😀  