### PR TITLE
Fix Ethiopic calendar epoch in Javadoc

### DIFF
--- a/src/main/java/org/threeten/extra/chrono/EthiopicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/EthiopicChronology.java
@@ -53,7 +53,7 @@ import java.util.Map;
  * <p>
  * This chronology defines the rules of the Ethiopic calendar system.
  * This calendar system is primarily used in Ethiopia.
- * Dates are aligned such that {@code 0001-01-01 (Ethiopic)} is {@code 0284-08-29 (ISO)}.
+ * Dates are aligned such that {@code 0001-01-01 (Ethiopic)} is {@code 0008-08-27 (ISO)}.
  * <p>
  * The fields are defined as follows:
  * <ul>

--- a/src/main/java/org/threeten/extra/chrono/EthiopicEra.java
+++ b/src/main/java/org/threeten/extra/chrono/EthiopicEra.java
@@ -42,7 +42,7 @@ import java.time.chrono.Era;
  * All previous years, zero or earlier in the proleptic count or one and greater
  * in the year-of-era count, are part of the 'Before Incarnation Era' era.
  * <p>
- * The start of the Ethiopic epoch {@code 0001-01-01 (Ethiopic)} is {@code 0284-08-29 (ISO)}.
+ * The start of the Ethiopic epoch {@code 0001-01-01 (Ethiopic)} is {@code 0008-08-27 (ISO)}.
  * <p>
  * <b>Do not use {@code ordinal()} to obtain the numeric representation of {@code EthiopicEra}.
  * Use {@code getValue()} instead.</b>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Ethiopic calendar epoch alignment in the Javadoc, updating the mapping of Ethiopic 0001-01-01 to ISO 0008-08-27.
  * Clarified explanatory notes to ensure accurate date conversions and reduce confusion for users working with Ethiopic dates.
  * No functional, API, or behavioral changes; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->