### PR TITLE
InternationalFixedEra.CE#getValue returns incorrect value

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedEra.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedEra.java
@@ -37,7 +37,7 @@ import java.time.chrono.Era;
 /**
  * An era in the International Fixed calendar system.
  * <p>
- * The International Fixed calendar system only has one era.
+ * The International Fixed calendar system officially only has one era.
  * The current era, for years from 1 onwards, is known as 'Current Era'.
  * All previous years are invalid.
  * <p>
@@ -85,7 +85,7 @@ public enum InternationalFixedEra implements Era {
      */
     @Override
     public int getValue() {
-        return ordinal();
+        return 1;
     }
 
 }

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -367,6 +367,30 @@ public class TestInternationalFixedChronology {
         assertEquals(29, InternationalFixedDate.of(2000, 6, 29).lengthOfMonth());
     }
 
+    @Test
+    public void test_era_valid() {
+        Era era = InternationalFixedChronology.INSTANCE.eraOf(1);
+        assertNotNull(era);
+        assertEquals(1, era.getValue());
+    }
+
+    //-----------------------------------------------------------------------
+    // data_invalidEraValues()
+    //-----------------------------------------------------------------------
+    public static Object[][] data_invalidEraValues() {
+        return new Object[][] {
+                {-1},
+                {0},
+                {2},
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("data_invalidEraValues")
+    public void test_era_invalid(int eraValue) {
+        assertThrows(DateTimeException.class, () -> InternationalFixedChronology.INSTANCE.eraOf(eraValue));
+    }
+
     //-----------------------------------------------------------------------
     // era, prolepticYear and dateYearDay
     //-----------------------------------------------------------------------


### PR DESCRIPTION
There is but one era in the InternationalFixed chronology, documented to have the value 1.
This PR revolves the incorrect behaviour reported in issue #204.

However, there are two ways to solve it.

This PR chose an unorthodox way, by returning the constant `1`.
Since there is only one ear, this seems reasonable.

However, all other eras return `ordinal()`, as did the `InternationalFixedEra` before.
To maintain this logic, one would have to introduce an unused era to pick up the value 0, such as

```java
public enum InternationalFixedEra implements Era {

    /**
     * Unused era, outside of 'Current Era' below.
     * It is invalid, its usage is not supported and leads to runtime exception.
     */
    UNUSED,

    /**
     * The singleton instance for the current era, 'Current Era',
     * which has the numeric value 1.
     */
    CE;

// ......
}
```
