### PR TITLE
`maven-compiler-plugin` set `createMissingPackageInfoClass` to false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -809,6 +809,7 @@
             <!-- setup defaults for compile and testCompile -->
             <configuration>
               <release>8</release>
+              <createMissingPackageInfoClass>false</createMissingPackageInfoClass>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
close #226

The `maven-compiler-plugin` was upgraded from 3.8.0 to 3.10.1 in PR #207, which resulted in `package-info.class` compiled with java9 in the release jar.

See [MCOMPILER-205](https://issues.apache.org/jira/browse/MCOMPILER-205) incremental compilation broken for package-info classes


https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#createMissingPackageInfoClass
| Name                              | Type      | Since  | Description                                                  |
| :-------------------------------- | :-------- | :----- | :----------------------------------------------------------- |
| `<createMissingPackageInfoClass>` | `boolean` | `3.10` | Package info source files that only contain javadoc and no annotation on the package can lead to no class file being generated by the compiler. This causes a file miss on the next compilations and forces an unnecessary recompilation. The default value of `true` causes an empty class file to be generated. This behavior can be changed by setting this parameter to `false`. **Default value is**: `true`. **User property is**: `maven.compiler.createMissingPackageInfoClass`. |


