### PR TITLE
Switch to junit-native MethodSource for test data.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,17 @@
   </build>
 
   <!-- ==================================================================== -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.8.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.joda</groupId>
@@ -523,26 +534,8 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.tngtech.junit.dataprovider</groupId>
-      <artifactId>junit-jupiter-params-dataprovider</artifactId>
-      <version>2.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/threeten/extra/TestAmountFormats.java
+++ b/src/test/java/org/threeten/extra/TestAmountFormats.java
@@ -41,9 +41,7 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test AmountFormats.
@@ -62,7 +60,6 @@ public class TestAmountFormats {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_wordBased() {
         return new Object[][] {
             {Period.ofYears(0), Locale.ROOT, "0 days"},
@@ -100,12 +97,11 @@ public class TestAmountFormats {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_wordBased")
+    @MethodSource("data_wordBased")
     public void test_wordBased(Period period, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(period, locale));
     }
 
-    @DataProvider
     public static Object[][] duration_wordBased() {
         return new Object[][] {
             {Duration.ofMinutes(180 + 2), Locale.ENGLISH, "3 hours and 2 minutes"},
@@ -136,12 +132,11 @@ public class TestAmountFormats {
     }
 
     @ParameterizedTest
-    @UseDataProvider("duration_wordBased")
+    @MethodSource("duration_wordBased")
     public void test_wordBased(Duration duration, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(duration, locale));
     }
 
-    @DataProvider
     public static Object[][] period_duration_wordBased() {
         return new Object[][] {
             {Period.ofDays(1), Duration.ofMinutes(180 + 2), Locale.ROOT, "1 day, 3 hours and 2 minutes"},
@@ -163,7 +158,7 @@ public class TestAmountFormats {
     }
 
     @ParameterizedTest
-    @UseDataProvider("period_duration_wordBased")
+    @MethodSource("period_duration_wordBased")
     public void test_wordBased(Period period, Duration duration, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(period, duration, locale));
     }
@@ -296,12 +291,11 @@ public class TestAmountFormats {
 
     // -----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("wordBased_ru_formatSeparator")
+    @MethodSource("wordBased_ru_formatSeparator")
     public void test_wordBased_ru_formatSeparator(String expected, Duration duration) {
         assertEquals(expected, AmountFormats.wordBased(duration, RU));
     }
 
-    @DataProvider
     public static Object[][] wordBased_ru_formatSeparator() {
         return new Object[][]{
             {"18 \u0447\u0430\u0441\u043E\u0432 \u0438 32 \u043C\u0438\u043D\u0443\u0442\u044B", Duration.ofMinutes(1112)},
@@ -311,12 +305,11 @@ public class TestAmountFormats {
 
     // -----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("wordBased_ru_period_predicate")
+    @MethodSource("wordBased_ru_period_predicate")
     public void test_wordBased_ru_period_predicate(String expected, Period period) {
         assertEquals(expected, AmountFormats.wordBased(period, RU));
     }
 
-    @DataProvider
     public static Object[][] wordBased_ru_period_predicate() {
         return new Object[][]{
 
@@ -439,12 +432,11 @@ public class TestAmountFormats {
 
     // -----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("wordBased_ru_duration_predicate")
+    @MethodSource("wordBased_ru_duration_predicate")
     public void test_wordBased_ru_duration_predicate(String expected, Duration duration) {
         assertEquals(expected, AmountFormats.wordBased(duration, RU));
     }
 
-    @DataProvider
     public static Object[][] wordBased_ru_duration_predicate() {
         return new Object[][]{
 
@@ -544,12 +536,11 @@ public class TestAmountFormats {
 
     // -----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("duration_unitBased")
+    @MethodSource("duration_unitBased")
     public void test_parseUnitBasedDuration(Duration expected, String input) {
         assertEquals(expected, AmountFormats.parseUnitBasedDuration(input));
     }
 
-    @DataProvider
     public static Object[][] duration_unitBased() {
         return new Object[][] {
             {Duration.ZERO, "0"},
@@ -574,7 +565,7 @@ public class TestAmountFormats {
     }
 
     @ParameterizedTest
-    @UseDataProvider("duration_unitBasedErrors")
+    @MethodSource("duration_unitBasedErrors")
     public void test_parseUnitBasedDurationErrors(Exception e, String input) {
         Exception thrown =
             assertThrows(e.getClass(), () -> AmountFormats.parseUnitBasedDuration(input));
@@ -587,7 +578,6 @@ public class TestAmountFormats {
         }
     }
 
-    @DataProvider
     public static Object[][] duration_unitBasedErrors() {
         return new Object[][] {
             {new NullPointerException("durationText must not be null"), null},

--- a/src/test/java/org/threeten/extra/TestConvert.java
+++ b/src/test/java/org/threeten/extra/TestConvert.java
@@ -40,15 +40,12 @@ import java.time.Period;
 
 import org.joda.convert.StringConvert;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.threeten.extra.scale.TaiInstant;
 import org.threeten.extra.scale.UtcInstant;
 
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
-
 public class TestConvert {
 
-    @DataProvider
     public static Object[][] data_inputs() {
         return new Object[][] {
                 {Seconds.of(23), "PT23S"},
@@ -69,13 +66,13 @@ public class TestConvert {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_inputs")
+    @MethodSource("data_inputs")
     public void test_convertToString(Object obj, String str) {
         assertEquals(str, StringConvert.INSTANCE.convertToString(obj));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_inputs")
+    @MethodSource("data_inputs")
     public void test_convertFromString(Object obj, String str) {
         assertEquals(obj, StringConvert.INSTANCE.convertFromString(obj.getClass(), str));
     }

--- a/src/test/java/org/threeten/extra/TestDays.java
+++ b/src/test/java/org/threeten/extra/TestDays.java
@@ -54,9 +54,7 @@ import java.time.temporal.TemporalAmount;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -182,7 +180,6 @@ public class TestDays {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_valid() {
         return new Object[][] {
             {"P0D", 0},
@@ -214,24 +211,23 @@ public class TestDays {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
         assertEquals(Days.of(expectedDays), Days.parse(str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
         assertEquals(Days.of(expectedDays), Days.parse("+" + str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
         assertEquals(Days.of(-expectedDays), Days.parse("-" + str));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3Y"},
@@ -252,7 +248,7 @@ public class TestDays {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Days.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -48,9 +48,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -116,7 +114,6 @@ public class TestHours {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_valid() {
         return new Object[][] {
             {"PT0H", 0},
@@ -143,24 +140,23 @@ public class TestHours {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
         assertEquals(Hours.of(expectedDays), Hours.parse(str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
         assertEquals(Hours.of(expectedDays), Hours.parse("+" + str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
         assertEquals(Hours.of(-expectedDays), Hours.parse("-" + str));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3W"},
@@ -181,7 +177,7 @@ public class TestHours {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Hours.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -55,9 +55,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
-
 /**
  * Test class.
  */
@@ -237,7 +234,6 @@ public class TestInterval {
     private static final Instant MAX_OFFSET_DATE_TIME = OffsetDateTime.MAX.minusDays(1L).toInstant();
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_parseValid() {
         Instant minPlusOneDay = Instant.MIN.plus(Duration.ofDays(1));
         Instant maxMinusOneDay = Instant.MAX.minus(Duration.ofDays(1));
@@ -264,7 +260,7 @@ public class TestInterval {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_parseValid")
+    @MethodSource("data_parseValid")
     public void test_parse_CharSequence(String input, Instant start, Instant end) {
         Interval test = Interval.parse(input);
         assertEquals(start, test.getStart());
@@ -537,7 +533,6 @@ public class TestInterval {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_intersection() {
         return new Object[][] {
             // adjacent
@@ -554,7 +549,7 @@ public class TestInterval {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_intersection")
+    @MethodSource("data_intersection")
     public void test_intersection(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
 
@@ -566,7 +561,7 @@ public class TestInterval {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_intersection")
+    @MethodSource("data_intersection")
     public void test_intersection_reverse(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
 
@@ -592,7 +587,6 @@ public class TestInterval {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_union() {
         return new Object[][] {
             // adjacent
@@ -609,7 +603,7 @@ public class TestInterval {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_union")
+    @MethodSource("data_union")
     public void test_unionAndSpan(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
 
@@ -622,7 +616,7 @@ public class TestInterval {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_union")
+    @MethodSource("data_union")
     public void test_unionAndSpan_reverse(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
 
@@ -635,7 +629,7 @@ public class TestInterval {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_union")
+    @MethodSource("data_union")
     public void test_span_enclosesInputs(
             Instant start1, Instant end1, Instant start2, Instant end2, Instant expStart, Instant expEnd) {
 
@@ -696,17 +690,17 @@ public class TestInterval {
             {Interval.of(NOW12, Instant.MAX), Instant.MAX, true, true, false, false},
         };
     }
-    
+
     @ParameterizedTest
     @MethodSource("data_starts")
     public void test_starts_Instant(
-            Interval test, 
-            Instant instant, 
+            Interval test,
+            Instant instant,
             boolean expectedStartsBefore,
             boolean expectedStartsAtOrBefore,
             boolean expectedStartsAfter,
             boolean expectedStartsAtOrAfter) {
-        
+
         assertEquals(expectedStartsBefore, test.startsBefore(instant));
         assertEquals(expectedStartsAtOrBefore, test.startsAtOrBefore(instant));
         assertEquals(expectedStartsAfter, test.startsAfter(instant));
@@ -749,17 +743,17 @@ public class TestInterval {
             {Interval.of(NOW12, Instant.MAX), Instant.MAX, false, false, true, true},
         };
     }
-    
+
     @ParameterizedTest
     @MethodSource("data_ends")
     public void test_ends_Instant(
-            Interval test, 
-            Instant instant, 
+            Interval test,
+            Instant instant,
             boolean expectedEndsBefore,
             boolean expectedEndsAtOrBefore,
             boolean expectedEndsAfter,
             boolean expectedEndsAtOrAfter) {
-        
+
         assertEquals(expectedEndsBefore, test.endsBefore(instant));
         assertEquals(expectedEndsAtOrBefore, test.endsAtOrBefore(instant));
         assertEquals(expectedEndsAfter, test.endsAfter(instant));

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -47,16 +47,16 @@ import java.time.Period;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.collect.Range;
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
 
 /**
  * Test date range.
@@ -702,7 +702,6 @@ public class TestLocalDateRange {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_queries() {
         return new Object[][] {
             // before start
@@ -752,7 +751,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_queries")
+    @MethodSource("data_queries")
     public void test_encloses(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -760,7 +759,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_queries")
+    @MethodSource("data_queries")
     public void test_abuts(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -768,7 +767,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_queries")
+    @MethodSource("data_queries")
     public void test_isConnected(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -776,7 +775,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_queries")
+    @MethodSource("data_queries")
     public void test_overlaps(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -784,7 +783,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_queries")
+    @MethodSource("data_queries")
     public void test_crossCheck(
             LocalDate start, LocalDate end, boolean isEnclosedBy, boolean abuts, boolean isConnected, boolean overlaps) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
@@ -844,7 +843,6 @@ public class TestLocalDateRange {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_intersection() {
         return new Object[][] {
             // adjacent
@@ -861,7 +859,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_intersection")
+    @MethodSource("data_intersection")
     public void test_intersection(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
 
@@ -873,7 +871,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_intersection")
+    @MethodSource("data_intersection")
     public void test_intersection_reverse(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
 
@@ -899,7 +897,6 @@ public class TestLocalDateRange {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_union() {
         return new Object[][] {
             // adjacent
@@ -916,7 +913,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_union")
+    @MethodSource("data_union")
     public void test_unionAndSpan(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
 
@@ -929,7 +926,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_union")
+    @MethodSource("data_union")
     public void test_unionAndSpan_reverse(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
 
@@ -942,7 +939,7 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_union")
+    @MethodSource("data_union")
     public void test_span_enclosesInputs(
             LocalDate start1, LocalDate end1, LocalDate start2, LocalDate end2, LocalDate expStart, LocalDate expEnd) {
 
@@ -1008,7 +1005,6 @@ public class TestLocalDateRange {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_isBefore() {
         return new Object[][] {
             // before start
@@ -1052,14 +1048,14 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_isBefore")
+    @MethodSource("data_isBefore")
     public void test_isBefore_range(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertEquals(before, test.isBefore(LocalDateRange.of(start, end)));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_isBefore")
+    @MethodSource("data_isBefore")
     public void test_isBefore_date(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertEquals(before, test.isBefore(start));
@@ -1085,7 +1081,6 @@ public class TestLocalDateRange {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_isAfter() {
         return new Object[][] {
             // before start
@@ -1132,14 +1127,14 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_isAfter")
+    @MethodSource("data_isAfter")
     public void test_isAfter_range(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertEquals(before, test.isAfter(LocalDateRange.of(start, end)));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_isAfter")
+    @MethodSource("data_isAfter")
     public void test_isAfter_date(LocalDate start, LocalDate end, boolean before) {
         LocalDateRange test = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertEquals(before, test.isAfter(end.minusDays(1)));
@@ -1210,9 +1205,8 @@ public class TestLocalDateRange {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
-    public static List<List<Object>> data_crossCheckGuava() {
-        List<List<Object>> list = new ArrayList<>();
+    public static List<Arguments> data_crossCheckGuava() {
+        List<Arguments> list = new ArrayList<>();
         for (int i1 = 1; i1 < 5; i1++) {
             for (int j1 = i1; j1 < 5; j1++) {
                 LocalDate date11 = LocalDate.of(2016, 1, i1);
@@ -1225,7 +1219,7 @@ public class TestLocalDateRange {
                         LocalDate date22 = LocalDate.of(2016, 1, j2);
                         LocalDateRange extraRange2 = LocalDateRange.of(date21, date22);
                         Range<LocalDate> guavaRange2 = Range.closedOpen(date21, date22);
-                        list.add(Arrays.asList(extraRange1, extraRange2, guavaRange1, guavaRange2));
+                        list.add(arguments(extraRange1, extraRange2, guavaRange1, guavaRange2));
                     }
                 }
             }
@@ -1234,11 +1228,11 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_crossCheckGuava")
+    @MethodSource("data_crossCheckGuava")
     public void crossCheckGuava_encloses(
             LocalDateRange extraRange1,
-            LocalDateRange extraRange2, 
-            Range<LocalDate> guavaRange1, 
+            LocalDateRange extraRange2,
+            Range<LocalDate> guavaRange1,
             Range<LocalDate> guavaRange2) {
 
         boolean extra = extraRange1.encloses(extraRange2);
@@ -1247,11 +1241,11 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_crossCheckGuava")
+    @MethodSource("data_crossCheckGuava")
     public void crossCheckGuava_isConnected(
             LocalDateRange extraRange1,
-            LocalDateRange extraRange2, 
-            Range<LocalDate> guavaRange1, 
+            LocalDateRange extraRange2,
+            Range<LocalDate> guavaRange1,
             Range<LocalDate> guavaRange2) {
 
         boolean extra = extraRange1.isConnected(extraRange2);
@@ -1260,11 +1254,11 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_crossCheckGuava")
+    @MethodSource("data_crossCheckGuava")
     public void crossCheckGuava_intersection(
             LocalDateRange extraRange1,
-            LocalDateRange extraRange2, 
-            Range<LocalDate> guavaRange1, 
+            LocalDateRange extraRange2,
+            Range<LocalDate> guavaRange1,
             Range<LocalDate> guavaRange2) {
 
         LocalDateRange extra = null;
@@ -1288,11 +1282,11 @@ public class TestLocalDateRange {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_crossCheckGuava")
+    @MethodSource("data_crossCheckGuava")
     public void crossCheckGuava_span(
             LocalDateRange extraRange1,
-            LocalDateRange extraRange2, 
-            Range<LocalDate> guavaRange1, 
+            LocalDateRange extraRange2,
+            Range<LocalDate> guavaRange1,
             Range<LocalDate> guavaRange2) {
 
         LocalDateRange extra = extraRange1.span(extraRange2);

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -48,9 +48,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -133,7 +131,6 @@ public class TestMinutes {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_valid() {
         return new Object[][] {
             {"PT0M", 0},
@@ -177,24 +174,23 @@ public class TestMinutes {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedMinutes) {
         assertEquals(Minutes.of(expectedMinutes), Minutes.parse(str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedMinutes) {
         assertEquals(Minutes.of(expectedMinutes), Minutes.parse("+" + str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedMinutes) {
         assertEquals(Minutes.of(-expectedMinutes), Minutes.parse("-" + str));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3W"},
@@ -217,7 +213,7 @@ public class TestMinutes {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Minutes.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestMonths.java
+++ b/src/test/java/org/threeten/extra/TestMonths.java
@@ -54,9 +54,7 @@ import java.time.temporal.TemporalAmount;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -177,7 +175,6 @@ public class TestMonths {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_valid() {
         return new Object[][] {
             {"P0M", 0},
@@ -209,24 +206,23 @@ public class TestMonths {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedDays) {
         assertEquals(Months.of(expectedDays), Months.parse(str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedDays) {
         assertEquals(Months.of(expectedDays), Months.parse("+" + str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedDays) {
         assertEquals(Months.of(-expectedDays), Months.parse("-" + str));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3W"},
@@ -245,7 +241,7 @@ public class TestMonths {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Months.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestOffsetDate.java
+++ b/src/test/java/org/threeten/extra/TestOffsetDate.java
@@ -87,9 +87,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test OffsetDate.
@@ -315,7 +313,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     // parse()
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleToString")
+    @MethodSource("data_sampleToString")
     public void factory_parse_validText(int y, int m, int d, String offsetId, String parsable) {
         OffsetDate t = OffsetDate.parse(parsable);
         assertNotNull(t, parsable);
@@ -325,7 +323,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
         assertEquals(ZoneOffset.of(offsetId), t.getOffset());
     }
 
-    @DataProvider
     public static Object[][] data_sampleBadParse() {
         return new Object[][]{
                 {"2008/07/05"},
@@ -348,7 +345,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleBadParse")
+    @MethodSource("data_sampleBadParse")
     public void factory_parse_invalidText(String unparsable) {
         assertThrows(DateTimeParseException.class, () -> OffsetDate.parse(unparsable));
     }
@@ -411,7 +408,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // basics
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_sampleDates() {
         return new Object[][] {
             {2008, 7, 5, OFFSET_PTWO},
@@ -425,7 +421,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_get_OffsetDate(int y, int m, int d, ZoneOffset offset) {
         LocalDate localDate = LocalDate.of(y, m, d);
         OffsetDate a = OffsetDate.of(localDate, offset);
@@ -543,7 +539,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // until(Temporal, TemporalUnit)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
                 {1, OffsetDate.of(2007, 6, 30, OFFSET_PONE), OffsetDate.of(2007, 7, 1, OFFSET_PONE), ChronoUnit.DAYS},
@@ -554,7 +549,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until(long expected, OffsetDate od1, OffsetDate od2, TemporalUnit unit) {
         assertEquals(expected, od1.until(od2, unit));
         assertEquals(-expected, od2.until(od1, unit));
@@ -949,7 +944,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // plusWeeks()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samplePlusWeeksSymmetry() {
         return new Object[][] {
             {OffsetDate.of(-1, 1, 1, OFFSET_PONE)},
@@ -982,7 +976,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samplePlusWeeksSymmetry")
+    @MethodSource("data_samplePlusWeeksSymmetry")
     public void test_plusWeeks_symmetry(OffsetDate reference) {
         for (int weeks = 0; weeks < 365 * 8; weeks++) {
             OffsetDate t = reference.plusWeeks(weeks).plusWeeks(-weeks);
@@ -1078,7 +1072,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // plusDays()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samplePlusDaysSymmetry() {
         return new Object[][] {
             {OffsetDate.of(-1, 1, 1, OFFSET_PONE)},
@@ -1111,7 +1104,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samplePlusDaysSymmetry")
+    @MethodSource("data_samplePlusDaysSymmetry")
     public void test_plusDays_symmetry(OffsetDate reference) {
         for (int days = 0; days < 365 * 8; days++) {
             OffsetDate t = reference.plusDays(days).plusDays(-days);
@@ -1374,7 +1367,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // minusWeeks()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_sampleMinusWeeksSymmetry() {
         return new Object[][] {
             {OffsetDate.of(-1, 1, 1, OFFSET_PONE)},
@@ -1407,7 +1399,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleMinusWeeksSymmetry")
+    @MethodSource("data_sampleMinusWeeksSymmetry")
     public void test_minusWeeks_symmetry(OffsetDate reference) {
         for (int weeks = 0; weeks < 365 * 8; weeks++) {
             OffsetDate t = reference.minusWeeks(weeks).minusWeeks(-weeks);
@@ -1503,7 +1495,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // minusDays()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_sampleMinusDaysSymmetry() {
         return new Object[][] {
             {OffsetDate.of(-1, 1, 1, OFFSET_PONE)},
@@ -1536,7 +1527,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleMinusDaysSymmetry")
+    @MethodSource("data_sampleMinusDaysSymmetry")
     public void test_minusDays_symmetry(OffsetDate reference) {
         for (int days = 0; days < 365 * 8; days++) {
             OffsetDate t = reference.minusDays(days).minusDays(-days);
@@ -1664,7 +1655,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     // toLocalDate()
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_toLocalDate(int year, int month, int day, ZoneOffset offset) {
         LocalDate t = LocalDate.of(year, month, day);
         assertEquals(t, OffsetDate.of(year, month, day, offset).toLocalDate());
@@ -1831,7 +1822,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     // equals() / hashCode()
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_equals_true(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(y, m, d, offset);
         OffsetDate b = OffsetDate.of(y, m, d, offset);
@@ -1840,7 +1831,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_equals_false_year_differs(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(y, m, d, offset);
         OffsetDate b = OffsetDate.of(y + 1, m, d, offset);
@@ -1848,7 +1839,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_equals_false_month_differs(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(y, m, d, offset);
         OffsetDate b = OffsetDate.of(y, m + 1, d, offset);
@@ -1856,7 +1847,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_equals_false_day_differs(int y, int m, int d, ZoneOffset offset) {
         OffsetDate a = OffsetDate.of(y, m, d, offset);
         OffsetDate b = OffsetDate.of(y, m, d + 1, offset);
@@ -1864,7 +1855,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleDates")
+    @MethodSource("data_sampleDates")
     public void test_equals_false_offset_differs(int y, int m, int d, ZoneOffset ignored) {
         OffsetDate a = OffsetDate.of(y, m, d, OFFSET_PONE);
         OffsetDate b = OffsetDate.of(y, m, d, OFFSET_PTWO);
@@ -1884,7 +1875,6 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_sampleToString() {
         return new Object[][] {
             {2008, 7, 5, "Z", "2008-07-05Z"},
@@ -1913,7 +1903,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleToString")
+    @MethodSource("data_sampleToString")
     public void test_toString(int y, int m, int d, String offsetId, String expected) {
         OffsetDate t = OffsetDate.of(y, m, d, ZoneOffset.of(offsetId));
         String str = t.toString();

--- a/src/test/java/org/threeten/extra/TestPeriodDuration.java
+++ b/src/test/java/org/threeten/extra/TestPeriodDuration.java
@@ -57,9 +57,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -194,7 +192,6 @@ public class TestPeriodDuration {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_valid() {
         return new Object[][] {
                 {"P1Y2M3W4DT5H6M7S", Period.of(1, 2, 3 * 7 + 4), Duration.ofHours(5).plusMinutes(6).plusSeconds(7)},
@@ -220,24 +217,23 @@ public class TestPeriodDuration {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid(String str, Period period, Duration duration) {
         assertEquals(PeriodDuration.of(period, duration), PeriodDuration.parse(str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, Period period, Duration duration) {
         assertEquals(PeriodDuration.of(period, duration), PeriodDuration.parse("+" + str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, Period period, Duration duration) {
         assertEquals(PeriodDuration.of(period, duration).negated(), PeriodDuration.parse("-" + str));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
                 {"P3Q"},
@@ -256,7 +252,7 @@ public class TestPeriodDuration {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> PeriodDuration.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestQuarter.java
+++ b/src/test/java/org/threeten/extra/TestQuarter.java
@@ -85,9 +85,7 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test Quarter.
@@ -315,7 +313,6 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     // plus(long), plus(long,unit)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {1, -5, 4},
@@ -333,7 +330,7 @@ public class TestQuarter {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_long(int base, long amount, int expected) {
         assertEquals(Quarter.of(expected), Quarter.of(base).plus(amount));
     }
@@ -341,7 +338,6 @@ public class TestQuarter {
     //-----------------------------------------------------------------------
     // minus(long), minus(long,unit)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_minus() {
         return new Object[][] {
             {1, -5, 2},
@@ -359,7 +355,7 @@ public class TestQuarter {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_minus")
+    @MethodSource("data_minus")
     public void test_minus_long(int base, long amount, int expected) {
         assertEquals(Quarter.of(expected), Quarter.of(base).minus(amount));
     }

--- a/src/test/java/org/threeten/extra/TestSeconds.java
+++ b/src/test/java/org/threeten/extra/TestSeconds.java
@@ -48,9 +48,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -150,7 +148,6 @@ public class TestSeconds {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_valid() {
         return new Object[][] {
             {"PT0S", 0},
@@ -211,24 +208,23 @@ public class TestSeconds {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid(String str, int expectedSeconds) {
         assertEquals(Seconds.of(expectedSeconds), Seconds.parse(str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialPlus(String str, int expectedSeconds) {
         assertEquals(Seconds.of(expectedSeconds), Seconds.parse("+" + str));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_valid")
+    @MethodSource("data_valid")
     public void test_parse_CharSequence_valid_initialMinus(String str, int expectedSeconds) {
         assertEquals(Seconds.of(-expectedSeconds), Seconds.parse("-" + str));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3W"},
@@ -249,7 +245,7 @@ public class TestSeconds {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Seconds.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestTemporals.java
+++ b/src/test/java/org/threeten/extra/TestTemporals.java
@@ -78,9 +78,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test Temporals.
@@ -153,7 +151,7 @@ public class TestTemporals {
         test = Temporals.nextWorkingDay().adjustInto(saturday);
         assertEquals(LocalDate.of(2012, JANUARY, 2), test);
     }
-    
+
     //-----------------------------------------------------------------------
     // nextWorkingDayOrSame()
     //-----------------------------------------------------------------------
@@ -357,7 +355,6 @@ public class TestTemporals {
     //-----------------------------------------------------------------------
     // parseFirstMatching()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_parseFirstMatching() {
         return new Object[][] {
             {"2016-09-06", DateTimeFormatter.ISO_LOCAL_DATE, DateTimeFormatter.BASIC_ISO_DATE},
@@ -366,7 +363,7 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_parseFirstMatching")
+    @MethodSource("data_parseFirstMatching")
     public void test_parseFirstMatching(String text, DateTimeFormatter fmt1, DateTimeFormatter fmt2) {
         assertEquals(LocalDate.of(2016, 9, 6), Temporals.parseFirstMatching(text, LocalDate::from, fmt1, fmt2));
     }
@@ -389,7 +386,6 @@ public class TestTemporals {
     //-----------------------------------------------------------------------
     // chronoUnit() / timeUnit()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_timeUnitConversion() {
         return new Object[][] {
             {ChronoUnit.NANOS, TimeUnit.NANOSECONDS},
@@ -403,7 +399,7 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_timeUnitConversion")
+    @MethodSource("data_timeUnitConversion")
     public void test_timeUnit(ChronoUnit chronoUnit, TimeUnit timeUnit) {
         assertEquals(timeUnit, Temporals.timeUnit(chronoUnit));
     }
@@ -419,7 +415,7 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_timeUnitConversion")
+    @MethodSource("data_timeUnitConversion")
     public void test_chronoUnit(ChronoUnit chronoUnit, TimeUnit timeUnit) {
         assertEquals(chronoUnit, Temporals.chronoUnit(timeUnit));
     }
@@ -432,7 +428,6 @@ public class TestTemporals {
     //-----------------------------------------------------------------------
     // convertAmount()
     //-------------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_convertAmount() {
         return new Object[][] {
             {2L, NANOS, SECONDS, 0L, 2L},
@@ -580,7 +575,7 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_convertAmount")
+    @MethodSource("data_convertAmount")
     public void test_convertAmount(
             long fromAmount, TemporalUnit fromUnit, TemporalUnit resultUnit,
             long resultWhole, long resultRemainder) {
@@ -590,7 +585,7 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_convertAmount")
+    @MethodSource("data_convertAmount")
     public void test_convertAmount_negative(
             long fromAmount, TemporalUnit fromUnit, TemporalUnit resultUnit,
             long resultWhole, long resultRemainder) {
@@ -621,7 +616,6 @@ public class TestTemporals {
         }
     }
 
-    @DataProvider
     public static Object[][] data_convertAmountInvalid() {
         return new Object[][] {
             {SECONDS, MONTHS},
@@ -641,12 +635,11 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_convertAmountInvalid")
+    @MethodSource("data_convertAmountInvalid")
     public void test_convertAmountInvalid(TemporalUnit fromUnit, TemporalUnit resultUnit) {
         assertThrows(DateTimeException.class, () -> Temporals.convertAmount(1, fromUnit, resultUnit));
     }
 
-    @DataProvider
     public static Object[][] data_convertAmountInvalidUnsupported() {
         return new Object[][] {
             {SECONDS, ERAS},
@@ -665,7 +658,7 @@ public class TestTemporals {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_convertAmountInvalidUnsupported")
+    @MethodSource("data_convertAmountInvalidUnsupported")
     public void test_convertAmountInvalidUnsupported(TemporalUnit fromUnit, TemporalUnit resultUnit) {
         assertThrows(UnsupportedTemporalTypeException.class, () -> Temporals.convertAmount(1, fromUnit, resultUnit));
     }

--- a/src/test/java/org/threeten/extra/TestWeeks.java
+++ b/src/test/java/org/threeten/extra/TestWeeks.java
@@ -54,9 +54,7 @@ import java.time.temporal.TemporalAmount;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -170,7 +168,6 @@ public class TestWeeks {
         assertEquals(Weeks.of(2), Weeks.parse("-P-2W"));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3Y"},
@@ -188,7 +185,7 @@ public class TestWeeks {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Weeks.parse(str));
     }

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -112,16 +112,13 @@ import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestYearWeek {
 
     private static final YearWeek TEST_NON_LEAP = YearWeek.of(2014, 1);
     private static final YearWeek TEST = YearWeek.of(2015, 1);
 
-    @DataProvider
     public static Object[][] data_sampleYearWeeks() {
         return new Object[][]{
             {2015, 1},
@@ -183,7 +180,6 @@ public class TestYearWeek {
         };
     }
 
-    @DataProvider
     public static Object[][] data_53WeekYear() {
         return new Object[][]{
             {4},
@@ -260,7 +256,6 @@ public class TestYearWeek {
         };
     }
 
-    @DataProvider
     public static Object[][] data_sampleAtDay() {
         return new Object[][]{
             {2014, 52, MONDAY,    2014, 12, 22},
@@ -293,7 +288,6 @@ public class TestYearWeek {
         };
     }
 
-    @DataProvider
     public static Object[][] data_outOfBounds() {
     	return new Object[][] {
     		{IsoFields.WEEK_OF_WEEK_BASED_YEAR, 54},
@@ -385,7 +379,7 @@ public class TestYearWeek {
     // of(Year, int)
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleYearWeeks")
+    @MethodSource("data_sampleYearWeeks")
     public void test_of_Year_int(int year, int week) {
         YearWeek yearWeek = YearWeek.of(Year.of(year), week);
         assertEquals(year, yearWeek.getYear());
@@ -401,7 +395,7 @@ public class TestYearWeek {
     // of(int, int)
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleYearWeeks")
+    @MethodSource("data_sampleYearWeeks")
     public void test_of(int year, int week) {
         YearWeek yearWeek = YearWeek.of(year, week);
         assertEquals(year, yearWeek.getYear());
@@ -479,7 +473,7 @@ public class TestYearWeek {
     // atDay(DayOfWeek)
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleAtDay")
+    @MethodSource("data_sampleAtDay")
     public void test_atDay(int weekBasedYear, int weekOfWeekBasedYear, DayOfWeek dayOfWeek, int year, int month, int dayOfMonth) {
         YearWeek yearWeek = YearWeek.of(weekBasedYear, weekOfWeekBasedYear);
         LocalDate expected = LocalDate.of(year, month, dayOfMonth);
@@ -511,7 +505,7 @@ public class TestYearWeek {
     // is53WeekYear()
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_53WeekYear")
+    @MethodSource("data_53WeekYear")
     public void test_is53WeekYear(int year) {
         YearWeek yearWeek = YearWeek.of(year, 1);
         assertTrue(yearWeek.is53WeekYear());
@@ -581,7 +575,7 @@ public class TestYearWeek {
     // from(TemporalAccessor)
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleAtDay")
+    @MethodSource("data_sampleAtDay")
     public void test_from(int weekBasedYear, int weekOfWeekBasedYear, DayOfWeek dayOfWeek, int year, int month, int dayOfMonth) {
         YearWeek expected = YearWeek.of(weekBasedYear, weekOfWeekBasedYear);
         LocalDate ld = LocalDate.of(year, month, dayOfMonth);
@@ -657,7 +651,7 @@ public class TestYearWeek {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_outOfBounds")
+    @MethodSource("data_outOfBounds")
     public void test_with_outOfBounds(TemporalField field, long newValue) {
         assertThrows(DateTimeException.class, () -> TEST.with(field, newValue));
     }
@@ -1055,7 +1049,7 @@ public class TestYearWeek {
     // equals() / hashCode()
     //-----------------------------------------------------------------------
     @ParameterizedTest
-    @UseDataProvider("data_sampleYearWeeks")
+    @MethodSource("data_sampleYearWeeks")
     public void test_equalsAndHashCodeContract(int year, int week) {
         YearWeek a = YearWeek.of(year, week);
         YearWeek b = YearWeek.of(year, week);
@@ -1086,7 +1080,6 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_sampleToString() {
         return new Object[][]{
             {2015, 1, "2015-W01"},
@@ -1098,7 +1091,7 @@ public class TestYearWeek {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_sampleToString")
+    @MethodSource("data_sampleToString")
     public void test_toString(int year, int week, String expected) {
         YearWeek yearWeek = YearWeek.of(year, week);
         String s = yearWeek.toString();

--- a/src/test/java/org/threeten/extra/TestYears.java
+++ b/src/test/java/org/threeten/extra/TestYears.java
@@ -54,9 +54,7 @@ import java.time.temporal.TemporalAmount;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test class.
@@ -175,7 +173,6 @@ public class TestYears {
         assertEquals(Years.of(2), Years.parse("-P-2Y"));
     }
 
-    @DataProvider
     public static Object[][] data_invalid() {
         return new Object[][] {
             {"P3M"},
@@ -193,7 +190,7 @@ public class TestYears {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_invalid")
+    @MethodSource("data_invalid")
     public void test_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> Years.parse(str));
     }

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
@@ -77,9 +77,7 @@ import java.util.function.IntPredicate;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -105,7 +103,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {INSTANCE.date(1, 1, 1), LocalDate.of(0, 9, 4)},
@@ -142,55 +139,55 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_AccountingDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso, LocalDate.from(accounting));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_AccountingDate_from_LocalDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(accounting, AccountingDate.from(INSTANCE, iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_AccountingDate_chronology_dateEpochDay(AccountingDate accounting, LocalDate iso) {
         assertEquals(accounting, INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_AccountingDate_toEpochDay(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso.toEpochDay(), accounting.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_AccountingDate_until_CoptiDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(INSTANCE.period(0, 0, 0), accounting.until(accounting));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_AccountingDate_until_LocalDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(INSTANCE.period(0, 0, 0), accounting.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_CoptiDate(AccountingDate accounting, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(accounting));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(AccountingDate accounting, LocalDate iso) {
         assertEquals(accounting, INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso, LocalDate.from(accounting.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(accounting.plus(1, DAYS)));
@@ -200,7 +197,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(AccountingDate accounting, LocalDate iso) {
         assertEquals(iso, LocalDate.from(accounting.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(accounting.minus(1, DAYS)));
@@ -210,7 +207,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(AccountingDate accounting, LocalDate iso) {
         assertEquals(0, accounting.until(iso.plusDays(0), DAYS));
         assertEquals(1, accounting.until(iso.plusDays(1), DAYS));
@@ -218,7 +215,6 @@ public class TestAccountingChronology {
         assertEquals(-40, accounting.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {2012, 0, 0},
@@ -262,7 +258,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> INSTANCE.date(year, month, dom));
     }
@@ -338,7 +334,6 @@ public class TestAccountingChronology {
         assertEquals(false, INSTANCE.isLeapYear(-6));
     }
 
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {2012, 1, 28},
@@ -363,7 +358,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, INSTANCE.date(year, month, 1).lengthOfMonth());
     }
@@ -450,7 +445,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // AccountingDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             {2012, 1, 23, DAY_OF_MONTH, 1, 28},
@@ -478,7 +472,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), INSTANCE.date(year, month, dom).range(field));
     }
@@ -491,7 +485,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // AccountingDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 5},
@@ -513,7 +506,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, INSTANCE.date(year, month, dom).getLong(field));
     }
@@ -526,7 +519,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // AccountingDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 3, 2014, 5, 24},
@@ -565,7 +557,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -630,7 +622,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // AccountingDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -659,7 +650,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -667,7 +658,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -683,7 +674,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // AccountingDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -713,7 +703,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -784,7 +774,6 @@ public class TestAccountingChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {INSTANCE.date(1, 1, 1), "Accounting calendar ends on SUNDAY nearest end of AUGUST, year divided in THIRTEEN_EVEN_MONTHS_OF_4_WEEKS with leap-week in month 13 CE 1-01-01"},
@@ -793,7 +782,7 @@ public class TestAccountingChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(AccountingDate accounting, String expected) {
         assertEquals(expected, accounting.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
@@ -46,9 +46,7 @@ import java.util.function.IntFunction;
 import java.util.function.IntPredicate;
 
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -58,7 +56,6 @@ public class TestAccountingChronologyBuilder {
     //-----------------------------------------------------------------------
     // isLeapYear(), date(int, int, int)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_yearEnding() {
         return new Object[][] {
             {DayOfWeek.MONDAY, Month.JANUARY},
@@ -84,7 +81,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_isLeapYear_inLastWeekOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -105,7 +102,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_isLeapYear_nearestEndOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -126,7 +123,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_previousLeapYears_inLastWeekOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -156,7 +153,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_previousLeapYears_nearestEndOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -186,7 +183,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_date_int_int_int_inLastWeekOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -202,7 +199,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_date_int_int_int_nearestEndOf(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -220,7 +217,6 @@ public class TestAccountingChronologyBuilder {
     //-----------------------------------------------------------------------
     // range(MONTH_OF_YEAR), range(DAY_OF_MONTH)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_range() {
         return new Object[][] {
             {AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS, 1,
@@ -268,7 +264,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_range")
+    @MethodSource("data_range")
     public void test_range(AccountingYearDivision division, int leapWeekInMonth,
             ValueRange expectedWeekOfMonthRange, ValueRange expectedDayOfMonthRange, ValueRange expectedMonthRange, ValueRange expectedProlepticMonthRange) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
@@ -283,7 +279,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_date_dayOfMonth_range(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
@@ -298,7 +294,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_date_dayOfYear_inLastWeekOf_range(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -319,7 +315,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_yearEnding")
+    @MethodSource("data_yearEnding")
     public void test_date_dayOfYear_nearestEndOf_range(DayOfWeek dayOfWeek, Month ending) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS).leapWeekInMonth(12)
@@ -340,10 +336,9 @@ public class TestAccountingChronologyBuilder {
     }
 
     //-----------------------------------------------------------------------
-    // getWeeksInMonth(month), 
+    // getWeeksInMonth(month),
     // getWeeksAtStartOfMonth(weeks), getMonthFromElapsedWeeks(weeks)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_weeksInMonth() {
         return new Object[][] {
             {AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS, new int[] {4, 4, 5, 4, 4, 5, 4, 4, 5, 4, 4, 5}, 1},
@@ -372,7 +367,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_getWeeksInMonth(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
@@ -385,7 +380,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_getWeeksAtStartOf(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
@@ -398,7 +393,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_getMonthFromElapsedWeeks(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         AccountingChronology chronology = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
@@ -416,14 +411,14 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_negativeWeeks_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         assertEquals(1, division.getMonthFromElapsedWeeks(0));
         assertThrows(DateTimeException.class, () -> division.getMonthFromElapsedWeeks(-1));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_extraWeeks_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         int elapsedWeeks = 0;
         for (int month = 1; month <= weeksInMonth.length; month++) {
@@ -435,7 +430,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_weeksInMonth")
+    @MethodSource("data_weeksInMonth")
     public void test_extraWeeksLeap_getMonthFromElapsedWeekspublic(AccountingYearDivision division, int[] weeksInMonth, int leapWeekInMonth) {
         int elapsedWeeks = 1;
         for (int month = 1; month <= weeksInMonth.length; month++) {
@@ -449,7 +444,6 @@ public class TestAccountingChronologyBuilder {
     //-----------------------------------------------------------------------
     // toChronology() failures.
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_badChronology() {
         return new Object[][] {
             {DayOfWeek.MONDAY, Month.JANUARY, AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS, 0},
@@ -466,7 +460,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badChronology")
+    @MethodSource("data_badChronology")
     public void test_badChronology_nearestEndOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
         assertThrows(IllegalStateException.class, () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)
@@ -474,7 +468,7 @@ public class TestAccountingChronologyBuilder {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badChronology")
+    @MethodSource("data_badChronology")
     public void test_badChronology_inLastWeekOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
         assertThrows(IllegalStateException.class, () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                 .withDivision(division).leapWeekInMonth(leapWeekInMonth)

--- a/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
@@ -87,9 +87,7 @@ import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -111,7 +109,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {BritishCutoverDate.of(1, 1, 1), LocalDate.of(0, 12, 30)},
@@ -157,55 +154,55 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso, LocalDate.from(cutover));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_BritishCutoverDate_from_LocalDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(cutover, BritishCutoverDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_BritishCutoverDate_chronology_dateEpochDay(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(cutover, BritishCutoverChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_BritishCutoverDate_toEpochDay(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso.toEpochDay(), cutover.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_BritishCutoverDate_until_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(BritishCutoverChronology.INSTANCE.period(0, 0, 0), cutover.until(cutover));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_BritishCutoverDate_until_LocalDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(BritishCutoverChronology.INSTANCE.period(0, 0, 0), cutover.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_BritishCutoverDate(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(cutover));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(cutover, BritishCutoverChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso, LocalDate.from(cutover.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(cutover.plus(1, DAYS)));
@@ -215,7 +212,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(iso, LocalDate.from(cutover.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(cutover.minus(1, DAYS)));
@@ -225,7 +222,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(BritishCutoverDate cutover, LocalDate iso) {
         assertEquals(0, cutover.until(iso.plusDays(0), DAYS));
         assertEquals(1, cutover.until(iso.plusDays(1), DAYS));
@@ -233,7 +230,6 @@ public class TestBritishCutoverChronology {
         assertEquals(-40, cutover.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {1900, 0, 0},
@@ -277,7 +273,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> BritishCutoverDate.of(year, month, dom));
     }
@@ -329,7 +325,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // lengthOfMonth()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {1700, 1, 31},
@@ -399,7 +394,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, BritishCutoverDate.of(year, month, 1).lengthOfMonth());
     }
@@ -407,7 +402,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // lengthOfYear()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_lengthOfYear() {
         return new Object[][] {
             {-101, 365},
@@ -440,13 +434,13 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfYear")
+    @MethodSource("data_lengthOfYear")
     public void test_lengthOfYear_atStart(int year, int length) {
         assertEquals(length, BritishCutoverDate.of(year, 1, 1).lengthOfYear());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfYear")
+    @MethodSource("data_lengthOfYear")
     public void test_lengthOfYear_atEnd(int year, int length) {
         assertEquals(length, BritishCutoverDate.of(year, 12, 31).lengthOfYear());
     }
@@ -546,7 +540,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             {1700, 1, 23, DAY_OF_MONTH, 1, 31},
@@ -633,7 +626,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), BritishCutoverDate.of(year, month, dom).range(field));
     }
@@ -646,7 +639,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {1752, 5, 26, DAY_OF_WEEK, 2},
@@ -695,7 +687,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, BritishCutoverDate.of(year, month, dom).getLong(field));
     }
@@ -708,7 +700,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {1752, 9, 2, DAY_OF_WEEK, 1, 1752, 8, 31},
@@ -807,7 +798,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -822,7 +813,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.with(TemporalAdjuster)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_lastDayOfMonth() {
         return new Object[][] {
             {BritishCutoverDate.of(1752, 2, 23), BritishCutoverDate.of(1752, 2, 29)},
@@ -835,7 +825,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lastDayOfMonth")
+    @MethodSource("data_lastDayOfMonth")
     public void test_adjust_lastDayOfMonth(BritishCutoverDate input, BritishCutoverDate expected) {
         BritishCutoverDate test = input.with(TemporalAdjusters.lastDayOfMonth());
         assertEquals(expected, test);
@@ -844,7 +834,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.with(Local*)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_withLocalDate() {
         return new Object[][] {
             {BritishCutoverDate.of(1752, 9, 2), LocalDate.of(1752, 9, 12), BritishCutoverDate.of(1752, 9, 1)},
@@ -856,7 +845,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_withLocalDate")
+    @MethodSource("data_withLocalDate")
     public void test_adjust_LocalDate(BritishCutoverDate input, LocalDate local, BritishCutoverDate expected) {
         BritishCutoverDate test = input.with(local);
         assertEquals(expected, test);
@@ -888,7 +877,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {1752, 9, 2, -1, DAYS, 1752, 9, 1, true},
@@ -941,7 +929,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom, boolean bidi) {
@@ -949,7 +937,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -967,7 +955,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // BritishCutoverDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {1752, 9, 1, 1752, 9, 2, DAYS, 1},
@@ -1021,7 +1008,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -1073,7 +1060,6 @@ public class TestBritishCutoverChronology {
     }
 
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_untilCLD() {
         return new Object[][] {
             {1752, 7, 2, 1752, 7, 1, 0, 0, -1},
@@ -1175,7 +1161,7 @@ public class TestBritishCutoverChronology {
             {1752, 9, 14, 1752, 10, 13, 0, 0, 29},
             {1752, 9, 14, 1752, 10, 14, 0, 1, 0},
             {1752, 9, 14, 1752, 10, 15, 0, 1, 1},
-            
+
             {1752, 9, 24, 1752, 7, 23, 0, -2, -1},
             {1752, 9, 24, 1752, 7, 24, 0, -2, 0},
             {1752, 9, 24, 1752, 8, 23, 0, -1, -1},
@@ -1192,7 +1178,7 @@ public class TestBritishCutoverChronology {
             {1752, 9, 24, 1752, 10, 23, 0, 0, 29},
             {1752, 9, 24, 1752, 10, 24, 0, 1, 0},
             {1752, 9, 24, 1752, 10, 25, 0, 1, 1},
-            
+
             {1752, 10, 3, 1752, 10, 1, 0, 0, -2},
             {1752, 10, 3, 1752, 9, 30, 0, 0, -3},
             {1752, 10, 3, 1752, 9, 16, 0, 0, -17},
@@ -1204,7 +1190,7 @@ public class TestBritishCutoverChronology {
             {1752, 10, 3, 1752, 8, 4, 0, -1, -30},
             {1752, 10, 3, 1752, 8, 3, 0, -2, 0},
             {1752, 10, 3, 1752, 8, 2, 0, -2, -1},
-            
+
             {1752, 10, 4, 1752, 10, 1, 0, 0, -3},
             {1752, 10, 4, 1752, 9, 30, 0, 0, -4},
             {1752, 10, 4, 1752, 9, 16, 0, 0, -18},
@@ -1220,7 +1206,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_untilCLD")
+    @MethodSource("data_untilCLD")
     public void test_until_CLD(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -1234,7 +1220,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_untilCLD")
+    @MethodSource("data_untilCLD")
     public void test_until_CLD_plus(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -1312,7 +1298,6 @@ public class TestBritishCutoverChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {BritishCutoverDate.of(1, 1, 1), "BritishCutover AD 1-01-01"},
@@ -1321,7 +1306,7 @@ public class TestBritishCutoverChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(BritishCutoverDate cutover, String expected) {
         assertEquals(expected, cutover.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
@@ -76,9 +76,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -109,7 +107,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {CopticDate.of(-1, 13, 6), LocalDate.of(283, 8, 29)},
@@ -138,55 +135,55 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_CopticDate(CopticDate coptic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(coptic));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_CopticDate_from_LocalDate(CopticDate coptic, LocalDate iso) {
         assertEquals(coptic, CopticDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_CopticDate_chronology_dateEpochDay(CopticDate coptic, LocalDate iso) {
         assertEquals(coptic, CopticChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_CopticDate_toEpochDay(CopticDate coptic, LocalDate iso) {
         assertEquals(iso.toEpochDay(), coptic.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_CopticDate_until_CopticDate(CopticDate coptic, LocalDate iso) {
         assertEquals(CopticChronology.INSTANCE.period(0, 0, 0), coptic.until(coptic));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_CopticDate_until_LocalDate(CopticDate coptic, LocalDate iso) {
         assertEquals(CopticChronology.INSTANCE.period(0, 0, 0), coptic.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_CopticDate(CopticDate coptic, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(coptic));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(CopticDate coptic, LocalDate iso) {
         assertEquals(coptic, CopticChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(CopticDate coptic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(coptic.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(coptic.plus(1, DAYS)));
@@ -196,7 +193,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(CopticDate coptic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(coptic.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(coptic.minus(1, DAYS)));
@@ -206,7 +203,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(CopticDate coptic, LocalDate iso) {
         assertEquals(0, coptic.until(iso.plusDays(0), DAYS));
         assertEquals(1, coptic.until(iso.plusDays(1), DAYS));
@@ -214,7 +211,6 @@ public class TestCopticChronology {
         assertEquals(-40, coptic.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {1728, 0, 0},
@@ -247,7 +243,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> CopticDate.of(year, month, dom));
     }
@@ -288,7 +284,6 @@ public class TestCopticChronology {
         assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-6));
     }
 
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {1726, 1, 30},
@@ -309,7 +304,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, CopticDate.of(year, month, 1).lengthOfMonth());
     }
@@ -390,7 +385,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // CopticDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             {1727, 1, 23, DAY_OF_MONTH, 1, 30},
@@ -420,7 +414,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), CopticDate.of(year, month, dom).range(field));
     }
@@ -433,7 +427,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // CopticDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {1727, 6, 8, DAY_OF_WEEK, 2},
@@ -455,7 +448,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, CopticDate.of(year, month, dom).getLong(field));
     }
@@ -468,7 +461,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // CopticDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {1727, 6, 8, DAY_OF_WEEK, 4, 1727, 6, 10},
@@ -505,7 +497,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -570,7 +562,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // CopticDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {1726, 5, 26, 0, DAYS, 1726, 5, 26},
@@ -599,7 +590,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -607,7 +598,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -644,7 +635,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // CopticDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {1726, 5, 26, 1726, 5, 26, DAYS, 0},
@@ -672,7 +662,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -715,7 +705,6 @@ public class TestCopticChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {CopticDate.of(1, 1, 1), "Coptic AM 1-01-01"},
@@ -727,7 +716,7 @@ public class TestCopticChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(CopticDate coptic, String expected) {
         assertEquals(expected, coptic.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
@@ -79,9 +79,7 @@ import java.util.function.IntPredicate;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -112,7 +110,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {DiscordianDate.of(2, 1, 1), LocalDate.of(-1164, 1, 1)},
@@ -154,55 +151,55 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(discordian));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_DiscordianDate_from_LocalDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(discordian, DiscordianDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_DiscordianDate_chronology_dateEpochDay(DiscordianDate discordian, LocalDate iso) {
         assertEquals(discordian, DiscordianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_DiscordianDate_toEpochDay(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso.toEpochDay(), discordian.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_DiscordianDate_until_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(DiscordianChronology.INSTANCE.period(0, 0, 0), discordian.until(discordian));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_DiscordianDate_until_LocalDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(DiscordianChronology.INSTANCE.period(0, 0, 0), discordian.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_DiscordianDate(DiscordianDate discordian, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(discordian));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(DiscordianDate discordian, LocalDate iso) {
         assertEquals(discordian, DiscordianChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(discordian.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(discordian.plus(1, DAYS)));
@@ -212,7 +209,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(DiscordianDate discordian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(discordian.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(discordian.minus(1, DAYS)));
@@ -222,7 +219,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(DiscordianDate discordian, LocalDate iso) {
         assertEquals(0, discordian.until(iso.plusDays(0), DAYS));
         assertEquals(1, discordian.until(iso.plusDays(1), DAYS));
@@ -230,7 +227,6 @@ public class TestDiscordianChronology {
         assertEquals(-40, discordian.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {1900, 0, 0},
@@ -257,7 +253,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> DiscordianDate.of(year, month, dom));
     }
@@ -302,7 +298,6 @@ public class TestDiscordianChronology {
         assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1160));
     }
 
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {1900, 1, 73},
@@ -321,7 +316,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, DiscordianDate.of(year, month, 1).lengthOfMonth());
     }
@@ -414,7 +409,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // DiscordianDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             // St Tibs is in its own month, so (0 to 0) or (1 to 73)
@@ -457,7 +451,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), DiscordianDate.of(year, month, dom).range(field));
     }
@@ -470,7 +464,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // DiscordianDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 1, 26, DAY_OF_WEEK, 1},
@@ -511,7 +504,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, DiscordianDate.of(year, month, dom).getLong(field));
     }
@@ -524,7 +517,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // DiscordianDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 1, 2014, 5, 24},
@@ -600,14 +592,13 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(DiscordianDate.of(expectedYear, expectedMonth, expectedDom), DiscordianDate.of(year, month, dom).with(field, value));
     }
 
-    @DataProvider
     public static Object[][] data_with_bad() {
         return new Object[][] {
             {2013, 1, 1, DAY_OF_WEEK, 0},
@@ -633,7 +624,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with_bad")
+    @MethodSource("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
         assertThrows(DateTimeException.class, () -> DiscordianDate.of(year, month, dom).with(field, value));
     }
@@ -696,7 +687,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // DiscordianDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -723,7 +713,6 @@ public class TestDiscordianChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_plus_leap() {
         return new Object[][] {
             {2014, 0, 0, 0, DAYS, 2014, 0, 0},
@@ -744,7 +733,6 @@ public class TestDiscordianChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_minus_leap() {
         return new Object[][] {
             {2014, 0, 0, 0, DAYS, 2014, 0, 0},
@@ -766,7 +754,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -774,7 +762,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leap")
+    @MethodSource("data_plus_leap")
     public void test_plus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -782,7 +770,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -791,7 +779,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_minus_leap")
+    @MethodSource("data_minus_leap")
     public void test_minus_leap_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -807,7 +795,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // DiscordianDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -873,7 +860,6 @@ public class TestDiscordianChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_until_period() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, 0, 0, 0},
@@ -920,7 +906,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -931,7 +917,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until_period")
+    @MethodSource("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -996,7 +982,6 @@ public class TestDiscordianChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {DiscordianDate.of(1, 1, 1), "Discordian YOLD 1-1-01"},
@@ -1006,7 +991,7 @@ public class TestDiscordianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(DiscordianDate discordian, String expected) {
         assertEquals(expected, discordian.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
@@ -76,9 +76,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -109,7 +107,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {EthiopicDate.of(-1, 13, 6), LocalDate.of(7, 8, 27)},
@@ -139,55 +136,55 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(ethiopic));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_EthiopicDate_from_LocalDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(ethiopic, EthiopicDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_EthiopicDate_chronology_dateEpochDay(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(ethiopic, EthiopicChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_EthiopicDate_toEpochDay(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso.toEpochDay(), ethiopic.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_EthiopicDate_until_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(EthiopicChronology.INSTANCE.period(0, 0, 0), ethiopic.until(ethiopic));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_EthiopicDate_until_LocalDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(EthiopicChronology.INSTANCE.period(0, 0, 0), ethiopic.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_EthiopicDate(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(ethiopic));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(ethiopic, EthiopicChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(ethiopic.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(ethiopic.plus(1, DAYS)));
@@ -197,7 +194,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(iso, LocalDate.from(ethiopic.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(ethiopic.minus(1, DAYS)));
@@ -207,7 +204,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(EthiopicDate ethiopic, LocalDate iso) {
         assertEquals(0, ethiopic.until(iso.plusDays(0), DAYS));
         assertEquals(1, ethiopic.until(iso.plusDays(1), DAYS));
@@ -215,7 +212,6 @@ public class TestEthiopicChronology {
         assertEquals(-40, ethiopic.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {2008, 0, 0},
@@ -248,7 +244,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> EthiopicDate.of(year, month, dom));
     }
@@ -289,7 +285,6 @@ public class TestEthiopicChronology {
         assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-6));
     }
 
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {2006, 1, 30},
@@ -310,7 +305,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, EthiopicDate.of(year, month, 1).lengthOfMonth());
     }
@@ -391,7 +386,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // EthiopicDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             {2007, 1, 23, DAY_OF_MONTH, 1, 30},
@@ -421,7 +415,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), EthiopicDate.of(year, month, dom).range(field));
     }
@@ -434,7 +428,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // EthiopicDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2007, 6, 8, DAY_OF_WEEK, 7},
@@ -456,7 +449,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, EthiopicDate.of(year, month, dom).getLong(field));
     }
@@ -469,7 +462,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // EthiopicDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2007, 6, 8, DAY_OF_WEEK, 3, 2007, 6, 4},
@@ -509,14 +501,13 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(EthiopicDate.of(expectedYear, expectedMonth, expectedDom), EthiopicDate.of(year, month, dom).with(field, value));
     }
 
-    @DataProvider
     public static Object[][] data_with_bad() {
         return new Object[][] {
             {2007, 6, 8, DAY_OF_WEEK, 0},
@@ -532,7 +523,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with_bad")
+    @MethodSource("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
         assertThrows(DateTimeException.class, () -> EthiopicDate.of(year, month, dom).with(field, value));
     }
@@ -595,7 +586,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // EthiopicDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2006, 5, 26, 0, DAYS, 2006, 5, 26},
@@ -624,7 +614,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -632,7 +622,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -669,7 +659,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // EthiopicDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2006, 5, 26, 2006, 5, 26, DAYS, 0},
@@ -697,7 +686,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -740,7 +729,6 @@ public class TestEthiopicChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {EthiopicDate.of(1, 1, 1), "Ethiopic INCARNATION 1-01-01"},
@@ -752,7 +740,7 @@ public class TestEthiopicChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(EthiopicDate ethiopic, String expected) {
         assertEquals(expected, ethiopic.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -79,9 +79,7 @@ import java.util.function.IntPredicate;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -104,7 +102,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {InternationalFixedDate.of(1, 1, 1), LocalDate.of(1, 1, 1)},
@@ -152,55 +149,55 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso, LocalDate.from(fixed));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_InternationalFixedDate_from_LocalDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(fixed, InternationalFixedDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_InternationalFixedDate_chronology_dateEpochDay(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(fixed, InternationalFixedChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_InternationalFixedDate_toEpochDay(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso.toEpochDay(), fixed.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_InternationalFixedDate_until_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(InternationalFixedChronology.INSTANCE.period(0, 0, 0), fixed.until(fixed));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_InternationalFixedDate_until_LocalDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(InternationalFixedChronology.INSTANCE.period(0, 0, 0), fixed.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_InternationalFixedDate(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(fixed));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(fixed, InternationalFixedChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso, LocalDate.from(fixed.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(fixed.plus(1, DAYS)));
@@ -212,7 +209,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(iso, LocalDate.from(fixed.minus(0, DAYS)));
         if (LocalDate.ofYearDay(1, 35).isBefore(iso)) {
@@ -225,7 +222,7 @@ public class TestInternationalFixedChronology {
 
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(InternationalFixedDate fixed, LocalDate iso) {
         assertEquals(0, fixed.until(iso.plusDays(0), DAYS));
         assertEquals(1, fixed.until(iso.plusDays(1), DAYS));
@@ -235,7 +232,6 @@ public class TestInternationalFixedChronology {
         }
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {-1, 13, 28},
@@ -277,12 +273,11 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(year, month, dom));
     }
 
-    @DataProvider
     public static Object[][] data_badLeapDates() {
         return new Object[][] {
             {1},
@@ -294,7 +289,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badLeapDates")
+    @MethodSource("data_badLeapDates")
     public void badLeapDayDates(int year) {
         assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(year, 6, 29));
     }
@@ -334,7 +329,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // lengthOfMonth()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {1900, 1, 28, 28},
@@ -355,13 +349,13 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
         assertEquals(length, InternationalFixedDate.of(year, month, day).lengthOfMonth());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
         assertEquals(length, InternationalFixedDate.of(year, month, 1).lengthOfMonth());
     }
@@ -412,7 +406,6 @@ public class TestInternationalFixedChronology {
         assertEquals(1582, InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, 1582));
     }
 
-    @DataProvider
     public static Object[][] data_prolepticYear_bad() {
         return new Object[][] {
             {-10},
@@ -422,7 +415,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_prolepticYear_bad")
+    @MethodSource("data_prolepticYear_bad")
     public void test_prolepticYearBad(int year) {
         assertThrows(DateTimeException.class, () -> InternationalFixedChronology.INSTANCE.prolepticYear(InternationalFixedEra.CE, year));
     }
@@ -472,7 +465,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // InternationalFixedDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             // Leap Day and Year Day are members of months
@@ -533,7 +525,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
         assertEquals(range, InternationalFixedDate.of(year, month, dom).range(field));
     }
@@ -546,7 +538,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // InternationalFixedDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 5},
@@ -615,7 +606,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, InternationalFixedDate.of(year, month, dom).getLong(field));
     }
@@ -628,7 +619,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // InternationalFixedDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 1, 2014, 5, 22},
@@ -763,14 +753,13 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(InternationalFixedDate.of(expectedYear, expectedMonth, expectedDom), InternationalFixedDate.of(year, month, dom).with(field, value));
     }
 
-    @DataProvider
     public static Object[][] data_with_bad() {
         return new Object[][] {
             {2013, 1, 1, ALIGNED_DAY_OF_WEEK_IN_MONTH, 0},
@@ -830,7 +819,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with_bad")
+    @MethodSource("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
         assertThrows(DateTimeException.class, () -> InternationalFixedDate.of(year, month, dom).with(field, value));
     }
@@ -843,7 +832,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // InternationalFixedDate.with(TemporalAdjuster)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_temporalAdjusters_lastDayOfMonth() {
         return new Object[][] {
             {2012, 6, 23, 2012, 6, 29},
@@ -855,7 +843,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_temporalAdjusters_lastDayOfMonth")
+    @MethodSource("data_temporalAdjusters_lastDayOfMonth")
     public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
         InternationalFixedDate base = InternationalFixedDate.of(year, month, day);
         InternationalFixedDate expected = InternationalFixedDate.of(expectedYear, expectedMonth, expectedDay);
@@ -900,7 +888,6 @@ public class TestInternationalFixedChronology {
     // InternationalFixedDate.plus
     // InternationalFixedDate.minus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -936,7 +923,6 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_plus_leap_and_year_day() {
         return new Object[][] {
             {2014, 13, 29, 0, DAYS, 2014, 13, 29},
@@ -978,7 +964,6 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_minus_leap_and_year_day() {
         return new Object[][] {
             {2014, 13, 29, 0, DAYS, 2014, 13, 29},
@@ -1022,7 +1007,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -1030,7 +1015,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leap_and_year_day")
+    @MethodSource("data_plus_leap_and_year_day")
     public void test_plus_leap_and_year_day_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -1038,7 +1023,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -1047,7 +1032,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_minus_leap_and_year_day")
+    @MethodSource("data_minus_leap_and_year_day")
     public void test_minus_leap_and_year_day_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -1063,7 +1048,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // InternationalFixedDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -1195,7 +1179,6 @@ public class TestInternationalFixedChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_until_period() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, 0, 0, 0},
@@ -1272,7 +1255,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -1283,7 +1266,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until_period")
+    @MethodSource("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -1327,7 +1310,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // equals()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_equals() {
         return new Object[][] {
             {InternationalFixedDate.of(2000, 1, 3),
@@ -1340,7 +1322,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_equals")
+    @MethodSource("data_equals")
     public void test_equals(InternationalFixedDate a1, InternationalFixedDate b, InternationalFixedDate c,
                                     InternationalFixedDate d) {
         assertTrue(a1.equals(a1));
@@ -1355,7 +1337,6 @@ public class TestInternationalFixedChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {InternationalFixedDate.of(1, 1, 1), "Ifc CE 1/01/01"},
@@ -1368,7 +1349,7 @@ public class TestInternationalFixedChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(InternationalFixedDate date, String expected) {
         assertEquals(expected, date.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
@@ -77,9 +77,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -110,7 +108,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {JulianDate.of(1, 1, 1), LocalDate.of(0, 12, 30)},
@@ -147,55 +144,55 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_JulianDate(JulianDate julian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(julian));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_JulianDate_from_LocalDate(JulianDate julian, LocalDate iso) {
         assertEquals(julian, JulianDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_JulianDate_chronology_dateEpochDay(JulianDate julian, LocalDate iso) {
         assertEquals(julian, JulianChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_JulianDate_toEpochDay(JulianDate julian, LocalDate iso) {
         assertEquals(iso.toEpochDay(), julian.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_JulianDate_until_JulianDate(JulianDate julian, LocalDate iso) {
         assertEquals(JulianChronology.INSTANCE.period(0, 0, 0), julian.until(julian));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_JulianDate_until_LocalDate(JulianDate julian, LocalDate iso) {
         assertEquals(JulianChronology.INSTANCE.period(0, 0, 0), julian.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_JulianDate(JulianDate julian, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(julian));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(JulianDate julian, LocalDate iso) {
         assertEquals(julian, JulianChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(JulianDate julian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(julian.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(julian.plus(1, DAYS)));
@@ -205,7 +202,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(JulianDate julian, LocalDate iso) {
         assertEquals(iso, LocalDate.from(julian.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(julian.minus(1, DAYS)));
@@ -215,7 +212,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(JulianDate julian, LocalDate iso) {
         assertEquals(0, julian.until(iso.plusDays(0), DAYS));
         assertEquals(1, julian.until(iso.plusDays(1), DAYS));
@@ -223,7 +220,6 @@ public class TestJulianChronology {
         assertEquals(-40, julian.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {1900, 0, 0},
@@ -267,7 +263,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> JulianDate.of(year, month, dom));
     }
@@ -308,7 +304,6 @@ public class TestJulianChronology {
         assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-6));
     }
 
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {1900, 1, 31},
@@ -334,7 +329,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, JulianDate.of(year, month, 1).lengthOfMonth());
     }
@@ -420,7 +415,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // JulianDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             {2012, 1, 23, DAY_OF_MONTH, 1, 31},
@@ -447,7 +441,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), JulianDate.of(year, month, dom).range(field));
     }
@@ -460,7 +454,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // JulianDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 7},
@@ -482,7 +475,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, JulianDate.of(year, month, dom).getLong(field));
     }
@@ -495,7 +488,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // JulianDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 3, 2014, 5, 22},
@@ -533,7 +525,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -598,7 +590,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // JulianDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -627,7 +618,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -635,7 +626,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -651,7 +642,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // JulianDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -681,7 +671,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -745,7 +735,6 @@ public class TestJulianChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {JulianDate.of(1, 1, 1), "Julian AD 1-01-01"},
@@ -754,7 +743,7 @@ public class TestJulianChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(JulianDate julian, String expected) {
         assertEquals(expected, julian.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
@@ -79,9 +79,7 @@ import java.util.function.IntPredicate;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -113,7 +111,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // creation, toLocalDate()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             {PaxDate.of(1, 1, 1), LocalDate.of(0, 12, 31)},
@@ -179,55 +176,55 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_PaxDate(PaxDate pax, LocalDate iso) {
         assertEquals(iso, LocalDate.from(pax));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_PaxDate_from_LocalDate(PaxDate pax, LocalDate iso) {
         assertEquals(pax, PaxDate.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_PaxDate_chronology_dateEpochDay(PaxDate pax, LocalDate iso) {
         assertEquals(pax, PaxChronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_PaxDate_toEpochDay(PaxDate pax, LocalDate iso) {
         assertEquals(iso.toEpochDay(), pax.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_PaxDate_until_PaxDate(PaxDate pax, LocalDate iso) {
         assertEquals(PaxChronology.INSTANCE.period(0, 0, 0), pax.until(pax));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_PaxDate_until_LocalDate(PaxDate pax, LocalDate iso) {
         assertEquals(PaxChronology.INSTANCE.period(0, 0, 0), pax.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_PaxDate(PaxDate pax, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(pax));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(PaxDate pax, LocalDate iso) {
         assertEquals(pax, PaxChronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(PaxDate pax, LocalDate iso) {
         assertEquals(iso, LocalDate.from(pax.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(pax.plus(1, DAYS)));
@@ -237,7 +234,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(PaxDate pax, LocalDate iso) {
         assertEquals(iso, LocalDate.from(pax.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(pax.minus(1, DAYS)));
@@ -247,7 +244,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(PaxDate pax, LocalDate iso) {
         assertEquals(0, pax.until(iso.plusDays(0), DAYS));
         assertEquals(1, pax.until(iso.plusDays(1), DAYS));
@@ -255,7 +252,6 @@ public class TestPaxChronology {
         assertEquals(-40, pax.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {1900, 0, 0},
@@ -303,7 +299,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> PaxDate.of(year, month, dom));
     }
@@ -353,7 +349,6 @@ public class TestPaxChronology {
         assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-400));
     }
 
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {1900, 1, 28},
@@ -383,7 +378,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int length) {
         assertEquals(length, PaxDate.of(year, month, 1).lengthOfMonth());
     }
@@ -469,7 +464,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // PaxDate.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             {2012, 1, 23, DAY_OF_MONTH, 1, 28},
@@ -502,7 +496,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, int expectedMin, int expectedMax) {
         assertEquals(ValueRange.of(expectedMin, expectedMax), PaxDate.of(year, month, dom).range(field));
     }
@@ -515,7 +509,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // PaxDate.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 4},
@@ -537,7 +530,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, PaxDate.of(year, month, dom).getLong(field));
     }
@@ -550,7 +543,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // PaxDate.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 3, 2014, 5, 25},
@@ -588,7 +580,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -653,7 +645,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // PaxDate.plus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -691,7 +682,6 @@ public class TestPaxChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_plus_leap() {
         return new Object[][] {
             {2012, 12, 26, 1, MONTHS, 2012, 13, 7},
@@ -700,7 +690,6 @@ public class TestPaxChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_minus_leap() {
         return new Object[][] {
             {2012, 13, 7, -1, MONTHS, 2012, 12, 26},
@@ -710,7 +699,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -718,7 +707,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leap")
+    @MethodSource("data_plus_leap")
     public void test_plus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -726,7 +715,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -735,7 +724,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_minus_leap")
+    @MethodSource("data_minus_leap")
     public void test_minus_leap_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -750,7 +739,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // PaxDate.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -792,7 +780,6 @@ public class TestPaxChronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_until_period() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, 0, 0, 0},
@@ -821,7 +808,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -832,7 +819,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until_period")
+    @MethodSource("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -897,7 +884,6 @@ public class TestPaxChronology {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {PaxDate.of(1, 1, 1), "Pax CE 1-01-01"},
@@ -906,7 +892,7 @@ public class TestPaxChronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(PaxDate pax, String expected) {
         assertEquals(expected, pax.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
@@ -83,9 +83,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -108,7 +106,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.of
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             { Symmetry010Date.of(   1,  1,  1), LocalDate.of(   1,  1,  1) },
@@ -146,55 +143,55 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym010));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry010Date_from_LocalDate(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(sym010, Symmetry010Date.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry010Date_chronology_dateEpochDay(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(sym010, Symmetry010Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry010Date_toEpochDay(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso.toEpochDay(), sym010.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry010Date_until_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(Symmetry010Chronology.INSTANCE.period(0, 0, 0), sym010.until(sym010));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry010Date_until_LocalDate(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(Symmetry010Chronology.INSTANCE.period(0, 0, 0), sym010.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(sym010, Symmetry010Chronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_Symmetry010Date(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(sym010));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym010.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(sym010.plus(1, DAYS)));
@@ -204,7 +201,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym010.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(sym010.minus(1, DAYS)));
@@ -214,7 +211,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(Symmetry010Date sym010, LocalDate iso) {
         assertEquals(0, sym010.until(iso.plusDays(0), DAYS));
         assertEquals(1, sym010.until(iso.plusDays(1), DAYS));
@@ -222,7 +219,6 @@ public class TestSymmetry010Chronology {
         assertEquals(-40, sym010.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {-1, 13, 28},
@@ -256,12 +252,11 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> Symmetry010Date.of(year, month, dom));
     }
 
-    @DataProvider
     public static Object[][] data_badLeapDates() {
         return new Object[][] {
             {1},
@@ -272,7 +267,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badLeapDates")
+    @MethodSource("data_badLeapDates")
     public void badLeapDayDates(int year) {
         assertThrows(DateTimeException.class, () -> Symmetry010Date.of(year, 12, 37));
     }
@@ -306,7 +301,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.lengthOfMonth
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {2000, 1, 28, 30},
@@ -326,13 +320,13 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
         assertEquals(length, Symmetry010Date.of(year, month, day).lengthOfMonth());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
         assertEquals(length, Symmetry010Date.of(year, month, 1).lengthOfMonth());
     }
@@ -394,7 +388,6 @@ public class TestSymmetry010Chronology {
         assertEquals(1582, Symmetry010Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1582));
     }
 
-    @DataProvider
     public static Object[][] data_prolepticYear_badEra() {
         return new Era[][] {
             { AccountingEra.BCE },
@@ -422,7 +415,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_prolepticYear_badEra")
+    @MethodSource("data_prolepticYear_badEra")
     public void test_prolepticYear_badEra(Era era) {
         assertThrows(ClassCastException.class, () -> Symmetry010Chronology.INSTANCE.prolepticYear(era, 4));
     }
@@ -469,7 +462,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             // Leap Day and Year Day are members of months
@@ -516,7 +508,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
         assertEquals(range, Symmetry010Date.of(year, month, dom).range(field));
     }
@@ -529,7 +521,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 2},
@@ -565,7 +556,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, Symmetry010Date.of(year, month, dom).getLong(field));
     }
@@ -578,7 +569,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 1, 2014, 5, 20},
@@ -655,14 +645,13 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(Symmetry010Date.of(expectedYear, expectedMonth, expectedDom), Symmetry010Date.of(year, month, dom).with(field, value));
     }
 
-    @DataProvider
     public static Object[][] data_with_bad() {
         return new Object[][] {
             {2013,  1,  1, ALIGNED_DAY_OF_WEEK_IN_MONTH, -1},
@@ -702,7 +691,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with_bad")
+    @MethodSource("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
         assertThrows(DateTimeException.class, () -> Symmetry010Date.of(year, month, dom).with(field, value));
     }
@@ -715,7 +704,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.with(TemporalAdjuster)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_temporalAdjusters_lastDayOfMonth() {
         return new Object[][] {
             {2012, 1, 23, 2012, 1, 30},
@@ -735,7 +723,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_temporalAdjusters_lastDayOfMonth")
+    @MethodSource("data_temporalAdjusters_lastDayOfMonth")
     public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
         Symmetry010Date base = Symmetry010Date.of(year, month, day);
         Symmetry010Date expected = Symmetry010Date.of(expectedYear, expectedMonth, expectedDay);
@@ -780,7 +768,6 @@ public class TestSymmetry010Chronology {
     // Symmetry010Date.plus
     // Symmetry010Date.minus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -816,7 +803,6 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_plus_leapWeek() {
         return new Object[][] {
             {2015, 12, 28, 0, DAYS, 2015, 12, 28},
@@ -837,7 +823,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -845,7 +831,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leapWeek")
+    @MethodSource("data_plus_leapWeek")
     public void test_plus_leapWeek_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -853,7 +839,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -862,7 +848,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leapWeek")
+    @MethodSource("data_plus_leapWeek")
     public void test_minus_leapWeek_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -878,7 +864,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -906,7 +891,6 @@ public class TestSymmetry010Chronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_until_period() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, 0,  0,  0},
@@ -922,7 +906,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -933,7 +917,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until_period")
+    @MethodSource("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -979,7 +963,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.equals
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_equals() {
         return new Object[][] {
             {Symmetry010Date.of(2000, 1, 3), Symmetry010Date.of(2000, 1, 4), Symmetry010Date.of(2000, 2, 3), Symmetry010Date.of(2001, 1, 3)},
@@ -989,7 +972,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_equals")
+    @MethodSource("data_equals")
     public void test_equals(Symmetry010Date a1, Symmetry010Date b, Symmetry010Date c, Symmetry010Date d) {
         assertTrue(a1.equals(a1));
         assertFalse(a1.equals(b));
@@ -1003,7 +986,6 @@ public class TestSymmetry010Chronology {
     //-----------------------------------------------------------------------
     // Symmetry010Date.toString
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {Symmetry010Date.of(   1,  1,  1), "Sym010 CE 1/01/01"},
@@ -1014,7 +996,7 @@ public class TestSymmetry010Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(Symmetry010Date date, String expected) {
         assertEquals(expected, date.toString());
     }

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -83,9 +83,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test.
@@ -108,7 +106,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.of
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_samples() {
         return new Object[][] {
             { Symmetry454Date.of(   1,  1,  1), LocalDate.of(   1,  1,  1) },
@@ -146,55 +143,55 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_from_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym454));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry454Date_from_LocalDate(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(sym454, Symmetry454Date.from(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry454Date_chronology_dateEpochDay(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(sym454, Symmetry454Chronology.INSTANCE.dateEpochDay(iso.toEpochDay()));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry454Date_toEpochDay(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso.toEpochDay(), sym454.toEpochDay());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry454Date_until_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(Symmetry454Chronology.INSTANCE.period(0, 0, 0), sym454.until(sym454));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Symmetry454Date_until_LocalDate(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(Symmetry454Chronology.INSTANCE.period(0, 0, 0), sym454.until(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_Chronology_date_Temporal(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(sym454, Symmetry454Chronology.INSTANCE.date(iso));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_LocalDate_until_Symmetry454Date(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(Period.ZERO, iso.until(sym454));
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_plusDays(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym454.plus(0, DAYS)));
         assertEquals(iso.plusDays(1), LocalDate.from(sym454.plus(1, DAYS)));
@@ -204,7 +201,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_minusDays(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(iso, LocalDate.from(sym454.minus(0, DAYS)));
         assertEquals(iso.minusDays(1), LocalDate.from(sym454.minus(1, DAYS)));
@@ -214,7 +211,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_samples")
+    @MethodSource("data_samples")
     public void test_until_DAYS(Symmetry454Date sym454, LocalDate iso) {
         assertEquals(0, sym454.until(iso.plusDays(0), DAYS));
         assertEquals(1, sym454.until(iso.plusDays(1), DAYS));
@@ -222,7 +219,6 @@ public class TestSymmetry454Chronology {
         assertEquals(-40, sym454.until(iso.minusDays(40), DAYS));
     }
 
-    @DataProvider
     public static Object[][] data_badDates() {
         return new Object[][] {
             {-1, 13, 28},
@@ -256,12 +252,11 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badDates")
+    @MethodSource("data_badDates")
     public void test_badDates(int year, int month, int dom) {
         assertThrows(DateTimeException.class, () -> Symmetry454Date.of(year, month, dom));
     }
 
-    @DataProvider
     public static Object[][] data_badLeapDates() {
         return new Object[][] {
             {1},
@@ -272,7 +267,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badLeapDates")
+    @MethodSource("data_badLeapDates")
     public void test_badLeapDayDates(int year) {
         assertThrows(DateTimeException.class, () -> Symmetry454Date.of(year, 12, 29));
     }
@@ -311,7 +306,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.lengthOfMonth
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_lengthOfMonth() {
         return new Object[][] {
             {2000, 1, 28, 28},
@@ -331,13 +325,13 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonth(int year, int month, int day, int length) {
         assertEquals(length, Symmetry454Date.of(year, month, day).lengthOfMonth());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_lengthOfMonth")
+    @MethodSource("data_lengthOfMonth")
     public void test_lengthOfMonthFirst(int year, int month, int day, int length) {
         assertEquals(length, Symmetry454Date.of(year, month, 1).lengthOfMonth());
     }
@@ -400,7 +394,6 @@ public class TestSymmetry454Chronology {
         assertEquals(1582, Symmetry454Chronology.INSTANCE.prolepticYear(IsoEra.CE, 1582));
     }
 
-    @DataProvider
     public static Object[][] data_prolepticYear_badEra() {
         return new Era[][] {
             { AccountingEra.BCE },
@@ -428,7 +421,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_prolepticYear_badEra")
+    @MethodSource("data_prolepticYear_badEra")
     public void test_prolepticYear_badEra(Era era) {
         assertThrows(ClassCastException.class, () -> Symmetry454Chronology.INSTANCE.prolepticYear(era, 4));
     }
@@ -475,7 +468,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.range
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_ranges() {
         return new Object[][] {
             // Leap Day and Year Day are members of months
@@ -522,7 +514,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_ranges")
+    @MethodSource("data_ranges")
     public void test_range(int year, int month, int dom, TemporalField field, ValueRange range) {
         assertEquals(range, Symmetry454Date.of(year, month, dom).range(field));
     }
@@ -535,7 +527,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.getLong
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_getLong() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 5},
@@ -571,7 +562,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_getLong")
+    @MethodSource("data_getLong")
     public void test_getLong(int year, int month, int dom, TemporalField field, long expected) {
         assertEquals(expected, Symmetry454Date.of(year, month, dom).getLong(field));
     }
@@ -584,7 +575,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.with
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_with() {
         return new Object[][] {
             {2014, 5, 26, DAY_OF_WEEK, 1, 2014, 5, 22},
@@ -661,14 +651,13 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with")
+    @MethodSource("data_with")
     public void test_with_TemporalField(int year, int month, int dom,
             TemporalField field, long value,
             int expectedYear, int expectedMonth, int expectedDom) {
         assertEquals(Symmetry454Date.of(expectedYear, expectedMonth, expectedDom), Symmetry454Date.of(year, month, dom).with(field, value));
     }
 
-    @DataProvider
     public static Object[][] data_with_bad() {
         return new Object[][] {
             {2013, 1, 1, ALIGNED_DAY_OF_WEEK_IN_MONTH, -1},
@@ -710,7 +699,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_with_bad")
+    @MethodSource("data_with_bad")
     public void test_with_TemporalField_badValue(int year, int month, int dom, TemporalField field, long value) {
         assertThrows(DateTimeException.class, () -> Symmetry454Date.of(year, month, dom).with(field, value));
     }
@@ -723,7 +712,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.with(TemporalAdjuster)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_temporalAdjusters_lastDayOfMonth() {
         return new Object[][] {
             {2012, 1, 23, 2012, 1, 28},
@@ -743,7 +731,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_temporalAdjusters_lastDayOfMonth")
+    @MethodSource("data_temporalAdjusters_lastDayOfMonth")
     public void test_temporalAdjusters_LastDayOfMonth(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay) {
         Symmetry454Date base = Symmetry454Date.of(year, month, day);
         Symmetry454Date expected = Symmetry454Date.of(expectedYear, expectedMonth, expectedDay);
@@ -788,7 +776,6 @@ public class TestSymmetry454Chronology {
     // Symmetry454Date.plus
     // Symmetry454Date.minus
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {2014, 5, 26, 0, DAYS, 2014, 5, 26},
@@ -824,7 +811,6 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_plus_leapWeek() {
         return new Object[][] {
             {2015, 12, 28, 0, DAYS, 2015, 12, 28},
@@ -845,7 +831,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -853,7 +839,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leapWeek")
+    @MethodSource("data_plus_leapWeek")
     public void test_plus_leapWeek_TemporalUnit(int year, int month, int dom,
             long amount, TemporalUnit unit,
             int expectedYear, int expectedMonth, int expectedDom) {
@@ -861,7 +847,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_minus_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -870,7 +856,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus_leapWeek")
+    @MethodSource("data_plus_leapWeek")
     public void test_minus_leapWeek_TemporalUnit(
             int expectedYear, int expectedMonth, int expectedDom,
             long amount, TemporalUnit unit,
@@ -886,7 +872,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.until
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_until() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, DAYS, 0},
@@ -914,7 +899,6 @@ public class TestSymmetry454Chronology {
         };
     }
 
-    @DataProvider
     public static Object[][] data_until_period() {
         return new Object[][] {
             {2014, 5, 26, 2014, 5, 26, 0, 0, 0},
@@ -930,7 +914,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until")
+    @MethodSource("data_until")
     public void test_until_TemporalUnit(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -941,7 +925,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_until_period")
+    @MethodSource("data_until_period")
     public void test_until_end(
             int year1, int month1, int dom1,
             int year2, int month2, int dom2,
@@ -987,7 +971,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.equals
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_equals() {
         return new Object[][] {
             {Symmetry454Date.of(2000, 1, 3), Symmetry454Date.of(2000, 1, 4), Symmetry454Date.of(2000, 2, 3), Symmetry454Date.of(2001, 1, 3)},
@@ -997,7 +980,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_equals")
+    @MethodSource("data_equals")
     public void test_equals(Symmetry454Date a1, Symmetry454Date b, Symmetry454Date c, Symmetry454Date d) {
         assertTrue(a1.equals(a1));
         assertFalse(a1.equals(b));
@@ -1011,7 +994,6 @@ public class TestSymmetry454Chronology {
     //-----------------------------------------------------------------------
     // Symmetry454Date.toString
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {Symmetry454Date.of(1, 1, 1), "Sym454 CE 1/01/01"},
@@ -1022,7 +1004,7 @@ public class TestSymmetry454Chronology {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(Symmetry454Date date, String expected) {
         assertEquals(expected, date.toString());
     }

--- a/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
@@ -47,9 +47,7 @@ import java.time.format.DateTimeParseException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test TaiInstant.
@@ -163,7 +161,6 @@ public class TestTaiInstant {
         }
     }
 
-    @DataProvider
     public static Object[][] data_badParse() {
         return new Object[][] {
             {"A.123456789s(TAI)"},
@@ -176,7 +173,7 @@ public class TestTaiInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badParse")
+    @MethodSource("data_badParse")
     public void factory_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeParseException.class, () -> TaiInstant.parse(str));
     }
@@ -189,7 +186,6 @@ public class TestTaiInstant {
     //-----------------------------------------------------------------------
     // withTAISeconds()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_withTAISeconds() {
         return new Object[][] {
             {0L, 12345L, 1L, 1L, 12345L},
@@ -202,7 +198,7 @@ public class TestTaiInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_withTAISeconds")
+    @MethodSource("data_withTAISeconds")
     public void test_withTAISeconds(long tai, long nanos, long newTai, Long expectedTai, Long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos).withTaiSeconds(newTai);
         assertEquals(expectedTai.longValue(), i.getTaiSeconds());
@@ -212,7 +208,6 @@ public class TestTaiInstant {
     //-----------------------------------------------------------------------
     // withNano()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_withNano() {
         return new Object[][] {
             {0L, 12345L, 1, 0L, 1L},
@@ -225,7 +220,7 @@ public class TestTaiInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_withNano")
+    @MethodSource("data_withNano")
     public void test_withNano(long tai, long nanos, int newNano, Long expectedTai, Long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos);
         if (expectedTai != null) {
@@ -240,7 +235,6 @@ public class TestTaiInstant {
     //-----------------------------------------------------------------------
     // plus(Duration)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {Long.MIN_VALUE, 0, Long.MAX_VALUE, 0, -1, 0},
@@ -426,7 +420,7 @@ public class TestTaiInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus(long seconds, int nanos, long plusSeconds, int plusNanos, long expectedSeconds, int expectedNanoOfSecond) {
         TaiInstant i = TaiInstant.ofTaiSeconds(seconds, nanos).plus(Duration.ofSeconds(plusSeconds, plusNanos));
         assertEquals(expectedSeconds, i.getTaiSeconds());
@@ -448,7 +442,6 @@ public class TestTaiInstant {
     //-----------------------------------------------------------------------
     // minus(Duration)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_minus() {
         return new Object[][] {
             {Long.MIN_VALUE, 0, Long.MIN_VALUE + 1, 0, -1, 0},
@@ -634,7 +627,7 @@ public class TestTaiInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_minus")
+    @MethodSource("data_minus")
     public void test_minus(long seconds, int nanos, long minusSeconds, int minusNanos, long expectedSeconds, int expectedNanoOfSecond) {
         TaiInstant i = TaiInstant.ofTaiSeconds(seconds, nanos).minus(Duration.ofSeconds(minusSeconds, minusNanos));
         assertEquals(expectedSeconds, i.getTaiSeconds());

--- a/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
@@ -47,9 +47,7 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test UtcInstant.
@@ -187,7 +185,6 @@ public class TestUtcInstant {
         assertEquals(UtcInstant.ofModifiedJulianDay(MJD_1972_12_31_LEAP, NANOS_PER_DAY), UtcInstant.parse("1972-12-31T23:59:60Z"));
     }
 
-    @DataProvider
     public static Object[][] data_badParse() {
         return new Object[][] {
             {""},
@@ -197,7 +194,7 @@ public class TestUtcInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_badParse")
+    @MethodSource("data_badParse")
     public void factory_parse_CharSequence_invalid(String str) {
         assertThrows(DateTimeException.class, () -> UtcInstant.parse(str));
     }
@@ -215,7 +212,6 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     // withModifiedJulianDay()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_withModifiedJulianDay() {
         return new Object[][] {
             {0L, 12345L, 1L, 1L, 12345L},
@@ -232,7 +228,7 @@ public class TestUtcInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_withModifiedJulianDay")
+    @MethodSource("data_withModifiedJulianDay")
     public void test_withModifiedJulianDay(long mjd, long nanos, long newMjd, Long expectedMjd, Long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
@@ -247,7 +243,6 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     // withNanoOfDay()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_withNanoOfDay() {
         return new Object[][] {
             {0L, 12345L, 1L, 0L, 1L},
@@ -270,7 +265,7 @@ public class TestUtcInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_withNanoOfDay")
+    @MethodSource("data_withNanoOfDay")
     public void test_withNanoOfDay(long mjd, long nanos, long newNanoOfDay, Long expectedMjd, Long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
@@ -285,7 +280,6 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     // plus(Duration)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_plus() {
         return new Object[][] {
             {0, 0,  -2 * SECS_PER_DAY, 5, -2, 5},
@@ -321,7 +315,7 @@ public class TestUtcInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_plus")
+    @MethodSource("data_plus")
     public void test_plus(long mjd, long nanos, long plusSeconds, int plusNanos, long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos).plus(Duration.ofSeconds(plusSeconds, plusNanos));
         assertEquals(expectedMjd, i.getModifiedJulianDay());
@@ -343,7 +337,6 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     // minus(Duration)
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_minus() {
         return new Object[][] {
             {0, 0,  2 * SECS_PER_DAY, -5, -2, 5},
@@ -379,7 +372,7 @@ public class TestUtcInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_minus")
+    @MethodSource("data_minus")
     public void test_minus(long mjd, long nanos, long minusSeconds, int minusNanos, long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos).minus(Duration.ofSeconds(minusSeconds, minusNanos));
         assertEquals(expectedMjd, i.getModifiedJulianDay());
@@ -587,7 +580,6 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     // toString()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_toString() {
         return new Object[][] {
             {40587, 0, "1970-01-01T00:00:00Z"},
@@ -607,13 +599,13 @@ public class TestUtcInstant {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString(long mjd, long nod, String expected) {
         assertEquals(expected, UtcInstant.ofModifiedJulianDay(mjd, nod).toString());
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_toString")
+    @MethodSource("data_toString")
     public void test_toString_parse(long mjd, long nod, String str) {
         assertEquals(UtcInstant.ofModifiedJulianDay(mjd, nod), UtcInstant.parse(str));
     }

--- a/src/test/java/org/threeten/extra/scale/TestUtcRules.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcRules.java
@@ -53,9 +53,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-
-import com.tngtech.junit.dataprovider.DataProvider;
-import com.tngtech.junit.dataprovider.UseDataProvider;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test SystemLeapSecondRules.
@@ -103,7 +101,6 @@ public class TestUtcRules {
     //-----------------------------------------------------------------------
     // getLeapSecond()
     //-----------------------------------------------------------------------
-    @DataProvider
     public static Object[][] data_leapSeconds() {
         return new Object[][] {
             {-1, 0, 10, "1858-11-16"},
@@ -237,7 +234,7 @@ public class TestUtcRules {
     }
 
     @ParameterizedTest
-    @UseDataProvider("data_leapSeconds")
+    @MethodSource("data_leapSeconds")
     public void test_leapSeconds(long mjd, int adjust, int offset, String checkDate) {
         assertEquals(LocalDate.parse(checkDate).getLong(JulianFields.MODIFIED_JULIAN_DAY), mjd);
 


### PR DESCRIPTION
Junit 5 now has a built-in annotation for designating methods as data sources.  This PR switches to using that.