### PR TITLE
Add `Interval.of(duration, end)` to compliment `Interval.of(start, duration)`

### DIFF
--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -130,6 +130,28 @@ public final class Interval
     }
 
     /**
+     * Obtains an instance of {@code Interval} from the duration and the end.
+     * <p>
+     * The start instant is calculated as the end minus the duration.
+     * The duration must not be negative.
+     *
+     * @param duration  the duration from the start to the end, not null
+     * @param endExclusive  the end instant, exclusive, not null
+     * @return the interval, not null
+     * @throws DateTimeException if the end is before the start,
+     *  or if the duration addition cannot be made
+     * @throws ArithmeticException if numeric overflow occurs when subtracting the duration
+     */
+    public static Interval of(Duration duration, Instant endExclusive) {
+        Objects.requireNonNull(duration, "duration");
+        Objects.requireNonNull(endExclusive, "endExclusive");
+        if (duration.isNegative()) {
+            throw new DateTimeException("Duration must not be negative");
+        }
+        return new Interval(endExclusive.minus(duration), endExclusive);
+    }
+
+    /**
      * Obtains an instance of {@code Interval} with the specified start instant and unbounded end.
      *
      * @param startInclusive the start instant, inclusive, not null

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -129,7 +129,7 @@ public class TestInterval {
 
     @Test
     public void test_of_Instant_Instant_nullStart() {
-        assertThrows(NullPointerException.class, () -> Interval.of(null, NOW2));
+        assertThrows(NullPointerException.class, () -> Interval.of((Instant) null, NOW2));
     }
 
     @Test
@@ -165,6 +165,36 @@ public class TestInterval {
     @Test
     public void test_of_Instant_Duration_nullDuration() {
         assertThrows(NullPointerException.class, () -> Interval.of(NOW1, (Duration) null));
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_of_Duration_Instant() {
+        Interval test = Interval.of(Duration.ofSeconds(60), NOW2);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW2, test.getEnd());
+    }
+
+    @Test
+    public void test_of_Duration_Instant_zero() {
+        Interval test = Interval.of(Duration.ZERO, NOW1);
+        assertEquals(NOW1, test.getStart());
+        assertEquals(NOW1, test.getEnd());
+    }
+
+    @Test
+    public void test_of_Duration_Instant_negative() {
+        assertThrows(DateTimeException.class, () -> Interval.of(Duration.ofSeconds(-1), NOW2));
+    }
+
+    @Test
+    public void test_of_Duration_Instant_nullInstant() {
+        assertThrows(NullPointerException.class, () -> Interval.of(Duration.ZERO, null));
+    }
+
+    @Test
+    public void test_of_Duration_Instant_nullDuration() {
+        assertThrows(NullPointerException.class, () -> Interval.of((Duration) null, NOW1));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
This adds a new `Interval.of(duration, end)` way of obtaining an `Interval` - the mirror of the existing method:

```
Interval.of(start, duration)
```

...but for easily getting an `Interval` that ends at a known instant, with a known duration!

This kind of interval is quite often handy in realtime analytics ("give me the last 30 minutes of results").