### PR TITLE
Fix test_now*() in TestDayOfMonth and TestDayOfYear

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,12 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+     <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>${pioneer.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- ==================================================================== -->
@@ -911,6 +917,7 @@
     <!-- Dependencies -->
     <joda-convert.version>2.2.2</joda-convert.version>
     <junit.version>5.9.0</junit.version>
+    <pioneer.version>1.7.1</pioneer.version>
     <guava.version>31.1-jre</guava.version>
     <!-- Plugin version numbers -->
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
@@ -467,8 +467,7 @@ public final class InternationalFixedChronology extends AbstractChronology imple
         if (!(era instanceof InternationalFixedEra)) {
             throw new ClassCastException("Invalid era: " + era);
         }
-        YEAR_RANGE.checkValidIntValue(yearOfEra, ChronoField.YEAR_OF_ERA);
-        return yearOfEra;
+        return YEAR_RANGE.checkValidIntValue(yearOfEra, ChronoField.YEAR_OF_ERA);
     }
 
     /**

--- a/src/main/java/org/threeten/extra/chrono/Symmetry010Chronology.java
+++ b/src/main/java/org/threeten/extra/chrono/Symmetry010Chronology.java
@@ -497,10 +497,7 @@ public final class Symmetry010Chronology
         if (!(era instanceof IsoEra)) {
             throw new ClassCastException("Invalid era: " + era);
         }
-
-        YEAR_RANGE.checkValidIntValue(yearOfEra, ChronoField.YEAR_OF_ERA);
-
-        return yearOfEra;
+        return YEAR_RANGE.checkValidIntValue(yearOfEra, ChronoField.YEAR_OF_ERA);
     }
 
     /**

--- a/src/main/java/org/threeten/extra/chrono/Symmetry454Chronology.java
+++ b/src/main/java/org/threeten/extra/chrono/Symmetry454Chronology.java
@@ -490,10 +490,7 @@ public final class Symmetry454Chronology
         if (!(era instanceof IsoEra)) {
             throw new ClassCastException("Invalid era: " + era);
         }
-
-        YEAR_RANGE.checkValidIntValue(yearOfEra, ChronoField.YEAR_OF_ERA);
-
-        return yearOfEra;
+        return YEAR_RANGE.checkValidIntValue(yearOfEra, ChronoField.YEAR_OF_ERA);
     }
 
     /**

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -109,6 +109,7 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 /**
  * Test DayOfMonth.
@@ -194,26 +195,18 @@ public class TestDayOfMonth {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+    @RetryingTest(100)
     public void test_now() {
-        DayOfMonth test = DayOfMonth.now();
-        if (LocalDate.now().getDayOfMonth() != test.getValue()) {
-            test = DayOfMonth.now();
-        }
-        assertEquals(LocalDate.now().getDayOfMonth(), test.getValue());
+        assertEquals(LocalDate.now().getDayOfMonth(), DayOfMonth.now().getValue());
     }
 
     //-----------------------------------------------------------------------
     // now(ZoneId)
     //-----------------------------------------------------------------------
-    @Test
+    @RetryingTest(100)
     public void test_now_ZoneId() {
         ZoneId zone = ZoneId.of("Asia/Tokyo");
-        DayOfMonth test = DayOfMonth.now(zone);
-        if (LocalDate.now(zone).getDayOfMonth() != test.getValue()) {
-            test = DayOfMonth.now(zone);
-        }
-        assertEquals(LocalDate.now(zone).getDayOfMonth(), test.getValue());
+        assertEquals(LocalDate.now(zone).getDayOfMonth(), DayOfMonth.now(zone).getValue());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -729,9 +729,9 @@ public class TestDayOfMonth {
 
     @Test
     public void test_compareTo_nullDayOfMonth() {
-        DayOfMonth doy = null;
+        DayOfMonth dom = null;
         DayOfMonth test = DayOfMonth.of(1);
-        assertThrows(NullPointerException.class, () -> test.compareTo(doy));
+        assertThrows(NullPointerException.class, () -> test.compareTo(dom));
     }
 
     //-----------------------------------------------------------------------
@@ -751,9 +751,9 @@ public class TestDayOfMonth {
 
     @Test
     public void test_equals_nullDayOfMonth() {
-        DayOfMonth doy = null;
+        DayOfMonth dom = null;
         DayOfMonth test = DayOfMonth.of(1);
-        assertEquals(false, test.equals(doy));
+        assertEquals(false, test.equals(dom));
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -93,6 +93,7 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.RetryingTest;
 
 /**
  * Test DayOfYear.
@@ -181,26 +182,18 @@ public class TestDayOfYear {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+    @RetryingTest(100)
     public void test_now() {
-        DayOfYear test = DayOfYear.now();
-        if (LocalDate.now().getDayOfYear() != test.getValue()) {
-            test = DayOfYear.now();
-        }
-        assertEquals(LocalDate.now().getDayOfYear(), test.getValue());
+        assertEquals(LocalDate.now().getDayOfYear(), DayOfYear.now().getValue());
     }
 
     //-----------------------------------------------------------------------
     // now(ZoneId)
     //-----------------------------------------------------------------------
-    @Test
+    @RetryingTest(100)
     public void test_now_ZoneId() {
         ZoneId zone = ZoneId.of("Asia/Tokyo");
-        DayOfYear test = DayOfYear.now(zone);
-        if (LocalDate.now(zone).getDayOfYear() != test.getValue()) {
-            test = DayOfYear.now(zone);
-        }
-        assertEquals(LocalDate.now(zone).getDayOfYear(), test.getValue());
+        assertEquals(LocalDate.now(zone).getDayOfYear(), DayOfYear.now(zone).getValue());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestOffsetDate.java
+++ b/src/test/java/org/threeten/extra/TestOffsetDate.java
@@ -88,6 +88,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.RetryingTest;
 
 /**
  * Test OffsetDate.
@@ -157,18 +158,9 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+    @RetryingTest(100)
     public void now() {
-        OffsetDate expected = OffsetDate.now(Clock.systemDefaultZone());
-        OffsetDate test = OffsetDate.now();
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = OffsetDate.now(Clock.systemDefaultZone());
-            test = OffsetDate.now();
-        }
-        assertEquals(expected, test);
+        assertEquals(OffsetDate.now(Clock.systemDefaultZone()), OffsetDate.now());
     }
 
     @Test

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -127,6 +127,7 @@ import java.util.Locale;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.RetryingTest;
 
 public class TestYearWeek {
 
@@ -335,18 +336,9 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+    @RetryingTest(100)
     public void test_now() {
-        YearWeek expected = YearWeek.now(Clock.systemDefaultZone());
-        YearWeek test = YearWeek.now();
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = YearWeek.now(Clock.systemDefaultZone());
-            test = YearWeek.now();
-        }
-        assertEquals(expected, test);
+        assertEquals(YearWeek.now(Clock.systemDefaultZone()), YearWeek.now());
     }
 
     //-----------------------------------------------------------------------
@@ -357,19 +349,10 @@ public class TestYearWeek {
         assertThrows(NullPointerException.class, () -> YearWeek.now((ZoneId) null));
     }
 
-    @Test
+    @RetryingTest(100)
     public void now_ZoneId() {
         ZoneId zone = ZoneId.of("UTC+01:02:03");
-        YearWeek expected = YearWeek.now(Clock.system(zone));
-        YearWeek test = YearWeek.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = YearWeek.now(Clock.system(zone));
-            test = YearWeek.now(zone);
-        }
-        assertEquals(expected, test);
+        assertEquals(YearWeek.now(Clock.system(zone)), YearWeek.now(zone));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -1107,8 +1107,12 @@ public class TestYearWeek {
     }
 
     @Test
+    public void test_equals_null() {
+        assertEquals(false, TEST.equals(null));
+    }
+
+    @Test
     public void test_equals_incorrectType() {
-        assertTrue(TEST.equals(null) == false);
         assertEquals(false, TEST.equals((Object) "Incorrect type"));
     }
 


### PR DESCRIPTION
Without fix, all of the following can fail:

- TestDayOfMonth.test_now()
- TestDayOfMonth.test_now_ZoneId()
- TestDayOfYear.test_now()
- TestDayOfYear.test_now_ZoneId()

... as `LocalDate.now()` is being used directly in `assertEquals`.

---

Let's take TestDayOfMonth.test_now() as an example.

```java
@Test
public void test_now() {
    DayOfMonth test = DayOfMonth.now();
    if (LocalDate.now().getDayOfMonth() != test.getValue()) {
        test = DayOfMonth.now();
    }
    assertEquals(LocalDate.now().getDayOfMonth(), test.getValue());
}
```

It is very unlikely (although still possible) for local date to change between re-assignment of `DayOfMonth.now()` to `test` and `LocalDate.now()` call, but it is not so unlikely for local date to change between _first_ assignment of `DayOfMonth.now()` to `test` and `LocalDate.now()` call.

If `LocalDate.now().getDayOfMonth() == test.getValue()`, TestDayOfMonth.test_now() becomes:

```java
@Test
public void test_now() {
    DayOfMonth test = DayOfMonth.now();
    assertEquals(LocalDate.now().getDayOfMonth(), test.getValue());
}
```

It's clear, that local date can change between line 1 and 2.

---

This PR introduces https://junit-pioneer.org/docs/retrying-test/ to fix 4 flawed tests and also improves readability of few others.