### PR TITLE
Add JSpecify null annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -505,20 +505,24 @@
     </dependencies>
   </dependencyManagement>
   <dependencies>
+    <!-- annotation dependencies, marked as optional -->
+    <!-- there is much debate, and little conclusion, in the Java community about whether this is correct or not -->
+    <!-- this library takes the view that these annotations are not required at runtime, therefore they are optional -->
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
       <version>${jspecify.version}</version>
       <scope>compile</scope>
-      <optional>true</optional><!-- mandatory in Scala -->
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.joda</groupId>
       <artifactId>joda-convert</artifactId>
       <version>${joda-convert.version}</version>
       <scope>compile</scope>
-      <optional>true</optional><!-- mandatory in Scala -->
+      <optional>true</optional>
     </dependency>
+    <!-- test dependencies -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,13 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>${jspecify.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional><!-- mandatory in Scala -->
+    </dependency>
+    <dependency>
       <groupId>org.joda</groupId>
       <artifactId>joda-convert</artifactId>
       <version>${joda-convert.version}</version>
@@ -928,6 +935,7 @@
     <!-- Dependencies -->
     <assertj.version>3.27.7</assertj.version>
     <joda-convert.version>2.2.4</joda-convert.version>
+    <jspecify.version>1.0.0</jspecify.version>
     <junit.version>5.13.4</junit.version>
     <pioneer.version>1.9.1</pioneer.version><!-- 2.x is Java 11 based -->
     <guava.version>33.6.0-jre</guava.version>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -10,7 +10,8 @@
     <release version="1.10.0" date="SNAPSHOT" description="v1.10.0">
       <action dev="jodastephen" type="add" issue="379">
         Add JSpecify nullness annotations.
-        See also #170
+        This causes AccountingChronology to throw NullPointerException instead of IllegalStateException when null is passed in.
+        See also #170.
       </action>
     </release>
     <release version="1.9.0" date="2026-05-31" description="v1.9.0">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -7,6 +7,12 @@
 
   <body>
     <!-- types are add, fix, remove, update -->
+    <release version="1.10.0" date="SNAPSHOT" description="v1.10.0">
+      <action dev="jodastephen" type="add" issue="379">
+        Add JSpecify nullness annotations.
+        See also #170
+      </action>
+    </release>
     <release version="1.9.0" date="2026-05-31" description="v1.9.0">
       <action dev="jodastephen" type="add" issue="374">
         Add PeriodDuration.truncatedTo().

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -41,6 +41,7 @@ module org.threeten.extra {
 
     // only annotations are used, thus they are optional
     requires static org.joda.convert;
+    requires static org.jspecify;
 
     // export all packages
     exports org.threeten.extra;

--- a/src/main/java/org/threeten/extra/AmPm.java
+++ b/src/main/java/org/threeten/extra/AmPm.java
@@ -50,6 +50,8 @@ import java.time.temporal.ValueRange;
 import java.util.Calendar;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A half-day before or after midday, with the values 'AM' and 'PM'.
  * <p>
@@ -202,7 +204,7 @@ public enum AmPm implements TemporalAccessor, TemporalAdjuster {
      * @return true if the field is supported on this am-pm, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field instanceof ChronoField) {
             return field == AMPM_OF_DAY;
         }

--- a/src/main/java/org/threeten/extra/AmPm.java
+++ b/src/main/java/org/threeten/extra/AmPm.java
@@ -324,7 +324,7 @@ public enum AmPm implements TemporalAccessor, TemporalAdjuster {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.precision()) {
             return (R) HALF_DAYS;
         }

--- a/src/main/java/org/threeten/extra/DayOfMonth.java
+++ b/src/main/java/org/threeten/extra/DayOfMonth.java
@@ -55,6 +55,8 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A day-of-month in the ISO-8601 calendar system.
  * <p>
@@ -249,7 +251,7 @@ public final class DayOfMonth
      * @return true if the field is supported on this day-of-month, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field instanceof ChronoField) {
             return field == DAY_OF_MONTH;
         }
@@ -359,7 +361,7 @@ public final class DayOfMonth
      * @param yearMonth  the year month to validate, null returns false
      * @return true if the year and month are valid for this day
      */
-    public boolean isValidYearMonth(YearMonth yearMonth) {
+    public boolean isValidYearMonth(@Nullable YearMonth yearMonth) {
         return yearMonth != null && yearMonth.isValidDay(day);
     }
 
@@ -502,7 +504,7 @@ public final class DayOfMonth
      * @return true if the day-of-month is the same
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/DayOfMonth.java
+++ b/src/main/java/org/threeten/extra/DayOfMonth.java
@@ -381,7 +381,7 @@ public final class DayOfMonth
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/DayOfYear.java
+++ b/src/main/java/org/threeten/extra/DayOfYear.java
@@ -379,7 +379,7 @@ public final class DayOfYear
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/DayOfYear.java
+++ b/src/main/java/org/threeten/extra/DayOfYear.java
@@ -53,6 +53,8 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A day-of-year in the ISO-8601 calendar system.
  * <p>
@@ -247,7 +249,7 @@ public final class DayOfYear
      * @return true if the field is supported on this day-of-year, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field instanceof ChronoField) {
             return field == DAY_OF_YEAR;
         }
@@ -485,7 +487,7 @@ public final class DayOfYear
      * @return true if the day-of-year is the same
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Days.java
+++ b/src/main/java/org/threeten/extra/Days.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A day-based amount of time, such as '12 days'.
@@ -574,7 +575,7 @@ public final class Days
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Half.java
+++ b/src/main/java/org/threeten/extra/Half.java
@@ -399,7 +399,7 @@ public enum Half implements TemporalAccessor, TemporalAdjuster {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/Half.java
+++ b/src/main/java/org/threeten/extra/Half.java
@@ -53,6 +53,8 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A half-of-year, such as 'H2'.
  * <p>
@@ -212,7 +214,7 @@ public enum Half implements TemporalAccessor, TemporalAdjuster {
      * @return true if the field is supported on this half-of-year, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field == HALF_OF_YEAR) {
             return true;
         } else if (field instanceof ChronoField) {

--- a/src/main/java/org/threeten/extra/HourMinute.java
+++ b/src/main/java/org/threeten/extra/HourMinute.java
@@ -855,7 +855,7 @@ public final class HourMinute
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.localTime()) {
             return (R) toLocalTime();
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/HourMinute.java
+++ b/src/main/java/org/threeten/extra/HourMinute.java
@@ -71,6 +71,7 @@ import java.util.Objects;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An hour-minute, such as {@code 12:31}.
@@ -321,7 +322,7 @@ public final class HourMinute
      * @return true if the field is supported on this hour-minute, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field instanceof ChronoField) {
             return field == MINUTE_OF_HOUR ||
                     field == MINUTE_OF_DAY ||
@@ -359,7 +360,7 @@ public final class HourMinute
      * @return true if the unit can be added/subtracted, false if not
      */
     @Override
-    public boolean isSupported(TemporalUnit unit) {
+    public boolean isSupported(@Nullable TemporalUnit unit) {
         if (unit instanceof ChronoUnit) {
             return unit == MINUTES || unit == HOURS || unit == HALF_DAYS;
         }
@@ -1046,7 +1047,7 @@ public final class HourMinute
      * @return true if this is equal to the other hour-minute
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Hours.java
+++ b/src/main/java/org/threeten/extra/Hours.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An hour-based amount of time, such as '4 hours'.
@@ -570,7 +571,7 @@ public final class Hours
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An immutable interval of time between two instants.
@@ -725,7 +726,7 @@ public final class Interval
      * @return true if this is equal to the other interval
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Interval.java
+++ b/src/main/java/org/threeten/extra/Interval.java
@@ -423,7 +423,7 @@ public final class Interval
      * <p>
      * This is equivalent to {@code (isConnected(other) && !abuts(other))}.
      *
-     * @param other  the time interval to compare to, null means a zero length interval now
+     * @param other  the time interval to compare to, not null
      * @return true if the time intervals overlap
      */
     public boolean overlaps(Interval other) {

--- a/src/main/java/org/threeten/extra/LocalDateRange.java
+++ b/src/main/java/org/threeten/extra/LocalDateRange.java
@@ -47,6 +47,7 @@ import java.util.stream.StreamSupport;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A range of local dates.
@@ -608,8 +609,8 @@ public final class LocalDateRange
                 Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.DISTINCT | Spliterator.ORDERED |
                         Spliterator.SORTED | Spliterator.SIZED | Spliterator.SUBSIZED) {
 
-            private LocalDate current = start;
-            
+            private @Nullable LocalDate current = start;
+
             @Override
             public boolean tryAdvance(Consumer<? super LocalDate> action) {
                 if (current != null) {
@@ -628,7 +629,7 @@ public final class LocalDateRange
             }
             
             @Override
-            public Comparator<? super LocalDate> getComparator() {
+            public @Nullable Comparator<? super LocalDate> getComparator() {
                 return null;
             }
         };
@@ -735,7 +736,7 @@ public final class LocalDateRange
      * @return true if this is equal to the other range
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/LocalDateRange.java
+++ b/src/main/java/org/threeten/extra/LocalDateRange.java
@@ -509,7 +509,7 @@ public final class LocalDateRange
      * <p>
      * This is equivalent to {@code (isConnected(other) && !abuts(other))}.
      *
-     * @param other  the time range to compare to, null means a zero length range now
+     * @param other  the time range to compare to, null
      * @return true if the time ranges overlap
      */
     public boolean overlaps(LocalDateRange other) {

--- a/src/main/java/org/threeten/extra/Minutes.java
+++ b/src/main/java/org/threeten/extra/Minutes.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A minute-based amount of time, such as '8 minutes'.
@@ -590,7 +591,7 @@ public final class Minutes
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Months.java
+++ b/src/main/java/org/threeten/extra/Months.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A month-based amount of time, such as '12 months'.
@@ -574,7 +575,7 @@ public final class Months
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/MutableClock.java
+++ b/src/main/java/org/threeten/extra/MutableClock.java
@@ -50,6 +50,8 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A clock that does not advance on its own and that must be updated manually.
  * <p>
@@ -316,7 +318,7 @@ public final class MutableClock
      * @return {@code true} if this is equal to the other clock
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/OffsetDate.java
+++ b/src/main/java/org/threeten/extra/OffsetDate.java
@@ -69,6 +69,7 @@ import java.util.Objects;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A date with an offset from UTC/Greenwich in the ISO-8601 calendar system,
@@ -369,7 +370,7 @@ public final class OffsetDate
      * @return true if the field is supported on this date, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field instanceof ChronoField) {
             return field.isDateBased() || field == OFFSET_SECONDS;
         }
@@ -406,7 +407,7 @@ public final class OffsetDate
      * @return true if the unit can be added/subtracted, false if not
      */
     @Override
-    public boolean isSupported(TemporalUnit unit) {
+    public boolean isSupported(@Nullable TemporalUnit unit) {
         if (unit instanceof ChronoUnit) {
             return unit.isDateBased();
         }
@@ -1328,7 +1329,7 @@ public final class OffsetDate
      * @return true if this is equal to the other date
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/OffsetDate.java
+++ b/src/main/java/org/threeten/extra/OffsetDate.java
@@ -1066,7 +1066,7 @@ public final class OffsetDate
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.localDate()) {
             return (R) date;
         } else if (query == TemporalQueries.chronology()) {

--- a/src/main/java/org/threeten/extra/OffsetDate.java
+++ b/src/main/java/org/threeten/extra/OffsetDate.java
@@ -316,6 +316,8 @@ public final class OffsetDate
      * @return the valid object, not null
      */
     private Object readResolve() {
+        Objects.requireNonNull(date, "date");
+        Objects.requireNonNull(offset, "offset");
         return of(date, offset);
     }
 

--- a/src/main/java/org/threeten/extra/PackedFields.java
+++ b/src/main/java/org/threeten/extra/PackedFields.java
@@ -54,6 +54,8 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.ValueRange;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Temporal fields based on a packed representation.
  * <p>
@@ -286,7 +288,7 @@ public final class PackedFields {
 
         //-----------------------------------------------------------------------
         @Override
-        public ChronoLocalDate resolve(
+        public @Nullable ChronoLocalDate resolve(
                 Map<TemporalField, Long> fieldValues, TemporalAccessor partialTemporal, ResolverStyle resolverStyle) {
             long value = fieldValues.remove(this);
             long hour = value / 100;
@@ -382,7 +384,7 @@ public final class PackedFields {
 
         //-----------------------------------------------------------------------
         @Override
-        public ChronoLocalDate resolve(
+        public @Nullable ChronoLocalDate resolve(
                 Map<TemporalField, Long> fieldValues, TemporalAccessor partialTemporal, ResolverStyle resolverStyle) {
             long value = fieldValues.remove(this);
             long hour = value / 10000;

--- a/src/main/java/org/threeten/extra/PeriodDuration.java
+++ b/src/main/java/org/threeten/extra/PeriodDuration.java
@@ -61,6 +61,7 @@ import java.util.Objects;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An amount of time in the ISO-8601 calendar system that combines a period and a duration.
@@ -680,7 +681,7 @@ public final class PeriodDuration
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/PeriodDuration.java
+++ b/src/main/java/org/threeten/extra/PeriodDuration.java
@@ -355,6 +355,8 @@ public final class PeriodDuration
      * @return the singleton instance
      */
     private Object readResolve() {
+        Objects.requireNonNull(period, "period");
+        Objects.requireNonNull(duration, "duration");
         return PeriodDuration.of(period, duration);
     }
 

--- a/src/main/java/org/threeten/extra/Quarter.java
+++ b/src/main/java/org/threeten/extra/Quarter.java
@@ -443,7 +443,7 @@ public enum Quarter implements TemporalAccessor, TemporalAdjuster {
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/Quarter.java
+++ b/src/main/java/org/threeten/extra/Quarter.java
@@ -54,6 +54,8 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A quarter-of-year, such as 'Q2'.
  * <p>
@@ -232,7 +234,7 @@ public enum Quarter implements TemporalAccessor, TemporalAdjuster {
      * @return true if the field is supported on this quarter-of-year, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field == QUARTER_OF_YEAR) {
             return true;
         } else if (field instanceof ChronoField) {

--- a/src/main/java/org/threeten/extra/Seconds.java
+++ b/src/main/java/org/threeten/extra/Seconds.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A second-based amount of time, such as '8 seconds'.
@@ -625,7 +626,7 @@ public final class Seconds
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/TemporalFields.java
+++ b/src/main/java/org/threeten/extra/TemporalFields.java
@@ -53,6 +53,8 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Additional Temporal fields.
  * <p>
@@ -207,7 +209,7 @@ public final class TemporalFields {
 
         //-----------------------------------------------------------------------
         @Override
-        public ChronoLocalDate resolve(
+        public @Nullable ChronoLocalDate resolve(
                 Map<TemporalField, Long> fieldValues,
                 TemporalAccessor partialTemporal,
                 ResolverStyle resolverStyle) {

--- a/src/main/java/org/threeten/extra/Weeks.java
+++ b/src/main/java/org/threeten/extra/Weeks.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A week-based amount of time, such as '12 weeks'.
@@ -530,7 +531,7 @@ public final class Weeks
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/YearHalf.java
+++ b/src/main/java/org/threeten/extra/YearHalf.java
@@ -988,7 +988,7 @@ public final class YearHalf
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/YearHalf.java
+++ b/src/main/java/org/threeten/extra/YearHalf.java
@@ -75,6 +75,7 @@ import java.util.stream.Stream;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A year-half in the ISO-8601 calendar system, such as {@code 2007-H2}.
@@ -361,7 +362,7 @@ public final class YearHalf
      * @return true if the field is supported on this year-half, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field == HALF_OF_YEAR) {
             return true;
         } else if (field instanceof ChronoField) {
@@ -398,7 +399,7 @@ public final class YearHalf
      * @return true if the unit can be added/subtracted, false if not
      */
     @Override
-    public boolean isSupported(TemporalUnit unit) {
+    public boolean isSupported(@Nullable TemporalUnit unit) {
         if (unit == HALF_YEARS) {
             return true;
         } else if (unit instanceof ChronoUnit) {
@@ -1233,7 +1234,7 @@ public final class YearHalf
      * @return true if this is equal to the other year-half
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/YearHalf.java
+++ b/src/main/java/org/threeten/extra/YearHalf.java
@@ -316,6 +316,7 @@ public final class YearHalf
      * @return the valid object, not null
      */
     private Object readResolve() {
+        Objects.requireNonNull(half, "half");
         return of(year, half);
     }
 

--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -76,6 +76,7 @@ import java.util.stream.Stream;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A year-quarter in the ISO-8601 calendar system, such as {@code 2007-Q2}.
@@ -362,7 +363,7 @@ public final class YearQuarter
      * @return true if the field is supported on this year-quarter, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field == QUARTER_OF_YEAR) {
             return true;
         } else if (field instanceof ChronoField) {
@@ -399,7 +400,7 @@ public final class YearQuarter
      * @return true if the unit can be added/subtracted, false if not
      */
     @Override
-    public boolean isSupported(TemporalUnit unit) {
+    public boolean isSupported(@Nullable TemporalUnit unit) {
         if (unit == QUARTER_YEARS) {
             return true;
         } else if (unit instanceof ChronoUnit) {
@@ -1234,7 +1235,7 @@ public final class YearQuarter
      * @return true if this is equal to the other year-quarter
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -317,6 +317,7 @@ public final class YearQuarter
      * @return the valid object, not null
      */
     private Object readResolve() {
+        Objects.requireNonNull(quarter, "quarter");
         return of(year, quarter);
     }
 

--- a/src/main/java/org/threeten/extra/YearQuarter.java
+++ b/src/main/java/org/threeten/extra/YearQuarter.java
@@ -989,7 +989,7 @@ public final class YearQuarter
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -855,7 +855,7 @@ public final class YearWeek
      */
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.chronology()) {
             return (R) IsoChronology.INSTANCE;
         } else if (query == TemporalQueries.precision()) {

--- a/src/main/java/org/threeten/extra/YearWeek.java
+++ b/src/main/java/org/threeten/extra/YearWeek.java
@@ -70,6 +70,7 @@ import java.util.Objects;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A year-week in the ISO week date system such as {@code 2015-W13}
@@ -360,7 +361,7 @@ public final class YearWeek
      * @return true if the field is supported on this year-week, false if not
      */
     @Override
-    public boolean isSupported(TemporalField field) {
+    public boolean isSupported(@Nullable TemporalField field) {
         if (field == WEEK_OF_WEEK_BASED_YEAR || field == WEEK_BASED_YEAR) {
             return true;
         } else if (field instanceof ChronoField) {
@@ -392,7 +393,7 @@ public final class YearWeek
      * @return true if the unit can be added/subtracted, false if not
      */
     @Override
-    public boolean isSupported(TemporalUnit unit) {
+    public boolean isSupported(@Nullable TemporalUnit unit) {
         if (unit == WEEKS || unit == WEEK_BASED_YEARS) {
             return true;
         } else if (unit instanceof ChronoUnit) {
@@ -1066,7 +1067,7 @@ public final class YearWeek
      * @return true if this is equal to the other year-week
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/Years.java
+++ b/src/main/java/org/threeten/extra/Years.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A year-based amount of time, such as '12 years'.
@@ -530,7 +531,7 @@ public final class Years
      * @return true if the other amount is equal to this one
      */
     @Override
-    public boolean equals(Object otherAmount) {
+    public boolean equals(@Nullable Object otherAmount) {
         if (this == otherAmount) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/chrono/AbstractDate.java
+++ b/src/main/java/org/threeten/extra/chrono/AbstractDate.java
@@ -46,6 +46,7 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.UnsupportedTemporalTypeException;
 import java.time.temporal.ValueRange;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An abstract date based on a year, month and day.
@@ -357,7 +358,7 @@ abstract class AbstractDate
      * @return true if this is equal to the other date
      */
     @Override  // override for performance
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronology.java
@@ -159,23 +159,26 @@ public final class AccountingChronology extends AbstractChronology implements Se
      * Creates an {@code AccountingChronology} validating the input.
      * Package private as only meant to be called from the builder.
      *
-     * @param endsOn  The day-of-week a given year ends on.
-     * @param end The  month-end the year is based on.
-     * @param inLastWeek  Whether the year ends in the last week of the month, or nearest the end-of-month.
-     * @param division  How the year is divided.
-     * @param leapWeekInMonth  The month in which the leap-week resides.
-     * @return The created Chronology, not null.
-     * @throws DateTimeException if the chronology cannot be built.
+     * @param endsOn  the day-of-week a given year ends on, not null
+     * @param end  the month-end the year is based on, not null
+     * @param inLastWeek  whether the year ends in the last week of the month, or nearest the end-of-month
+     * @param division  how the year is divided, not null
+     * @param leapWeekInMonth  the month in which the leap-week resides, valid for {@code division}, not zero
+     * @return the created Chronology, not null
+     * @throws DateTimeException if the chronology cannot be built
      */
-    static AccountingChronology create(DayOfWeek endsOn, Month end, boolean inLastWeek, AccountingYearDivision division,
-            int leapWeekInMonth, int yearOffset) {
-        if (endsOn == null || end == null || division == null || leapWeekInMonth == 0) {
-            throw new IllegalStateException("AccountingCronology cannot be built: "
-                    + (endsOn == null ? "| ending day-of-week |" : "")
-                    + (end == null ? "| month ending in/nearest to |" : "")
-                    + (division == null ? "| how year divided |" : "")
-                    + (leapWeekInMonth == 0 ? "| leap-week month |" : "")
-                    + " not set.");
+    static AccountingChronology create(
+            DayOfWeek endsOn,
+            Month end,
+            boolean inLastWeek,
+            AccountingYearDivision division,
+            int leapWeekInMonth,
+            int yearOffset) {
+        Objects.requireNonNull(endsOn, "endsOn");
+        Objects.requireNonNull(end, "end");
+        Objects.requireNonNull(division, "division");
+        if (leapWeekInMonth == 0) {
+            throw new IllegalStateException("AccountingChronology leapWeekInMonth cannot be zero");
         }
         if (!division.getMonthsInYearRange().isValidValue(leapWeekInMonth)) {
             throw new IllegalStateException("Leap week cannot not be placed in non-existent month " + leapWeekInMonth

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronology.java
@@ -54,6 +54,8 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * An Accounting calendar system.
  * <p>
@@ -279,7 +281,7 @@ public final class AccountingChronology extends AbstractChronology implements Se
      * @see #getId()
      */
     @Override
-    public String getCalendarType() {
+    public @Nullable String getCalendarType() {
         return null;
     }
 
@@ -554,7 +556,7 @@ public final class AccountingChronology extends AbstractChronology implements Se
 
     //-------------------------------------------------------------------------
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronology.java
@@ -54,6 +54,7 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -236,6 +237,8 @@ public final class AccountingChronology extends AbstractChronology implements Se
      * @return a built, validated instance.
      */
     private Object readResolve() {
+        Objects.requireNonNull(endsOn, "endsOn");
+        Objects.requireNonNull(end, "end");
         return AccountingChronology.create(endsOn, end, inLastWeek, getDivision(), leapWeekInMonth, yearOffset);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
@@ -34,6 +34,7 @@ package org.threeten.extra.chrono;
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Month;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -189,6 +190,9 @@ public final class AccountingChronologyBuilder {
      * @throws DateTimeException if the chronology cannot be built.
      */
     public AccountingChronology toChronology() {
+        Objects.requireNonNull(endsOn, "endsOn");
+        Objects.requireNonNull(end, "end");
+        Objects.requireNonNull(division, "division");
         return AccountingChronology.create(endsOn, end, inLastWeek, division, leapWeekInMonth, yearOffset);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
@@ -104,7 +104,7 @@ public final class AccountingChronologyBuilder {
      * @return this, for chaining, not null.
      */
     public AccountingChronologyBuilder endsOn(DayOfWeek endsOn) {
-        this.endsOn = endsOn;
+        this.endsOn = Objects.requireNonNull(endsOn, "endsOn");
         return this;
     }
 
@@ -119,7 +119,7 @@ public final class AccountingChronologyBuilder {
      */
     public AccountingChronologyBuilder nearestEndOf(Month end) {
         this.inLastWeek = false;
-        this.end = end;
+        this.end = Objects.requireNonNull(end, "end");
         return this;
     }
 
@@ -134,7 +134,7 @@ public final class AccountingChronologyBuilder {
      */
     public AccountingChronologyBuilder inLastWeekOf(Month end) {
         this.inLastWeek = true;
-        this.end = end;
+        this.end = Objects.requireNonNull(end, "end");
         return this;
     }
 
@@ -146,7 +146,7 @@ public final class AccountingChronologyBuilder {
      * @return this, for chaining, not null.
      */
     public AccountingChronologyBuilder withDivision(AccountingYearDivision division) {
-        this.division = division;
+        this.division = Objects.requireNonNull(division, "division");
         return this;
     }
 

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
@@ -190,9 +190,7 @@ public final class AccountingChronologyBuilder {
      * @throws DateTimeException if the chronology cannot be built.
      */
     public AccountingChronology toChronology() {
-        Objects.requireNonNull(endsOn, "endsOn");
-        Objects.requireNonNull(end, "end");
-        Objects.requireNonNull(division, "division");
+        //noinspection DataFlowIssue - nullness checked in the constructor of AccountingChronology
         return AccountingChronology.create(endsOn, end, inLastWeek, division, leapWeekInMonth, yearOffset);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
@@ -99,9 +99,8 @@ public final class AccountingChronologyBuilder {
     /**
      * Sets the day-of-week on which a given Accounting calendar year ends.
      *
-     * @param endsOn The day-of-week on which a given Accounting calendar year ends.
-     *
-     * @return this, for chaining, not null.
+     * @param endsOn the day-of-week on which a given Accounting calendar year ends
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder endsOn(DayOfWeek endsOn) {
         this.endsOn = Objects.requireNonNull(endsOn, "endsOn");
@@ -113,9 +112,8 @@ public final class AccountingChronologyBuilder {
      * Calendars setup this way will occasionally end in the start of the <i>next</i> month.
      * For example, for July, the month ends on any day from July 28th to August 3rd.
      *
-     * @param end The Gregorian/ISO month-end a given Accounting calendar year ends nearest to.
-     *
-     * @return this, for chaining, not null.
+     * @param end the Gregorian/ISO month-end a given Accounting calendar year ends nearest to
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder nearestEndOf(Month end) {
         this.inLastWeek = false;
@@ -128,9 +126,8 @@ public final class AccountingChronologyBuilder {
      * Calendars setup this way will always end in the last week of the given month.
      * For example, for July, the month ends on any day from July 25th to July 31st.
      *
-     * @param end The Gregorian/ISO month-end a given Accounting calendar year ends in the last week of.
-     *
-     * @return this, for chaining, not null.
+     * @param end the Gregorian/ISO month-end a given Accounting calendar year ends in the last week of
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder inLastWeekOf(Month end) {
         this.inLastWeek = true;
@@ -141,9 +138,8 @@ public final class AccountingChronologyBuilder {
     /**
      * Sets how a given Accounting year will be divided.
      *
-     * @param division How to divide a given calendar year.
-     *
-     * @return this, for chaining, not null.
+     * @param division how to divide a given calendar year
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder withDivision(AccountingYearDivision division) {
         this.division = Objects.requireNonNull(division, "division");
@@ -153,9 +149,8 @@ public final class AccountingChronologyBuilder {
     /**
      * Sets the month in which the leap-week occurs.
      *
-     * @param leapWeekInMonth The month in which the leap-week occurs.
-     *
-     * @return this, for chaining, not null.
+     * @param leapWeekInMonth the month in which the leap-week occurs
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder leapWeekInMonth(int leapWeekInMonth) {
         this.leapWeekInMonth = leapWeekInMonth;
@@ -165,7 +160,7 @@ public final class AccountingChronologyBuilder {
     /**
      * Sets the proleptic accounting year to end in the matching Iso year.
      *
-     * @return this, for chaining, not null.
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder accountingYearEndsInIsoYear() {
         this.yearOffset = 0;
@@ -176,7 +171,7 @@ public final class AccountingChronologyBuilder {
     /**
      * Sets the proleptic accounting year to start in the matching Iso year.
      *
-     * @return this, for chaining, not null.
+     * @return this, for chaining, not null
      */
     public AccountingChronologyBuilder accountingYearStartsInIsoYear() {
         this.yearOffset = 1;
@@ -186,8 +181,9 @@ public final class AccountingChronologyBuilder {
     /**
      * Completes this builder by creating the {@code AccountingChronology}.
      *
-     * @return the created chronology, not null.
-     * @throws DateTimeException if the chronology cannot be built.
+     * @return the created chronology, not null
+     * @throws IllegalStateException if any of the required fields are invalid
+     * @throws DateTimeException if the chronology cannot be built
      */
     public AccountingChronology toChronology() {
         //noinspection DataFlowIssue - nullness checked in the constructor of AccountingChronology

--- a/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingChronologyBuilder.java
@@ -34,6 +34,7 @@ package org.threeten.extra.chrono;
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Month;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Builder to create Accounting calendars.
@@ -63,7 +64,7 @@ public final class AccountingChronologyBuilder {
     /**
      * The day of the week on which a given Accounting year ends.
      */
-    private DayOfWeek endsOn;
+    private @Nullable DayOfWeek endsOn;
     /**
      * Whether the calendar ends in the last week of a given Gregorian/ISO month,
      * or nearest to the last day of the month (will sometimes be in the next month).
@@ -72,11 +73,11 @@ public final class AccountingChronologyBuilder {
     /**
      * Which Gregorian/ISO end-of-month the year ends in/is nearest to.
      */
-    private Month end;
+    private @Nullable Month end;
     /**
      * How to divide an accounting year.
      */
-    private AccountingYearDivision division;
+    private @Nullable AccountingYearDivision division;
     /**
      * The month which will have the leap-week added.
      */

--- a/src/main/java/org/threeten/extra/chrono/AccountingDate.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingDate.java
@@ -57,6 +57,8 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.ValueRange;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A date in an Accounting calendar system.
  * <p>
@@ -480,7 +482,7 @@ public final class AccountingDate extends AbstractDate implements ChronoLocalDat
      * @return true if this is equal to the other date
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/chrono/AccountingDate.java
+++ b/src/main/java/org/threeten/extra/chrono/AccountingDate.java
@@ -341,6 +341,7 @@ public final class AccountingDate extends AbstractDate implements ChronoLocalDat
      * @return the resolved date, not null
      */
     private Object readResolve() {
+        Objects.requireNonNull(chronology, "chronology");
         return AccountingDate.create(chronology, prolepticYear, month, day);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/BritishCutoverChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/BritishCutoverChronology.java
@@ -464,7 +464,7 @@ public final class BritishCutoverChronology
 
     //-----------------------------------------------------------------------
     @Override  // override for return type
-    public BritishCutoverDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+    public @Nullable BritishCutoverDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (BritishCutoverDate) super.resolveDate(fieldValues, resolverStyle);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/BritishCutoverChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/BritishCutoverChronology.java
@@ -52,6 +52,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The British Julian-Gregorian cutover calendar system.
  * <p>
@@ -204,7 +206,7 @@ public final class BritishCutoverChronology
      * @see #getId()
      */
     @Override
-    public String getCalendarType() {
+    public @Nullable String getCalendarType() {
         return null;
     }
 

--- a/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
+++ b/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
@@ -56,6 +56,8 @@ import java.time.temporal.TemporalUnit;
 import java.time.temporal.ValueRange;
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A date in the British Cutover calendar system.
  * <p>
@@ -527,7 +529,7 @@ public final class BritishCutoverDate
 
     //-------------------------------------------------------------------------
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
+++ b/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
@@ -83,7 +83,7 @@ public final class BritishCutoverDate
     /**
      * The underlying Julian date if before the cutover.
      */
-    private final transient JulianDate julianDate;
+    private final transient @Nullable JulianDate julianDate;
 
     //-----------------------------------------------------------------------
     /**
@@ -271,6 +271,7 @@ public final class BritishCutoverDate
      * @return the resolved date, not null
      */
     private Object readResolve() {
+        Objects.requireNonNull(isoDate, "isoDate");
         return new BritishCutoverDate(isoDate);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
+++ b/src/main/java/org/threeten/extra/chrono/BritishCutoverDate.java
@@ -521,7 +521,7 @@ public final class BritishCutoverDate
 
     @SuppressWarnings("unchecked")
     @Override
-    public <R> R query(TemporalQuery<R> query) {
+    public <R extends @Nullable Object> R query(TemporalQuery<R> query) {
         if (query == TemporalQueries.localDate()) {
             return (R) isoDate;
         }

--- a/src/main/java/org/threeten/extra/chrono/CopticChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/CopticChronology.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The Coptic calendar system.
@@ -337,7 +338,7 @@ public final class CopticChronology
 
     //-----------------------------------------------------------------------
     @Override  // override for return type
-    public CopticDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+    public @Nullable CopticDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (CopticDate) super.resolveDate(fieldValues, resolverStyle);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/DiscordianChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/DiscordianChronology.java
@@ -49,6 +49,7 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The Discordian calendar system.
@@ -449,7 +450,7 @@ public final class DiscordianChronology
 
     //-----------------------------------------------------------------------
     @Override  // override for return type
-    public DiscordianDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+    public @Nullable DiscordianDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (DiscordianDate) super.resolveDate(fieldValues, resolverStyle);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/EthiopicChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/EthiopicChronology.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The Ethiopic calendar system.
@@ -337,7 +338,7 @@ public final class EthiopicChronology
 
     //-----------------------------------------------------------------------
     @Override  // override for return type
-    public EthiopicDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+    public @Nullable EthiopicDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (EthiopicDate) super.resolveDate(fieldValues, resolverStyle);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/InternationalFixedChronology.java
@@ -47,6 +47,8 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The International Fixed calendar system.
  * <p>
@@ -204,7 +206,7 @@ public final class InternationalFixedChronology extends AbstractChronology imple
      * @see #getId()
      */
     @Override
-    public String getCalendarType() {
+    public @Nullable String getCalendarType() {
         return null;
     }
 

--- a/src/main/java/org/threeten/extra/chrono/JulianChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/JulianChronology.java
@@ -49,6 +49,7 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The Julian calendar system.
@@ -386,7 +387,7 @@ public final class JulianChronology extends AbstractChronology implements Serial
 
     //-----------------------------------------------------------------------
     @Override  // override for return type
-    public JulianDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+    public @Nullable JulianDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (JulianDate) super.resolveDate(fieldValues, resolverStyle);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/PaxChronology.java
+++ b/src/main/java/org/threeten/extra/chrono/PaxChronology.java
@@ -49,6 +49,7 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The Pax calendar system.
@@ -430,7 +431,7 @@ public final class PaxChronology extends AbstractChronology implements Serializa
 
     //-----------------------------------------------------------------------
     @Override
-    public PaxDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
+    public @Nullable PaxDate resolveDate(Map<TemporalField, Long> fieldValues, ResolverStyle resolverStyle) {
         return (PaxDate) super.resolveDate(fieldValues, resolverStyle);
     }
 

--- a/src/main/java/org/threeten/extra/chrono/Symmetry010Chronology.java
+++ b/src/main/java/org/threeten/extra/chrono/Symmetry010Chronology.java
@@ -48,6 +48,8 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The Symmetry010 calendar system.
  * <p>
@@ -226,7 +228,7 @@ public final class Symmetry010Chronology
      * @see #getId()
      */
     @Override
-    public String getCalendarType() {
+    public @Nullable String getCalendarType() {
         return null;
     }
 

--- a/src/main/java/org/threeten/extra/chrono/Symmetry454Chronology.java
+++ b/src/main/java/org/threeten/extra/chrono/Symmetry454Chronology.java
@@ -48,6 +48,8 @@ import java.time.temporal.ValueRange;
 import java.util.Arrays;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The Symmetry454 calendar system.
  * <p>
@@ -223,7 +225,7 @@ public final class Symmetry454Chronology
      * @see #getId()
      */
     @Override
-    public String getCalendarType() {
+    public @Nullable String getCalendarType() {
         return null;
     }
 

--- a/src/main/java/org/threeten/extra/chrono/package-info.java
+++ b/src/main/java/org/threeten/extra/chrono/package-info.java
@@ -32,4 +32,7 @@
 /**
  * Additional chronologies (calendar systems) that extend {@code java.time.*}.
  */
+@NullMarked
 package org.threeten.extra.chrono;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/org/threeten/extra/package-info.java
+++ b/src/main/java/org/threeten/extra/package-info.java
@@ -32,4 +32,8 @@
 /**
  * Value types and utilities that extend {@code java.time.*}.
  */
+@NullMarked
 package org.threeten.extra;
+
+import org.jspecify.annotations.NullMarked;
+

--- a/src/main/java/org/threeten/extra/scale/TaiInstant.java
+++ b/src/main/java/org/threeten/extra/scale/TaiInstant.java
@@ -42,6 +42,7 @@ import java.util.regex.Pattern;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An instantaneous point on the time-line measured in the TAI time-scale.
@@ -448,7 +449,7 @@ public final class TaiInstant
      * @return true if the other instant is equal to this one
      */
     @Override
-    public boolean equals(Object otherInstant) {
+    public boolean equals(@Nullable Object otherInstant) {
         if (this == otherInstant) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/scale/UtcInstant.java
+++ b/src/main/java/org/threeten/extra/scale/UtcInstant.java
@@ -49,6 +49,7 @@ import java.time.temporal.TemporalAccessor;
 
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An instantaneous point on the time-line measured in the UTC time-scale
@@ -129,7 +130,7 @@ public final class UtcInstant
     /**
      * A cache of the result from {@link #toString()} 
      */
-    private transient String toString;
+    private transient @Nullable String toString;
 
     //-----------------------------------------------------------------------
     /**
@@ -462,7 +463,7 @@ public final class UtcInstant
      * @return true if the other instant is equal to this one
      */
     @Override
-    public boolean equals(Object otherInstant) {
+    public boolean equals(@Nullable Object otherInstant) {
         if (this == otherInstant) {
             return true;
         }

--- a/src/main/java/org/threeten/extra/scale/package-info.java
+++ b/src/main/java/org/threeten/extra/scale/package-info.java
@@ -32,4 +32,7 @@
 /**
  * Support for time scales that extend {@code java.time.*}.
  */
+@NullMarked
 package org.threeten.extra.scale;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronologyBuilder.java
@@ -438,10 +438,7 @@ public class TestAccountingChronologyBuilder {
                 arguments(DayOfWeek.MONDAY, Month.JANUARY, AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS, 14),
                 arguments(DayOfWeek.MONDAY, Month.JANUARY, AccountingYearDivision.QUARTERS_OF_PATTERN_4_4_5_WEEKS, 13),
                 arguments(DayOfWeek.MONDAY, Month.JANUARY, AccountingYearDivision.QUARTERS_OF_PATTERN_4_5_4_WEEKS, 13),
-                arguments(DayOfWeek.MONDAY, Month.JANUARY, AccountingYearDivision.QUARTERS_OF_PATTERN_5_4_4_WEEKS, 13),
-                arguments(DayOfWeek.MONDAY, Month.JANUARY, null, 13),
-                arguments(DayOfWeek.MONDAY, null, AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS, 13),
-                arguments(null, Month.JANUARY, AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS, 13));
+                arguments(DayOfWeek.MONDAY, Month.JANUARY, AccountingYearDivision.QUARTERS_OF_PATTERN_5_4_4_WEEKS, 13));
     }
 
     @ParameterizedTest
@@ -457,6 +454,31 @@ public class TestAccountingChronologyBuilder {
     @MethodSource("data_badChronology")
     public void test_badChronology_inLastWeekOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
         assertThrows(IllegalStateException.class,
+                () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
+                        .withDivision(division).leapWeekInMonth(leapWeekInMonth)
+                        .toChronology());
+    }
+
+    public static Stream<Arguments> data_nullPassedIn() {
+        return Stream.of(
+                arguments(DayOfWeek.MONDAY, Month.JANUARY, null, 13),
+                arguments(DayOfWeek.MONDAY, null, AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS, 13),
+                arguments(null, Month.JANUARY, AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS, 13));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data_nullPassedIn")
+    public void test_nullPassedIn_nearestEndOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
+        assertThrows(NullPointerException.class,
+                () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).nearestEndOf(ending)
+                        .withDivision(division).leapWeekInMonth(leapWeekInMonth)
+                        .toChronology());
+    }
+
+    @ParameterizedTest
+    @MethodSource("data_nullPassedIn")
+    public void test_nullPassedIn_inLastWeekOf(DayOfWeek dayOfWeek, Month ending, AccountingYearDivision division, int leapWeekInMonth) {
+        assertThrows(NullPointerException.class,
                 () -> new AccountingChronologyBuilder().endsOn(dayOfWeek).inLastWeekOf(ending)
                         .withDivision(division).leapWeekInMonth(leapWeekInMonth)
                         .toChronology());


### PR DESCRIPTION
Introduce JSpecify nullness annotations to ThreeTen-Extra.

[JSpecify](https://jspecify.dev/) is becoming the de facto standard for nullness annotations in Java. It allows methods and fields to be marked as accepting null, with a non-null default.

This change introduces the annotations to the main code, not the tests.

See #170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an optional nullability annotation dependency and updated module metadata.
  * Marked the package (and many public APIs) with nullness contracts to better reflect nullable behavior.
  * Strengthened deserialization checks to fail fast when critical fields are missing.

* **Tests**
  * Added parameterized tests for chronology builder methods to verify null inputs now raise `NullPointerException`.

* **Documentation**
  * Updated release notes for **1.10.0 (SNAPSHOT)** describing the null-input exception behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->