### PR TITLE
Java 17 compatibility updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,13 +218,6 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>${maven-bundle-plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>biz.aQute.bnd</groupId>
-            <artifactId>biz.aQute.bndlib</artifactId>
-            <version>${bndlib.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -915,7 +908,7 @@
     <junit.version>5.8.2</junit.version>
     <!-- Plugin version numbers -->
     <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
-    <maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
+    <maven-bundle-plugin.version>5.1.4</maven-bundle-plugin.version>
     <maven-changes-plugin.version>2.12.1</maven-changes-plugin.version>
     <!-- v3.0.0 does not work with Eclipse -->
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
@@ -940,8 +933,7 @@
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.0.0-M3</maven-surefire-report-plugin.version>
     <maven-toolchains-plugin.version>1.1</maven-toolchains-plugin.version>
-    <bndlib.version>4.1.0</bndlib.version>
-    <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
     <spotbugs-maven-plugin.version>3.1.11</spotbugs-maven-plugin.version>
     <!-- Properties for maven-compiler-plugin -->


### PR DESCRIPTION
While working on #198, for no apparent reason managed to use OpenJDK 17. That complained about some of the build process, and I updated dependencies as needed to get it building cleanly.

There are no code changes, just updates to deps.

The update to the maven-bundle-plugin pulls in a newer (compatible) version of bndlib, so that no longer needs to be overridden, simplifying the plugin configuration.