### PR TITLE
Additional wordBased method on AmountFormats

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: 
+on:
   push:
     branches:
       - '*'
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         java: [8, 11, 21]
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/src/main/java/org/threeten/extra/AmountFormats.java
+++ b/src/main/java/org/threeten/extra/AmountFormats.java
@@ -168,9 +168,8 @@ public final class AmountFormats {
     /**
      * Formats a period and duration to a string in ISO-8601 format.
      * <p>
-     * To obtain the ISO-8601 format of a {@code Period} or {@code Duration}
-     * individually, simply call {@code toString()}.
-     * See also {@link PeriodDuration}.
+     * To obtain the ISO-8601 format of a {@link Period}, {@link Duration} or {@link PeriodDuration}
+     * simply call {@code toString()}.
      *
      * @param period  the period to format
      * @param duration  the duration to format
@@ -306,6 +305,24 @@ public final class AmountFormats {
     // are the signs opposite
     private static boolean oppositeSigns(int a, int b) {
         return a < 0 ? (b >= 0) : (b < 0);
+    }
+
+    /**
+     * Formats a period-duration to a string in a localized word-based format.
+     * <p>
+     * This returns a word-based format for the period-duration.
+     * The year and month are printed as supplied unless the signs differ, in which case they are normalized.
+     * The words are configured in a resource bundle text file -
+     * {@code org.threeten.extra.wordbased.properties} - with overrides per language.
+     *
+     * @param periodDuration  the period-duration to format
+     * @param locale  the locale to use
+     * @return the localized word-based format for the period-duration
+     */
+    public static String wordBased(PeriodDuration periodDuration, Locale locale) {
+        Objects.requireNonNull(periodDuration, "periodDuration must not be null");
+        Objects.requireNonNull(locale, "locale must not be null");
+        return wordBased(periodDuration.getPeriod(), periodDuration.getDuration(), locale);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestAmountFormats.java
+++ b/src/test/java/org/threeten/extra/TestAmountFormats.java
@@ -48,7 +48,9 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class TestAmountFormats {
 
+    private static final Locale FA = new Locale("fa");
     private static final Locale PL = new Locale("pl");
+    private static final Locale RO = new Locale("ro");
     private static final Locale RU = new Locale("ru");
 
     //-----------------------------------------------------------------------
@@ -85,14 +87,14 @@ public class TestAmountFormats {
             {Period.ofDays(7), Locale.ENGLISH, "1 week"},
             {Period.ofDays(-1), Locale.ENGLISH, "-1 day"},
 
-            {Period.ofDays(1), new Locale("ro"), "1 zi"},
-            {Period.ofDays(2), new Locale("ro"), "2 zile"},
-            {Period.ofDays(5), new Locale("ro"), "5 zile"},
-            {Period.ofDays(7), new Locale("ro"), "1 săptămână"},
-            {Period.ofWeeks(3), new Locale("ro"), "3 săptămâni"},
-            {Period.ofMonths(14).normalized(), new Locale("ro"), "1 an și 2 luni"},
-            {Period.ofMonths(1), new Locale("ro"), "1 lună"},
-            {Period.ofYears(2), new Locale("ro"), "2 ani"},
+            {Period.ofDays(1), RO, "1 zi"},
+            {Period.ofDays(2), RO, "2 zile"},
+            {Period.ofDays(5), RO, "5 zile"},
+            {Period.ofDays(7), RO, "1 săptămână"},
+            {Period.ofWeeks(3), RO, "3 săptămâni"},
+            {Period.ofMonths(14).normalized(), RO, "1 an și 2 luni"},
+            {Period.ofMonths(1), RO, "1 lună"},
+            {Period.ofYears(2), RO, "2 ani"},
         };
     }
 
@@ -116,18 +118,17 @@ public class TestAmountFormats {
             {Duration.ofNanos(1_000_000), Locale.ENGLISH, "1 millisecond"},
             {Duration.ofNanos(1000_000_000 + 2_000_000), Locale.ENGLISH, "1 second and 2 milliseconds"},
 
-            {Duration.ofMinutes(60 + 1), new Locale("ro"), "1 oră și 1 minut"},
-            {Duration.ofMinutes(180 + 2), new Locale("ro"), "3 ore și 2 minute"},
-            {Duration.ofMinutes(-60 - 40), new Locale("ro"), "-1 oră și -40 minute"},
-            {Duration.ofSeconds(-90), new Locale("ro"), "-1 minut și -30 secunde"},
-            {Duration.ofNanos(1_000_000), new Locale("ro"), "1 milisecundă"},
-            {Duration.ofNanos(1000_000_000 + 2_000_000), new Locale("ro"), "1 secundă și 2 milisecunde"},
+            {Duration.ofMinutes(60 + 1), RO, "1 oră și 1 minut"},
+            {Duration.ofMinutes(180 + 2), RO, "3 ore și 2 minute"},
+            {Duration.ofMinutes(-60 - 40), RO, "-1 oră și -40 minute"},
+            {Duration.ofSeconds(-90), RO, "-1 minut și -30 secunde"},
+            {Duration.ofNanos(1_000_000), RO, "1 milisecundă"},
+            {Duration.ofNanos(1000_000_000 + 2_000_000), RO, "1 secundă și 2 milisecunde"},
 
             {Duration.ofHours(5).plusMinutes(6).plusSeconds(7).plusNanos(8_000_000L), PL,
                 "5 godzin, 6 minut, 7 sekund i 8 milisekund"},
 
-            {Duration.ofMinutes(60 + 1), new Locale("fa"),
-                "1 \u0633\u0627\u0639\u062A \u0648 1 \u062f\u0642\u06cc\u0642\u0647"}
+            {Duration.ofMinutes(60 + 1), FA, "1 \u0633\u0627\u0639\u062A \u0648 1 \u062f\u0642\u06cc\u0642\u0647"}
         };
     }
 
@@ -161,6 +162,7 @@ public class TestAmountFormats {
     @MethodSource("period_duration_wordBased")
     public void test_wordBased(Period period, Duration duration, Locale locale, String expected) {
         assertEquals(expected, AmountFormats.wordBased(period, duration, locale));
+        assertEquals(expected, AmountFormats.wordBased(PeriodDuration.of(period, duration), locale));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Allow `PeriodDuration` to be directly formatted
Also remove trailing whitespace in yaml
See #269