### PR TITLE
Simplify Temporals.durationFromBigDecimalSeconds

### DIFF
--- a/src/main/java/org/threeten/extra/Temporals.java
+++ b/src/main/java/org/threeten/extra/Temporals.java
@@ -412,9 +412,7 @@ public final class Temporals {
      * @return a {@code Duration}, not null
      */
     public static Duration durationFromBigDecimalSeconds(BigDecimal seconds) {
-        BigDecimal min = BigDecimal.valueOf(Long.MIN_VALUE).add(BigDecimal.valueOf(000_000_000, 9));
-        BigDecimal max = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.valueOf(999_999_999, 9));
-        BigInteger nanos = seconds.setScale(9, RoundingMode.UP).max(min).min(max).unscaledValue();
+        BigInteger nanos = seconds.setScale(9, RoundingMode.UP).max(BigDecimalSeconds.MIN).min(BigDecimalSeconds.MAX).unscaledValue();
         BigInteger[] secondsNanos = nanos.divideAndRemainder(BigInteger.valueOf(1_000_000_000));
         return Duration.ofSeconds(secondsNanos[0].longValue(), secondsNanos[1].intValue());
     }
@@ -469,4 +467,14 @@ public final class Temporals {
         return durationFromBigDecimalSeconds(amount);
     }
 
+    /**
+     * Useful Duration constants expressed as BigDecimal seconds with a scale of 9.
+     */
+    private static final class BigDecimalSeconds {
+        public static final BigDecimal MIN = BigDecimal.valueOf(Long.MIN_VALUE).add(BigDecimal.valueOf(000_000_000, 9));
+        public static final BigDecimal MAX = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.valueOf(999_999_999, 9));
+
+        private BigDecimalSeconds() {
+        }
+    }
 }

--- a/src/main/java/org/threeten/extra/Temporals.java
+++ b/src/main/java/org/threeten/extra/Temporals.java
@@ -471,7 +471,7 @@ public final class Temporals {
      * Useful Duration constants expressed as BigDecimal seconds with a scale of 9.
      */
     private static final class BigDecimalSeconds {
-        public static final BigDecimal MIN = BigDecimal.valueOf(Long.MIN_VALUE).add(BigDecimal.valueOf(000_000_000, 9));
+        public static final BigDecimal MIN = BigDecimal.valueOf(Long.MIN_VALUE).add(BigDecimal.valueOf(0, 9));
         public static final BigDecimal MAX = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.valueOf(999_999_999, 9));
 
         private BigDecimalSeconds() {

--- a/src/main/java/org/threeten/extra/Temporals.java
+++ b/src/main/java/org/threeten/extra/Temporals.java
@@ -412,16 +412,11 @@ public final class Temporals {
      * @return a {@code Duration}, not null
      */
     public static Duration durationFromBigDecimalSeconds(BigDecimal seconds) {
-        BigInteger nanos = seconds.setScale(9, RoundingMode.UP).movePointRight(9).toBigIntegerExact();
-        BigInteger[] divRem = nanos.divideAndRemainder(BigInteger.valueOf(1_000_000_000));
-        if (divRem[0].bitLength() > 63) {
-            if (divRem[0].signum() >= 1) {
-                return Duration.ofSeconds(Long.MAX_VALUE, 999_999_999);
-            } else {
-                return Duration.ofSeconds(Long.MIN_VALUE);
-            }
-        }
-        return Duration.ofSeconds(divRem[0].longValue(), divRem[1].intValue());
+        BigDecimal min = BigDecimal.valueOf(Long.MIN_VALUE).add(BigDecimal.valueOf(000_000_000, 9));
+        BigDecimal max = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.valueOf(999_999_999, 9));
+        BigInteger nanos = seconds.setScale(9, RoundingMode.UP).max(min).min(max).unscaledValue();
+        BigInteger[] secondsNanos = nanos.divideAndRemainder(BigInteger.valueOf(1_000_000_000));
+        return Duration.ofSeconds(secondsNanos[0].longValue(), secondsNanos[1].intValue());
     }
 
     /**


### PR DESCRIPTION
This is my attempt to replace low-level code of `Temporals.durationFromBigDecimalSeconds` with something simpler and more readable. Nothing special, but I hope you will like it.

Proposed implementation can be faster in some rare situations, as it never divides big ints whose absolute value is greater than Long.MAX_VALUE x 10^9 (+/- 1). It is possible to optimize even more and avoid division at all when seconds < min or > max.

Note that `min` and `max` can be made `private static final`. I wasn't sure if it should be a job for HotSpot or not.

@jodastephen, @cowwoc - what do you think?