### PR TITLE
Fix implementations of query()

### DIFF
--- a/src/main/java/org/threeten/extra/AmPm.java
+++ b/src/main/java/org/threeten/extra/AmPm.java
@@ -310,14 +310,9 @@ public enum AmPm implements TemporalAccessor, TemporalAdjuster {
     /**
      * Queries this am-pm using the specified query.
      * <p>
-     * This queries this am-pm using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#precision()} is directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null

--- a/src/main/java/org/threeten/extra/DayOfMonth.java
+++ b/src/main/java/org/threeten/extra/DayOfMonth.java
@@ -44,6 +44,7 @@ import java.time.ZoneId;
 import java.time.chrono.Chronology;
 import java.time.chrono.IsoChronology;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjuster;
@@ -366,14 +367,9 @@ public final class DayOfMonth
     /**
      * Queries this day-of-month using the specified query.
      * <p>
-     * This queries this day-of-month using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null
@@ -386,6 +382,8 @@ public final class DayOfMonth
     public <R> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
+        } else if (query == TemporalQueries.precision()) {
+            return (R) ChronoUnit.DAYS;
         }
         return TemporalAccessor.super.query(query);
     }

--- a/src/main/java/org/threeten/extra/DayOfYear.java
+++ b/src/main/java/org/threeten/extra/DayOfYear.java
@@ -42,6 +42,7 @@ import java.time.ZoneId;
 import java.time.chrono.Chronology;
 import java.time.chrono.IsoChronology;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalAdjuster;
@@ -350,7 +351,7 @@ public final class DayOfYear
     /**
      * Checks if the year is valid for this day-of-year.
      * <p>
-     * This method checks whether this day-of-yearand the input year form
+     * This method checks whether this day-of-year and the input year form
      * a valid date. This can only return false for day-of-year 366.
      *
      * @param year  the year to validate
@@ -364,14 +365,9 @@ public final class DayOfYear
     /**
      * Queries this day-of-year using the specified query.
      * <p>
-     * This queries this day-of-year using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null
@@ -384,6 +380,8 @@ public final class DayOfYear
     public <R> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
+        } else if (query == TemporalQueries.precision()) {
+            return (R) ChronoUnit.DAYS;
         }
         return TemporalAccessor.super.query(query);
     }

--- a/src/main/java/org/threeten/extra/Half.java
+++ b/src/main/java/org/threeten/extra/Half.java
@@ -175,7 +175,7 @@ public enum Half implements TemporalAccessor, TemporalAdjuster {
 
     //-----------------------------------------------------------------------
     /**
-     * Gets the textual representation, such as 'H1' or '4th half'.
+     * Gets the textual representation, such as 'H1' or '2nd half'.
      * <p>
      * This returns the textual name used to identify the half-of-year,
      * suitable for presentation to the user.
@@ -362,7 +362,7 @@ public enum Half implements TemporalAccessor, TemporalAdjuster {
      * H2 has 184 days.
      *
      * @param leapYear  true if the length is required for a leap year
-     * @return the length of this month in days, 181, 182 or 184
+     * @return the length of this half in days, 181, 182 or 184
      */
     public int length(boolean leapYear) {
         return this == H1 ? (leapYear ? 182 : 181) : 184;
@@ -385,14 +385,9 @@ public enum Half implements TemporalAccessor, TemporalAdjuster {
     /**
      * Queries this half-of-year using the specified query.
      * <p>
-     * This queries this half-of-year using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null

--- a/src/main/java/org/threeten/extra/HourMinute.java
+++ b/src/main/java/org/threeten/extra/HourMinute.java
@@ -404,7 +404,7 @@ public final class HourMinute
      * <p>
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link #isSupported(TemporalField) supported fields} will return valid
-     * values based on this hour-minute,.
+     * values based on this hour-minute.
      * All other {@code ChronoField} instances will throw an {@code UnsupportedTemporalTypeException}.
      * <p>
      * If the field is not a {@code ChronoField}, then the result of this method
@@ -674,13 +674,13 @@ public final class HourMinute
      * The supported fields behave as follows:
      * <ul>
      * <li>{@code MINUTES} -
-     *  Returns a {@code LocalTime} with the specified number of minutes added.
+     *  Returns an {@code HourMinute} with the specified number of minutes added.
      *  This is equivalent to {@link #plusMinutes(long)}.
      * <li>{@code HOURS} -
-     *  Returns a {@code LocalTime} with the specified number of hours added.
+     *  Returns an {@code HourMinute} with the specified number of hours added.
      *  This is equivalent to {@link #plusHours(long)}.
      * <li>{@code HALF_DAYS} -
-     *  Returns a {@code LocalTime} with the specified number of half-days added.
+     *  Returns an {@code HourMinute} with the specified number of half-days added.
      *  This is equivalent to {@link #plusHours(long)} with the amount
      *  multiplied by 12.
      * </ul>
@@ -842,14 +842,9 @@ public final class HourMinute
     /**
      * Queries this hour-minute using the specified query.
      * <p>
-     * This queries this hour-minute using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#localTime()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null

--- a/src/main/java/org/threeten/extra/OffsetDate.java
+++ b/src/main/java/org/threeten/extra/OffsetDate.java
@@ -1050,14 +1050,10 @@ public final class OffsetDate
     /**
      * Queries this date using the specified query.
      * <p>
-     * This queries this date using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#localDate()}, {@link TemporalQueries#chronology()}, {@link TemporalQueries#offset()},
+     * {@link TemporalQueries#zone()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null
@@ -1068,7 +1064,9 @@ public final class OffsetDate
     @SuppressWarnings("unchecked")
     @Override
     public <R> R query(TemporalQuery<R> query) {
-        if (query == TemporalQueries.chronology()) {
+        if (query == TemporalQueries.localDate()) {
+            return (R) date;
+        } else if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {
             return (R) DAYS;

--- a/src/main/java/org/threeten/extra/Quarter.java
+++ b/src/main/java/org/threeten/extra/Quarter.java
@@ -383,7 +383,7 @@ public enum Quarter implements TemporalAccessor, TemporalAdjuster {
      * Q3 and Q4 have 92 days.
      *
      * @param leapYear  true if the length is required for a leap year
-     * @return the length of this month in days, from 90 to 92
+     * @return the length of this quarter in days, from 90 to 92
      */
     public int length(boolean leapYear) {
         switch (this) {
@@ -429,14 +429,9 @@ public enum Quarter implements TemporalAccessor, TemporalAdjuster {
     /**
      * Queries this quarter-of-year using the specified query.
      * <p>
-     * This queries this quarter-of-year using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null

--- a/src/main/java/org/threeten/extra/YearHalf.java
+++ b/src/main/java/org/threeten/extra/YearHalf.java
@@ -270,7 +270,7 @@ public final class YearHalf
      * Obtains an instance of {@code YearHalf} from a text string such as {@code 2007-H2}.
      * <p>
      * The string must represent a valid year-half.
-     * The format must be {@code uuuu-'Q'Q} where the 'Q' is case insensitive.
+     * The format must be {@code uuuu-'H'H} where the 'H' is case insensitive.
      * Years outside the range 0000 to 9999 must be prefixed by the plus or minus symbol.
      *
      * @param text  the text to parse such as "2007-H2", not null
@@ -452,7 +452,7 @@ public final class YearHalf
      * <p>
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link #isSupported(TemporalField) supported fields} will return valid
-     * values based on this year-half,.
+     * values based on this year-half.
      * All other {@code ChronoField} instances will throw an {@code UnsupportedTemporalTypeException}.
      * <p>
      * If the field is not a {@code ChronoField}, then the result of this method
@@ -974,14 +974,9 @@ public final class YearHalf
     /**
      * Queries this year-half using the specified query.
      * <p>
-     * This queries this year-half using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null

--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -453,7 +453,7 @@ public final class YearQuarter
      * <p>
      * If the field is a {@link ChronoField} then the query is implemented here.
      * The {@link #isSupported(TemporalField) supported fields} will return valid
-     * values based on this year-quarter,.
+     * values based on this year-quarter.
      * All other {@code ChronoField} instances will throw an {@code UnsupportedTemporalTypeException}.
      * <p>
      * If the field is not a {@code ChronoField}, then the result of this method
@@ -975,14 +975,9 @@ public final class YearQuarter
     /**
      * Queries this year-quarter using the specified query.
      * <p>
-     * This queries this year-quarter using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -842,14 +842,9 @@ public final class YearWeek
     /**
      * Queries this year-week using the specified query.
      * <p>
-     * This queries this year-week using the specified query strategy object.
-     * The {@code TemporalQuery} object defines the logic to be used to
-     * obtain the result. Read the documentation of the query to understand
-     * what the result of this method will be.
-     * <p>
-     * The result of this method is obtained by invoking the
-     * {@link TemporalQuery#queryFrom(TemporalAccessor)} method on the
-     * specified query passing {@code this} as the argument.
+     * {@link TemporalQueries#chronology()} and {@link TemporalQueries#precision()} are directly supported.
+     * Otherwise, the result of this method is obtained by invoking
+     * {@link TemporalAccessor#query(TemporalQuery)} on the parent interface.
      *
      * @param <R> the type of the result
      * @param query  the query to invoke, not null
@@ -862,6 +857,8 @@ public final class YearWeek
     public <R> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
+        } else if (query == TemporalQueries.precision()) {
+            return (R) WEEKS;
         }
         return Temporal.super.query(query);
     }

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -524,7 +524,7 @@ public class TestDayOfMonth {
         assertEquals(null, TEST.query(TemporalQueries.localDate()));
         assertEquals(null, TEST.query(TemporalQueries.localTime()));
         assertEquals(null, TEST.query(TemporalQueries.offset()));
-        assertEquals(null, TEST.query(TemporalQueries.precision()));
+        assertEquals(ChronoUnit.DAYS, TEST.query(TemporalQueries.precision()));
         assertEquals(null, TEST.query(TemporalQueries.zone()));
         assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -405,7 +405,7 @@ public class TestDayOfYear {
         assertEquals(null, TEST.query(TemporalQueries.localDate()));
         assertEquals(null, TEST.query(TemporalQueries.localTime()));
         assertEquals(null, TEST.query(TemporalQueries.offset()));
-        assertEquals(null, TEST.query(TemporalQueries.precision()));
+        assertEquals(ChronoUnit.DAYS, TEST.query(TemporalQueries.precision()));
         assertEquals(null, TEST.query(TemporalQueries.zone()));
         assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }

--- a/src/test/java/org/threeten/extra/TestOffsetDate.java
+++ b/src/test/java/org/threeten/extra/TestOffsetDate.java
@@ -519,6 +519,18 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     }
 
     @Test
+    public void test_query_localDate() {
+        assertEquals(TEST_2007_07_15_PONE.toLocalDate(), TEST_2007_07_15_PONE.query(TemporalQueries.localDate()));
+        assertEquals(TEST_2007_07_15_PONE.toLocalDate(), TemporalQueries.localDate().queryFrom(TEST_2007_07_15_PONE));
+    }
+
+    @Test
+    public void test_query_localTime() {
+        assertNull(TEST_2007_07_15_PONE.query(TemporalQueries.localTime()));
+        assertNull(TemporalQueries.localTime().queryFrom(TEST_2007_07_15_PONE));
+    }
+
+    @Test
     public void test_query_null() {
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.query(null));
     }

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -1059,7 +1059,7 @@ public class TestYearWeek {
         assertEquals(null, TEST.query(TemporalQueries.localDate()));
         assertEquals(null, TEST.query(TemporalQueries.localTime()));
         assertEquals(null, TEST.query(TemporalQueries.offset()));
-        assertEquals(null, TEST.query(TemporalQueries.precision()));
+        assertEquals(ChronoUnit.WEEKS, TEST.query(TemporalQueries.precision()));
         assertEquals(null, TEST.query(TemporalQueries.zone()));
         assertEquals(null, TEST.query(TemporalQueries.zoneId()));
     }


### PR DESCRIPTION
Precision query is defined to return null when date is inconsistent.
`MonthDay` is inconsistent, but all the clases here are consistent.
 Fix implementations and enhance docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct precision query support: DayOfMonth/DayOfYear return DAYS; YearWeek returns WEEKS.
  * OffsetDate now answers local date, chronology, offset/zone, and precision queries.
  * YearHalf exposes a generic query capability.

* **Documentation**
  * Clarified supported TemporalQueries and return types across AmPm, Half, HourMinute, Quarter, YearHalf, YearQuarter, and related types.

* **Tests**
  * Updated precision expectations and added OffsetDate tests for localDate/localTime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->