### PR TITLE
Update tests for JSpecify

### DIFF
--- a/src/test/java/org/threeten/extra/TestAmPm.java
+++ b/src/test/java/org/threeten/extra/TestAmPm.java
@@ -153,6 +153,7 @@ public class TestAmPm {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AmPm.from((TemporalAccessor) null));
     }
 
@@ -166,11 +167,13 @@ public class TestAmPm {
 
     @Test
     public void test_getDisplayName_nullStyle() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AmPm.AM.getDisplayName(null, Locale.US));
     }
 
     @Test
     public void test_getDisplayName_nullLocale() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AmPm.AM.getDisplayName(TextStyle.FULL, null));
     }
 
@@ -228,6 +231,7 @@ public class TestAmPm {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AmPm.AM.range(null));
     }
 
@@ -247,6 +251,7 @@ public class TestAmPm {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AmPm.PM.get(null));
     }
 
@@ -266,6 +271,7 @@ public class TestAmPm {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AmPm.PM.getLong(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestAmountFormats.java
+++ b/src/test/java/org/threeten/extra/TestAmountFormats.java
@@ -39,6 +39,7 @@ import java.time.Period;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -580,8 +581,8 @@ public class TestAmountFormats {
         }
     }
 
-    public static Object[][] duration_unitBasedErrors() {
-        return new Object[][] {
+    public static @Nullable Object[][] duration_unitBasedErrors() {
+        return new @Nullable Object[][] {
             {new NullPointerException("durationText must not be null"), null},
             {new DateTimeParseException("Not a numeric value", "", 0), ""},
             {new DateTimeParseException("Not a numeric value", "+", 0), "+"},

--- a/src/test/java/org/threeten/extra/TestDayOfMonth.java
+++ b/src/test/java/org/threeten/extra/TestDayOfMonth.java
@@ -325,6 +325,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> DayOfMonth.from((TemporalAccessor) null));
     }
 
@@ -389,6 +390,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
@@ -407,6 +409,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
@@ -435,6 +438,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
@@ -564,6 +568,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_adjustInto_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
@@ -606,6 +611,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_atMonth_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.atMonth((Month) null));
     }
 
@@ -696,6 +702,7 @@ public class TestDayOfMonth {
 
     @Test
     public void test_atYearMonth_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.atYearMonth((YearMonth) null));
     }
 
@@ -726,6 +733,7 @@ public class TestDayOfMonth {
     public void test_compareTo_nullDayOfMonth() {
         DayOfMonth dom = null;
         DayOfMonth test = DayOfMonth.of(1);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test.compareTo(dom));
     }
 

--- a/src/test/java/org/threeten/extra/TestDayOfYear.java
+++ b/src/test/java/org/threeten/extra/TestDayOfYear.java
@@ -265,6 +265,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> DayOfYear.from((TemporalAccessor) null));
     }
 
@@ -328,6 +329,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
@@ -346,6 +348,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
@@ -374,6 +377,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
@@ -478,6 +482,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_adjustInto_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
@@ -512,6 +517,7 @@ public class TestDayOfYear {
 
     @Test
     public void test_atYear_Year_nullYear() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.atYear((Year) null));
     }
 
@@ -576,6 +582,7 @@ public class TestDayOfYear {
     public void test_compareTo_nullDayOfYear() {
         DayOfYear doy = null;
         DayOfYear test = DayOfYear.of(1);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test.compareTo(doy));
     }
 

--- a/src/test/java/org/threeten/extra/TestDays.java
+++ b/src/test/java/org/threeten/extra/TestDays.java
@@ -178,6 +178,7 @@ public class TestDays {
 
     @Test
     public void test_from_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Days.from((TemporalAmount) null));
     }
 
@@ -257,6 +258,7 @@ public class TestDays {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Days.parse((CharSequence) null));
     }
 
@@ -279,11 +281,13 @@ public class TestDays {
 
     @Test
     public void test_between_date_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Days.between(LocalDate.now(), (Temporal) null));
     }
 
     @Test
     public void test_between_null_date() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Days.between((Temporal) null, LocalDate.now()));
     }
 
@@ -330,6 +334,7 @@ public class TestDays {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Days.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -397,6 +402,7 @@ public class TestDays {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Days.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -535,6 +541,7 @@ public class TestDays {
     @Test
     public void test_compareTo_null() {
         Days test5 = Days.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestHalf.java
+++ b/src/test/java/org/threeten/extra/TestHalf.java
@@ -177,6 +177,7 @@ public class TestHalf {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Half.from((TemporalAccessor) null));
     }
 
@@ -199,11 +200,13 @@ public class TestHalf {
 
     @Test
     public void test_getDisplayName_nullStyle() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Half.H1.getDisplayName(null, Locale.US));
     }
 
     @Test
     public void test_getDisplayName_nullLocale() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Half.H1.getDisplayName(TextStyle.FULL, null));
     }
 
@@ -263,6 +266,7 @@ public class TestHalf {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Half.H1.range(null));
     }
 
@@ -282,6 +286,7 @@ public class TestHalf {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Half.H2.get(null));
     }
 
@@ -301,6 +306,7 @@ public class TestHalf {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Half.H2.getLong(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestHourMinute.java
+++ b/src/test/java/org/threeten/extra/TestHourMinute.java
@@ -182,6 +182,7 @@ public class TestHourMinute {
             }
         }
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> HourMinute.from(LocalDate.of(2020, 6, 3)));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> HourMinute.from((TemporalAccessor) null));
     }
 
@@ -207,6 +208,7 @@ public class TestHourMinute {
 
     @Test
     public void test_parse_CharSequence_invalid() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> HourMinute.parse((CharSequence) null));
     }
 
@@ -220,7 +222,9 @@ public class TestHourMinute {
 
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_invalid() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> HourMinute.parse((CharSequence) null, DateTimeFormatter.ISO_OFFSET_TIME));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> HourMinute.parse("23:59", (DateTimeFormatter) null));
     }
 
@@ -310,6 +314,7 @@ public class TestHourMinute {
     public void test_range_invalid() {
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.range(SECOND_OF_MINUTE));
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.range(NANO_OF_SECOND));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.range((TemporalField) null));
     }
 
@@ -331,6 +336,7 @@ public class TestHourMinute {
     public void test_get_invalid() {
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.get(SECOND_OF_MINUTE));
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.get(NANO_OF_SECOND));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.get((TemporalField) null));
     }
 
@@ -352,6 +358,7 @@ public class TestHourMinute {
     public void test_getLong_invalid() {
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.getLong(SECOND_OF_MINUTE));
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.getLong(NANO_OF_SECOND));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.getLong((TemporalField) null));
     }
 
@@ -367,6 +374,7 @@ public class TestHourMinute {
     @Test
     public void test_with_TemporalAdjuster_invalid() {
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.with(LocalTime.of(9, 10, 11)));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.with((TemporalAdjuster) null));
     }
 
@@ -388,6 +396,7 @@ public class TestHourMinute {
     public void test_with_TemporalFieldlong_invalid() {
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.with(SECOND_OF_MINUTE, 1));
         assertThatExceptionOfType(UnsupportedTemporalTypeException.class).isThrownBy(() -> TEST.with(NANO_OF_SECOND, 1));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.with((TemporalField) null, 1));
     }
 
@@ -421,6 +430,7 @@ public class TestHourMinute {
     public void test_plus_TemporalAmount_invalid() {
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.plus(Days.of(1)));
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.plus(Seconds.of(3)));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.plus(null));
     }
 
@@ -438,6 +448,7 @@ public class TestHourMinute {
     public void test_plus_longTemporalUnit_invalid() {
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.plus(1, DAYS));
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.plus(1, SECONDS));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.plus(1, null));
     }
 
@@ -465,6 +476,7 @@ public class TestHourMinute {
     public void test_minus_TemporalAmount_invalid() {
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.minus(Days.of(1)));
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.minus(Seconds.of(3)));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.minus(null));
     }
 
@@ -482,6 +494,7 @@ public class TestHourMinute {
     public void test_minus_longTemporalUnit_invalid() {
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.minus(1, DAYS));
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.minus(1, SECONDS));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.minus(1, null));
     }
 
@@ -520,6 +533,7 @@ public class TestHourMinute {
 
     @Test
     public void test_adjustInto_Temporal_invalid() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.adjustInto((Temporal) null));
     }
 
@@ -549,7 +563,9 @@ public class TestHourMinute {
     public void test_until_TemporalTemporalUnit_invalid() {
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.until(HourMinute.of(0, 0), DAYS));
         assertThatExceptionOfType(DateTimeException.class).isThrownBy(() -> TEST.until(HourMinute.of(0, 0), SECONDS));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.until(null, HOURS));
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.until(HourMinute.of(0, 0), null));
     }
 
@@ -569,6 +585,7 @@ public class TestHourMinute {
 
     @Test
     public void test_format_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.format(null));
     }
 
@@ -583,6 +600,7 @@ public class TestHourMinute {
 
     @Test
     public void test_atDate_LocalDate_invalid() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.atDate(null));
     }
 
@@ -597,6 +615,7 @@ public class TestHourMinute {
 
     @Test
     public void test_atOffset_ZoneOffset_invalid() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.atOffset(null));
     }
 
@@ -649,6 +668,7 @@ public class TestHourMinute {
 
     @Test
     public void test_compareTo_nullHourMinute() {
+        //noinspection DataFlowIssue - testing nulls
         assertThatNullPointerException().isThrownBy(() -> TEST.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestHours.java
+++ b/src/test/java/org/threeten/extra/TestHours.java
@@ -186,6 +186,7 @@ public class TestHours {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Hours.parse((CharSequence) null));
     }
 
@@ -222,6 +223,7 @@ public class TestHours {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Hours.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -279,6 +281,7 @@ public class TestHours {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Hours.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -422,6 +425,7 @@ public class TestHours {
     @Test
     public void test_compareTo_null() {
         Hours test5 = Hours.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestInterval.java
+++ b/src/test/java/org/threeten/extra/TestInterval.java
@@ -131,11 +131,13 @@ public class TestInterval {
 
     @Test
     public void test_of_Instant_Instant_nullStart() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.of((Instant) null, NOW2));
     }
 
     @Test
     public void test_of_Instant_Instant_nullEnd() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.of(NOW1, (Instant) null));
     }
 
@@ -161,11 +163,13 @@ public class TestInterval {
 
     @Test
     public void test_of_Instant_Duration_nullInstant() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.of(null, Duration.ZERO));
     }
 
     @Test
     public void test_of_Instant_Duration_nullDuration() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.of(NOW1, (Duration) null));
     }
 
@@ -191,11 +195,13 @@ public class TestInterval {
 
     @Test
     public void test_of_Duration_Instant_nullInstant() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.of(Duration.ZERO, null));
     }
 
     @Test
     public void test_of_Duration_Instant_nullDuration() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.of((Duration) null, NOW1));
     }
 
@@ -227,6 +233,7 @@ public class TestInterval {
 
     @Test
     public void test_startingAt_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.startingAt(null));
     }
 
@@ -258,6 +265,7 @@ public class TestInterval {
 
     @Test
     public void test_endingAt_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.endingAt(null));
     }
 
@@ -311,6 +319,7 @@ public class TestInterval {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Interval.parse(null));
     }
 
@@ -332,6 +341,7 @@ public class TestInterval {
     @Test
     public void test_withStart_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.withStart(null));
     }
 
@@ -353,6 +363,7 @@ public class TestInterval {
     @Test
     public void test_withEnd_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.withEnd(null));
     }
 
@@ -396,6 +407,7 @@ public class TestInterval {
     @Test
     public void test_contains_Instant_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.contains((Instant) null));
     }
 
@@ -438,6 +450,7 @@ public class TestInterval {
     @Test
     public void test_encloses_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.encloses((Interval) null));
     }
 
@@ -479,6 +492,7 @@ public class TestInterval {
     @Test
     public void test_abuts_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.abuts((Interval) null));
     }
 
@@ -520,6 +534,7 @@ public class TestInterval {
     @Test
     public void test_isConnected_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.isConnected((Interval) null));
     }
 
@@ -561,6 +576,7 @@ public class TestInterval {
     @Test
     public void test_overlaps_Interval_null() {
         Interval base = Interval.of(NOW1, NOW2);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.overlaps((Interval) null));
     }
 
@@ -742,9 +758,13 @@ public class TestInterval {
     @Test
     public void test_starts_Instant_null() {
         Interval base = Interval.of(NOW12, NOW14);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.startsBefore((Instant) null));
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.startsAtOrBefore((Instant) null));
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.startsAfter((Instant) null));
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.startsAtOrAfter((Instant) null));
     }
 
@@ -795,9 +815,13 @@ public class TestInterval {
     @Test
     public void test_ends_Instant_null() {
         Interval base = Interval.of(NOW12, NOW14);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.endsBefore((Instant) null));
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.endsAtOrBefore((Instant) null));
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.endsAfter((Instant) null));
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> base.endsAtOrAfter((Instant) null));
     }
 

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -558,6 +558,7 @@ public class TestLocalDateRange {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> LocalDateRange.parse(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestMinutes.java
+++ b/src/test/java/org/threeten/extra/TestMinutes.java
@@ -222,6 +222,7 @@ public class TestMinutes {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Minutes.parse((CharSequence) null));
     }
 
@@ -248,6 +249,7 @@ public class TestMinutes {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -295,6 +297,7 @@ public class TestMinutes {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Minutes.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -436,6 +439,7 @@ public class TestMinutes {
     @Test
     public void test_compareTo_null() {
         Minutes test5 = Minutes.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestMonths.java
+++ b/src/test/java/org/threeten/extra/TestMonths.java
@@ -173,6 +173,7 @@ public class TestMonths {
 
     @Test
     public void test_from_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Months.from((TemporalAmount) null));
     }
 
@@ -250,6 +251,7 @@ public class TestMonths {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Months.parse((CharSequence) null));
     }
 
@@ -261,11 +263,13 @@ public class TestMonths {
 
     @Test
     public void test_between_date_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Months.between(LocalDate.now(), (Temporal) null));
     }
 
     @Test
     public void test_between_null_date() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Months.between((Temporal) null, LocalDate.now()));
     }
 
@@ -323,6 +327,7 @@ public class TestMonths {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Months.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -390,6 +395,7 @@ public class TestMonths {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Months.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -528,6 +534,7 @@ public class TestMonths {
     @Test
     public void test_compareTo_null() {
         Months test5 = Months.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestMutableClock.java
+++ b/src/test/java/org/threeten/extra/TestMutableClock.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.testing.EqualsTester;
@@ -94,11 +95,13 @@ public class TestMutableClock {
 
     @Test
     public void test_of_nullInstant() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.of(null, ZoneOffset.UTC));
     }
 
     @Test
     public void test_of_nullZone() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.of(Instant.EPOCH, null));
     }
 
@@ -122,6 +125,7 @@ public class TestMutableClock {
 
     @Test
     public void test_setInstant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().setInstant(null));
     }
 
@@ -146,6 +150,7 @@ public class TestMutableClock {
 
     @Test
     public void test_add_amountOnly_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().add(null));
     }
 
@@ -170,6 +175,7 @@ public class TestMutableClock {
 
     @Test
     public void test_add_amountAndUnit_nullUnit() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().add(0, null));
     }
 
@@ -193,6 +199,7 @@ public class TestMutableClock {
 
     @Test
     public void test_set_adjuster_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().set(null));
     }
 
@@ -214,6 +221,7 @@ public class TestMutableClock {
 
     @Test
     public void test_set_fieldAndValue_nullField() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().set(null, 0));
     }
 
@@ -243,6 +251,7 @@ public class TestMutableClock {
 
     @Test
     public void test_withZone_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> MutableClock.epochUTC().withZone(null));
     }
 
@@ -336,7 +345,7 @@ public class TestMutableClock {
     public void test_updatesAreAtomic() throws Exception {
         MutableClock clock = MutableClock.epochUTC();
         Duration increment = Duration.ofSeconds(1);
-        Callable<Void> applyOneUpdate = () -> {
+        Callable<@Nullable Void> applyOneUpdate = () -> {
             clock.add(increment);
             return null;
         };

--- a/src/test/java/org/threeten/extra/TestOffsetDate.java
+++ b/src/test/java/org/threeten/extra/TestOffsetDate.java
@@ -199,11 +199,13 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void now_Clock_nullZoneId() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.now((ZoneId) null));
     }
 
     @Test
     public void now_Clock_nullClock() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.now((Clock) null));
     }
 
@@ -258,6 +260,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void factory_of_ints_nullOffset() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.of(2007, 1, 1, (ZoneOffset) null));
     }
 
@@ -271,12 +274,14 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void factory_of_LocalDateZoneOffset_nullDate() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.of((LocalDate) null, OFFSET_PONE));
     }
 
     @Test
     public void factory_of_LocalDateZoneOffset_nullOffset() {
         LocalDate localDate = LocalDate.of(2008, 6, 30);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.of(localDate, (ZoneOffset) null));
     }
 
@@ -301,6 +306,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.from((TemporalAccessor) null));
     }
 
@@ -357,6 +363,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void factory_parse_nullText() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.parse((String) null));
     }
 
@@ -373,11 +380,13 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     @Test
     public void factory_parse_formatter_nullText() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("y M d");
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.parse((String) null, f));
     }
 
     @Test
     public void factory_parse_formatter_nullFormatter() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.parse("ANY", null));
     }
 
@@ -532,6 +541,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_query_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.query(null));
     }
 
@@ -598,6 +608,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_withOffsetSameLocal_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.withOffsetSameLocal(null));
     }
 
@@ -652,6 +663,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_with_adjustment_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.with((TemporalAdjuster) null));
     }
 
@@ -672,6 +684,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_with_TemporalField_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.with((TemporalField) null, 0));
     }
 
@@ -809,6 +822,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_plus_PlusAdjuster_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.plus((TemporalAmount) null));
     }
 
@@ -1232,6 +1246,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_plus_MinusAdjuster_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST_2007_07_15_PONE.minus((TemporalAmount) null));
     }
 
@@ -1642,6 +1657,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
 
     @Test
     public void test_format_formatter_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> OffsetDate.of(2010, 12, 3, OFFSET_PONE).format(null));
     }
 
@@ -1658,6 +1674,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     @Test
     public void test_atTime_Local_nullLocalTime() {
         OffsetDate t = OffsetDate.of(2008, 6, 30, OFFSET_PTWO);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> t.atTime((LocalTime) null));
     }
 
@@ -1731,6 +1748,7 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     @Test
     public void test_compareTo_null() {
         OffsetDate a = OffsetDate.of(2008, 6, 30, OFFSET_PONE);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> a.compareTo(null));
     }
 
@@ -1813,18 +1831,21 @@ public class TestOffsetDate extends AbstractDateTimeTest {
     @Test
     public void test_isBefore_null() {
         OffsetDate a = OffsetDate.of(2008, 6, 30, OFFSET_PONE);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> a.isBefore(null));
     }
 
     @Test
     public void test_isAfter_null() {
         OffsetDate a = OffsetDate.of(2008, 6, 30, OFFSET_PONE);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> a.isAfter(null));
     }
 
     @Test
     public void test_isEqual_null() {
         OffsetDate a = OffsetDate.of(2008, 6, 30, OFFSET_PONE);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> a.isEqual(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestPeriodDuration.java
+++ b/src/test/java/org/threeten/extra/TestPeriodDuration.java
@@ -263,6 +263,7 @@ public class TestPeriodDuration {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> PeriodDuration.parse((CharSequence) null));
     }
 
@@ -286,6 +287,7 @@ public class TestPeriodDuration {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> P1Y2M3D.plus(null));
     }
 
@@ -309,6 +311,7 @@ public class TestPeriodDuration {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> P1Y2M3D.minus(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestQuarter.java
+++ b/src/test/java/org/threeten/extra/TestQuarter.java
@@ -183,6 +183,7 @@ public class TestQuarter {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Quarter.from((TemporalAccessor) null));
     }
 
@@ -202,11 +203,13 @@ public class TestQuarter {
 
     @Test
     public void test_getDisplayName_nullStyle() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Quarter.Q1.getDisplayName(null, Locale.US));
     }
 
     @Test
     public void test_getDisplayName_nullLocale() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Quarter.Q1.getDisplayName(TextStyle.FULL, null));
     }
 
@@ -265,6 +268,7 @@ public class TestQuarter {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Quarter.Q1.range(null));
     }
 
@@ -286,6 +290,7 @@ public class TestQuarter {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Quarter.Q2.get(null));
     }
 
@@ -307,6 +312,7 @@ public class TestQuarter {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Quarter.Q2.getLong(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestSeconds.java
+++ b/src/test/java/org/threeten/extra/TestSeconds.java
@@ -254,6 +254,7 @@ public class TestSeconds {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Seconds.parse((CharSequence) null));
     }
 
@@ -280,6 +281,7 @@ public class TestSeconds {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -327,6 +329,7 @@ public class TestSeconds {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Seconds.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -468,6 +471,7 @@ public class TestSeconds {
     @Test
     public void test_compareTo_null() {
         Seconds test5 = Seconds.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestTemporals.java
+++ b/src/test/java/org/threeten/extra/TestTemporals.java
@@ -414,6 +414,7 @@ public class TestTemporals {
 
     @Test
     public void test_timeUnit_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Temporals.timeUnit(null));
     }
 
@@ -425,6 +426,7 @@ public class TestTemporals {
 
     @Test
     public void test_chronoUnit_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Temporals.chronoUnit(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestWeeks.java
+++ b/src/test/java/org/threeten/extra/TestWeeks.java
@@ -155,6 +155,7 @@ public class TestWeeks {
 
     @Test
     public void test_from_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Weeks.from((TemporalAmount) null));
     }
 
@@ -194,6 +195,7 @@ public class TestWeeks {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Weeks.parse((CharSequence) null));
     }
 
@@ -205,11 +207,13 @@ public class TestWeeks {
 
     @Test
     public void test_between_date_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Weeks.between(LocalDate.now(), (Temporal) null));
     }
 
     @Test
     public void test_between_null_date() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Weeks.between((Temporal) null, LocalDate.now()));
     }
 
@@ -267,6 +271,7 @@ public class TestWeeks {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -334,6 +339,7 @@ public class TestWeeks {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Weeks.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -472,6 +478,7 @@ public class TestWeeks {
     @Test
     public void test_compareTo_null() {
         Weeks test5 = Weeks.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestYearHalf.java
+++ b/src/test/java/org/threeten/extra/TestYearHalf.java
@@ -165,16 +165,19 @@ public class TestYearHalf {
 
     @Test
     public void test_of_Year_Half_nullHalf() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of(Year.of(2012), (Half) null));
     }
 
     @Test
     public void test_of_Year_Half_nullYear() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of((Year) null, Half.H2));
     }
 
     @Test
     public void test_of_Year_Half_nullBoth() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of((Year) null, (Half) null));
     }
 
@@ -195,6 +198,7 @@ public class TestYearHalf {
 
     @Test
     public void test_of_Year_int_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of((Year) null, 2));
     }
 
@@ -225,6 +229,7 @@ public class TestYearHalf {
 
     @Test
     public void test_of_int_Half_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of(2012, (Half) null));
     }
 
@@ -297,6 +302,7 @@ public class TestYearHalf {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.from((TemporalAccessor) null));
     }
 
@@ -325,6 +331,7 @@ public class TestYearHalf {
 
     @Test
     public void test_parse_CharSequenceDate_nullCharSequence() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.parse((CharSequence) null));
     }
 
@@ -361,11 +368,13 @@ public class TestYearHalf {
                 .appendLiteral(' ')
                 .appendValue(YEAR)
                 .toFormatter();
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.parse((CharSequence) null, f));
     }
 
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullDateTimeFormatter() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.parse("", (DateTimeFormatter) null));
     }
 
@@ -454,6 +463,7 @@ public class TestYearHalf {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
@@ -475,6 +485,7 @@ public class TestYearHalf {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
@@ -496,6 +507,7 @@ public class TestYearHalf {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
@@ -582,6 +594,7 @@ public class TestYearHalf {
 
     @Test
     public void test_with_TemporalAdjuster_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of(2007, H2).with((TemporalAdjuster) null));
     }
 
@@ -744,6 +757,7 @@ public class TestYearHalf {
 
     @Test
     public void test_adjustInto_Temporal_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
@@ -775,11 +789,13 @@ public class TestYearHalf {
 
     @Test
     public void test_until_TemporalTemporalUnit_nullTemporal() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of(2012, H2).until(null, HALF_YEARS));
     }
 
     @Test
     public void test_until_TemporalTemporalUnit_nullTemporalUnit() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of(2012, H2).until(YearHalf.of(2012, H1), null));
     }
 
@@ -788,6 +804,7 @@ public class TestYearHalf {
     //-----------------------------------------------------------------------
     @Test
     public void test_halvesUntil_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearHalf.of(2012, H2).halvesUntil(null));
     }
 
@@ -828,6 +845,7 @@ public class TestYearHalf {
 
     @Test
     public void test_format_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.format((DateTimeFormatter) null));
     }
 
@@ -940,6 +958,7 @@ public class TestYearHalf {
 
     @Test
     public void test_compareTo_nullYearHalf() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestYearQuarter.java
+++ b/src/test/java/org/threeten/extra/TestYearQuarter.java
@@ -163,16 +163,19 @@ public class TestYearQuarter {
 
     @Test
     public void test_of_Year_Quarter_nullQuarter() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of(Year.of(2012), (Quarter) null));
     }
 
     @Test
     public void test_of_Year_Quarter_nullYear() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of((Year) null, Quarter.Q2));
     }
 
     @Test
     public void test_of_Year_Quarter_nullBoth() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of((Year) null, (Quarter) null));
     }
 
@@ -193,6 +196,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_of_Year_int_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of((Year) null, 2));
     }
 
@@ -223,6 +227,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_of_int_Quarter_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, (Quarter) null));
     }
 
@@ -295,6 +300,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.from((TemporalAccessor) null));
     }
 
@@ -323,6 +329,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_parse_CharSequenceDate_nullCharSequence() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.parse((CharSequence) null));
     }
 
@@ -344,11 +351,13 @@ public class TestYearQuarter {
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullCharSequence() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("'Q'Q uuuu");
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.parse((CharSequence) null, f));
     }
 
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullDateTimeFormatter() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.parse("", (DateTimeFormatter) null));
     }
 
@@ -434,6 +443,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 
@@ -455,6 +465,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
@@ -476,6 +487,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
@@ -584,6 +596,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_with_TemporalAdjuster_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of(2007, Q2).with((TemporalAdjuster) null));
     }
 
@@ -746,6 +759,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_adjustInto_Temporal_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.adjustInto((Temporal) null));
     }
 
@@ -787,11 +801,13 @@ public class TestYearQuarter {
 
     @Test
     public void test_until_TemporalTemporalUnit_nullTemporal() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, Q2).until(null, QUARTER_YEARS));
     }
 
     @Test
     public void test_until_TemporalTemporalUnit_nullTemporalUnit() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, Q2).until(YearQuarter.of(2012, Q3), null));
     }
 
@@ -800,6 +816,7 @@ public class TestYearQuarter {
     //-----------------------------------------------------------------------
     @Test
     public void test_quartersUntil_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearQuarter.of(2012, Q2).quartersUntil(null));
     }
 
@@ -838,6 +855,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_format_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.format((DateTimeFormatter) null));
     }
 
@@ -967,6 +985,7 @@ public class TestYearQuarter {
 
     @Test
     public void test_compareTo_nullYearQuarter() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/TestYearWeek.java
+++ b/src/test/java/org/threeten/extra/TestYearWeek.java
@@ -347,6 +347,7 @@ public class TestYearWeek {
     //-----------------------------------------------------------------------
     @Test
     public void now_ZoneId_nullZoneId() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearWeek.now((ZoneId) null));
     }
 
@@ -370,6 +371,7 @@ public class TestYearWeek {
 
     @Test
     public void now_Clock_nullClock() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearWeek.now((Clock) null));
     }
 
@@ -517,6 +519,7 @@ public class TestYearWeek {
 
     @Test
     public void test_atDay_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.atDay(null));
     }
 
@@ -587,6 +590,7 @@ public class TestYearWeek {
 
     @Test
     public void test_compareTo_nullYearWeek() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.compareTo(null));
     }
 
@@ -610,6 +614,7 @@ public class TestYearWeek {
 
     @Test
     public void test_from_TemporalAccessor_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearWeek.from((TemporalAccessor) null));
     }
 
@@ -629,6 +634,7 @@ public class TestYearWeek {
 
     @Test
     public void test_get_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.get((TemporalField) null));
     }
 
@@ -648,6 +654,7 @@ public class TestYearWeek {
 
     @Test
     public void test_getLong_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.getLong((TemporalField) null));
     }
 
@@ -716,6 +723,7 @@ public class TestYearWeek {
 
     @Test
     public void test_parse_CharSequenceDate_nullCharSequence() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearWeek.parse((CharSequence) null));
     }
 
@@ -737,11 +745,13 @@ public class TestYearWeek {
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullCharSequence() {
         DateTimeFormatter f = DateTimeFormatter.ofPattern("E 'W'w YYYY").withLocale(Locale.ENGLISH);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearWeek.parse((CharSequence) null, f));
     }
 
     @Test
     public void test_parse_CharSequenceDateTimeFormatter_nullDateTimeFormatter() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> YearWeek.parse("", (DateTimeFormatter) null));
     }
 
@@ -821,6 +831,7 @@ public class TestYearWeek {
 
     @Test
     public void test_range_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TEST.range((TemporalField) null));
     }
 

--- a/src/test/java/org/threeten/extra/TestYears.java
+++ b/src/test/java/org/threeten/extra/TestYears.java
@@ -160,6 +160,7 @@ public class TestYears {
 
     @Test
     public void test_from_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Years.from((TemporalAmount) null));
     }
 
@@ -199,6 +200,7 @@ public class TestYears {
 
     @Test
     public void test_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Years.parse((CharSequence) null));
     }
 
@@ -210,11 +212,13 @@ public class TestYears {
 
     @Test
     public void test_between_date_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Years.between(LocalDate.now(), (Temporal) null));
     }
 
     @Test
     public void test_between_null_date() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Years.between((Temporal) null, LocalDate.now()));
     }
 
@@ -272,6 +276,7 @@ public class TestYears {
 
     @Test
     public void test_plus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Years.of(Integer.MIN_VALUE + 1).plus(null));
     }
 
@@ -339,6 +344,7 @@ public class TestYears {
 
     @Test
     public void test_minus_TemporalAmount_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> Years.of(Integer.MIN_VALUE + 1).minus(null));
     }
 
@@ -477,6 +483,7 @@ public class TestYears {
     @Test
     public void test_compareTo_null() {
         Years test5 = Years.of(5);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> test5.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestAccountingChronology.java
@@ -54,7 +54,10 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
@@ -84,8 +87,12 @@ import com.google.common.testing.EqualsTester;
  */
 public class TestAccountingChronology {
 
-    private static AccountingChronology INSTANCE = new AccountingChronologyBuilder().endsOn(DayOfWeek.SUNDAY).nearestEndOf(Month.AUGUST).
-            withDivision(AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS).leapWeekInMonth(13).toChronology();
+    private static final AccountingChronology INSTANCE = new AccountingChronologyBuilder()
+            .endsOn(DayOfWeek.SUNDAY)
+            .nearestEndOf(Month.AUGUST)
+            .withDivision(AccountingYearDivision.THIRTEEN_EVEN_MONTHS_OF_4_WEEKS)
+            .leapWeekInMonth(13)
+            .toChronology();
 
     //-----------------------------------------------------------------------
     // Chronology.of(String)
@@ -97,7 +104,7 @@ public class TestAccountingChronology {
 
     @Test
     public void test_chronology_of_name_id() {
-        assertEquals(null, INSTANCE.getCalendarType());
+        assertNull(INSTANCE.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -270,31 +277,37 @@ public class TestAccountingChronology {
 
     @Test
     public void test_date_create_no_chronology() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AccountingDate.create(null, 2012, 1, 1));
     }
 
     @Test
     public void test_date_from_no_chronology() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AccountingDate.from(null, LocalDate.of(2012, 1, 1)));
     }
 
     @Test
     public void test_date_now_no_chronology() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AccountingDate.now(null));
     }
 
     @Test
     public void test_date_of_no_chronology() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AccountingDate.of(null, 2012, 1, 1));
     }
 
     @Test
     public void test_date_ofEpochDay_no_chronology() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AccountingDate.ofEpochDay(null, 0));
     }
 
     @Test
     public void test_date_ofYearDay_no_chronology() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> AccountingDate.ofYearDay(null, 0, 1));
     }
 
@@ -317,21 +330,21 @@ public class TestAccountingChronology {
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(false, INSTANCE.isLeapYear(8));
-        assertEquals(false, INSTANCE.isLeapYear(7));
-        assertEquals(true, INSTANCE.isLeapYear(6));
-        assertEquals(false, INSTANCE.isLeapYear(5));
-        assertEquals(false, INSTANCE.isLeapYear(4));
-        assertEquals(false, INSTANCE.isLeapYear(3));
-        assertEquals(false, INSTANCE.isLeapYear(2));
-        assertEquals(false, INSTANCE.isLeapYear(1));
-        assertEquals(true, INSTANCE.isLeapYear(0));
-        assertEquals(false, INSTANCE.isLeapYear(-1));
-        assertEquals(false, INSTANCE.isLeapYear(-2));
-        assertEquals(false, INSTANCE.isLeapYear(-3));
-        assertEquals(false, INSTANCE.isLeapYear(-4));
-        assertEquals(true, INSTANCE.isLeapYear(-5));
-        assertEquals(false, INSTANCE.isLeapYear(-6));
+        assertFalse(INSTANCE.isLeapYear(8));
+        assertFalse(INSTANCE.isLeapYear(7));
+        assertTrue(INSTANCE.isLeapYear(6));
+        assertFalse(INSTANCE.isLeapYear(5));
+        assertFalse(INSTANCE.isLeapYear(4));
+        assertFalse(INSTANCE.isLeapYear(3));
+        assertFalse(INSTANCE.isLeapYear(2));
+        assertFalse(INSTANCE.isLeapYear(1));
+        assertTrue(INSTANCE.isLeapYear(0));
+        assertFalse(INSTANCE.isLeapYear(-1));
+        assertFalse(INSTANCE.isLeapYear(-2));
+        assertFalse(INSTANCE.isLeapYear(-3));
+        assertFalse(INSTANCE.isLeapYear(-4));
+        assertTrue(INSTANCE.isLeapYear(-5));
+        assertFalse(INSTANCE.isLeapYear(-6));
     }
 
     public static Object[][] data_lengthOfMonth() {
@@ -426,8 +439,8 @@ public class TestAccountingChronology {
     public void test_Chronology_eras() {
         List<Era> eras = INSTANCE.eras();
         assertEquals(2, eras.size());
-        assertEquals(true, eras.contains(AccountingEra.BCE));
-        assertEquals(true, eras.contains(AccountingEra.CE));
+        assertTrue(eras.contains(AccountingEra.BCE));
+        assertTrue(eras.contains(AccountingEra.CE));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestBritishCutoverChronology.java
@@ -54,8 +54,11 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -103,7 +106,7 @@ public class TestBritishCutoverChronology {
         assertNotNull(chrono);
         assertEquals(BritishCutoverChronology.INSTANCE, chrono);
         assertEquals("BritishCutover", chrono.getId());
-        assertEquals(null, chrono.getCalendarType());
+        assertNull(chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------
@@ -297,21 +300,21 @@ public class TestBritishCutoverChronology {
 
     @Test
     public void test_Chronology_isLeapYear_specific() {
-        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(8));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(7));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(6));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(5));
-        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(4));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(3));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(2));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(1));
-        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(0));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-1));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-2));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-3));
-        assertEquals(true, BritishCutoverChronology.INSTANCE.isLeapYear(-4));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-5));
-        assertEquals(false, BritishCutoverChronology.INSTANCE.isLeapYear(-6));
+        assertTrue(BritishCutoverChronology.INSTANCE.isLeapYear(8));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(7));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(6));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(5));
+        assertTrue(BritishCutoverChronology.INSTANCE.isLeapYear(4));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(3));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(2));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(1));
+        assertTrue(BritishCutoverChronology.INSTANCE.isLeapYear(0));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(-1));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(-2));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(-3));
+        assertTrue(BritishCutoverChronology.INSTANCE.isLeapYear(-4));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(-5));
+        assertFalse(BritishCutoverChronology.INSTANCE.isLeapYear(-6));
     }
 
     //-----------------------------------------------------------------------
@@ -520,8 +523,8 @@ public class TestBritishCutoverChronology {
     public void test_Chronology_eras() {
         List<Era> eras = BritishCutoverChronology.INSTANCE.eras();
         assertEquals(2, eras.size());
-        assertEquals(true, eras.contains(JulianEra.BC));
-        assertEquals(true, eras.contains(JulianEra.AD));
+        assertTrue(eras.contains(JulianEra.BC));
+        assertTrue(eras.contains(JulianEra.AD));
     }
 
     //-----------------------------------------------------------------------
@@ -1247,6 +1250,7 @@ public class TestBritishCutoverChronology {
 
     @Test
     public void test_atTime_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> BritishCutoverDate.of(2014, 5, 26).atTime(null));
     }
 

--- a/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestCopticChronology.java
@@ -54,8 +54,10 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -267,21 +269,21 @@ public class TestCopticChronology {
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(8));
-        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(7));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(6));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(5));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(4));
-        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(3));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(2));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(1));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(0));
-        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(-1));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-2));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-3));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-4));
-        assertEquals(true, CopticChronology.INSTANCE.isLeapYear(-5));
-        assertEquals(false, CopticChronology.INSTANCE.isLeapYear(-6));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(8));
+        assertTrue(CopticChronology.INSTANCE.isLeapYear(7));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(6));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(5));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(4));
+        assertTrue(CopticChronology.INSTANCE.isLeapYear(3));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(2));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(1));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(0));
+        assertTrue(CopticChronology.INSTANCE.isLeapYear(-1));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(-2));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(-3));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(-4));
+        assertTrue(CopticChronology.INSTANCE.isLeapYear(-5));
+        assertFalse(CopticChronology.INSTANCE.isLeapYear(-6));
     }
 
     public static Object[][] data_lengthOfMonth() {
@@ -367,8 +369,8 @@ public class TestCopticChronology {
     public void test_Chronology_eras() {
         List<Era> eras = CopticChronology.INSTANCE.eras();
         assertEquals(2, eras.size());
-        assertEquals(true, eras.contains(CopticEra.BEFORE_AM));
-        assertEquals(true, eras.contains(CopticEra.AM));
+        assertTrue(eras.contains(CopticEra.BEFORE_AM));
+        assertTrue(eras.contains(CopticEra.AM));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestDiscordianChronology.java
@@ -55,8 +55,10 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -281,21 +283,21 @@ public class TestDiscordianChronology {
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1174));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1173));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1172));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1171));
-        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1170));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1169));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1168));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1167));
-        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1166));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1165));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1164));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1163));
-        assertEquals(true, DiscordianChronology.INSTANCE.isLeapYear(1162));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1161));
-        assertEquals(false, DiscordianChronology.INSTANCE.isLeapYear(1160));
+        assertTrue(DiscordianChronology.INSTANCE.isLeapYear(1174));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1173));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1172));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1171));
+        assertTrue(DiscordianChronology.INSTANCE.isLeapYear(1170));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1169));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1168));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1167));
+        assertTrue(DiscordianChronology.INSTANCE.isLeapYear(1166));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1165));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1164));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1163));
+        assertTrue(DiscordianChronology.INSTANCE.isLeapYear(1162));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1161));
+        assertFalse(DiscordianChronology.INSTANCE.isLeapYear(1160));
     }
 
     public static Object[][] data_lengthOfMonth() {
@@ -383,7 +385,7 @@ public class TestDiscordianChronology {
     public void test_Chronology_eras() {
         List<Era> eras = DiscordianChronology.INSTANCE.eras();
         assertEquals(1, eras.size());
-        assertEquals(true, eras.contains(DiscordianEra.YOLD));
+        assertTrue(eras.contains(DiscordianEra.YOLD));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestEthiopicChronology.java
@@ -54,8 +54,10 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -268,21 +270,21 @@ public class TestEthiopicChronology {
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(8));
-        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(7));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(6));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(5));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(4));
-        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(3));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(2));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(1));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(0));
-        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(-1));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-2));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-3));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-4));
-        assertEquals(true, EthiopicChronology.INSTANCE.isLeapYear(-5));
-        assertEquals(false, EthiopicChronology.INSTANCE.isLeapYear(-6));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(8));
+        assertTrue(EthiopicChronology.INSTANCE.isLeapYear(7));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(6));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(5));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(4));
+        assertTrue(EthiopicChronology.INSTANCE.isLeapYear(3));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(2));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(1));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(0));
+        assertTrue(EthiopicChronology.INSTANCE.isLeapYear(-1));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(-2));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(-3));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(-4));
+        assertTrue(EthiopicChronology.INSTANCE.isLeapYear(-5));
+        assertFalse(EthiopicChronology.INSTANCE.isLeapYear(-6));
     }
 
     public static Object[][] data_lengthOfMonth() {
@@ -368,8 +370,8 @@ public class TestEthiopicChronology {
     public void test_Chronology_eras() {
         List<Era> eras = EthiopicChronology.INSTANCE.eras();
         assertEquals(2, eras.size());
-        assertEquals(true, eras.contains(EthiopicEra.BEFORE_INCARNATION));
-        assertEquals(true, eras.contains(EthiopicEra.INCARNATION));
+        assertTrue(eras.contains(EthiopicEra.BEFORE_INCARNATION));
+        assertTrue(eras.contains(EthiopicEra.INCARNATION));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestInternationalFixedChronology.java
@@ -57,6 +57,7 @@ import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -86,7 +87,7 @@ import com.google.common.testing.EqualsTester;
 /**
  * Test.
  */
-@SuppressWarnings({"static-method", "javadoc"})
+@SuppressWarnings({"static-method"})
 public class TestInternationalFixedChronology {
 
     //-----------------------------------------------------------------------
@@ -98,7 +99,7 @@ public class TestInternationalFixedChronology {
         assertNotNull(chrono);
         assertEquals(InternationalFixedChronology.INSTANCE, chrono);
         assertEquals("Ifc", chrono.getId());
-        assertEquals(null, chrono.getCalendarType());
+        assertNull(chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestJulianChronology.java
@@ -54,8 +54,10 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -287,21 +289,21 @@ public class TestJulianChronology {
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(8));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(7));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(6));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(5));
-        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(4));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(3));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(2));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(1));
-        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(0));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-1));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-2));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-3));
-        assertEquals(true, JulianChronology.INSTANCE.isLeapYear(-4));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-5));
-        assertEquals(false, JulianChronology.INSTANCE.isLeapYear(-6));
+        assertTrue(JulianChronology.INSTANCE.isLeapYear(8));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(7));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(6));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(5));
+        assertTrue(JulianChronology.INSTANCE.isLeapYear(4));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(3));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(2));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(1));
+        assertTrue(JulianChronology.INSTANCE.isLeapYear(0));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(-1));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(-2));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(-3));
+        assertTrue(JulianChronology.INSTANCE.isLeapYear(-4));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(-5));
+        assertFalse(JulianChronology.INSTANCE.isLeapYear(-6));
     }
 
     public static Object[][] data_lengthOfMonth() {
@@ -397,8 +399,8 @@ public class TestJulianChronology {
     public void test_Chronology_eras() {
         List<Era> eras = JulianChronology.INSTANCE.eras();
         assertEquals(2, eras.size());
-        assertEquals(true, eras.contains(JulianEra.BC));
-        assertEquals(true, eras.contains(JulianEra.AD));
+        assertTrue(eras.contains(JulianEra.BC));
+        assertTrue(eras.contains(JulianEra.AD));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestPaxChronology.java
@@ -54,8 +54,10 @@ import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DateTimeException;
 import java.time.LocalDate;
@@ -84,7 +86,7 @@ import com.google.common.testing.EqualsTester;
 /**
  * Test.
  */
-@SuppressWarnings({"static-method", "javadoc"})
+@SuppressWarnings({"static-method"})
 public class TestPaxChronology {
 
     //-----------------------------------------------------------------------
@@ -327,26 +329,26 @@ public class TestPaxChronology {
 
     @Test
     public void test_isLeapYear_specific() {
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(400));
-        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(100));
-        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(99));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(7));
-        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(6));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(5));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(4));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(3));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(2));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(1));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(0));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-1));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-2));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-3));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-4));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-5));
-        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(-6));
-        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(-99));
-        assertEquals(true, PaxChronology.INSTANCE.isLeapYear(-100));
-        assertEquals(false, PaxChronology.INSTANCE.isLeapYear(-400));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(400));
+        assertTrue(PaxChronology.INSTANCE.isLeapYear(100));
+        assertTrue(PaxChronology.INSTANCE.isLeapYear(99));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(7));
+        assertTrue(PaxChronology.INSTANCE.isLeapYear(6));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(5));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(4));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(3));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(2));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(1));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(0));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(-1));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(-2));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(-3));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(-4));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(-5));
+        assertTrue(PaxChronology.INSTANCE.isLeapYear(-6));
+        assertTrue(PaxChronology.INSTANCE.isLeapYear(-99));
+        assertTrue(PaxChronology.INSTANCE.isLeapYear(-100));
+        assertFalse(PaxChronology.INSTANCE.isLeapYear(-400));
     }
 
     public static Object[][] data_lengthOfMonth() {
@@ -446,8 +448,8 @@ public class TestPaxChronology {
     public void test_Chronology_eras() {
         List<Era> eras = PaxChronology.INSTANCE.eras();
         assertEquals(2, eras.size());
-        assertEquals(true, eras.contains(PaxEra.BCE));
-        assertEquals(true, eras.contains(PaxEra.CE));
+        assertTrue(eras.contains(PaxEra.BCE));
+        assertTrue(eras.contains(PaxEra.CE));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry010Chronology.java
@@ -58,6 +58,7 @@ import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,7 +91,7 @@ import com.google.common.testing.EqualsTester;
 /**
  * Test.
  */
-@SuppressWarnings({"static-method", "javadoc"})
+@SuppressWarnings({"static-method"})
 public class TestSymmetry010Chronology {
 
     //-----------------------------------------------------------------------
@@ -102,7 +103,7 @@ public class TestSymmetry010Chronology {
         assertNotNull(chrono);
         assertEquals(Symmetry010Chronology.INSTANCE, chrono);
         assertEquals("Sym010", chrono.getId());
-        assertEquals(null, chrono.getCalendarType());
+        assertNull(chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
+++ b/src/test/java/org/threeten/extra/chrono/TestSymmetry454Chronology.java
@@ -58,6 +58,7 @@ import static java.time.temporal.ChronoUnit.YEARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,7 +91,7 @@ import com.google.common.testing.EqualsTester;
 /**
  * Test.
  */
-@SuppressWarnings({"static-method", "javadoc"})
+@SuppressWarnings({"static-method"})
 public class TestSymmetry454Chronology {
 
     //-----------------------------------------------------------------------
@@ -102,7 +103,7 @@ public class TestSymmetry454Chronology {
         assertNotNull(chrono);
         assertEquals(Symmetry454Chronology.INSTANCE, chrono);
         assertEquals("Sym454", chrono.getId());
-        assertEquals(null, chrono.getCalendarType());
+        assertNull(chrono.getCalendarType());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/chrono/package-info.java
+++ b/src/test/java/org/threeten/extra/chrono/package-info.java
@@ -29,41 +29,8 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.threeten.extra.scale;
+@NullMarked
+package org.threeten.extra.chrono;
 
-/**
- * Mock rules that always returns a leap second.
- */
-public class MockUtcRulesAlwaysLeap extends UtcRules {
+import org.jspecify.annotations.NullMarked;
 
-    @Override
-    public String getName() {
-        return "Mock";
-    }
-
-    @Override
-    public int getLeapSecondAdjustment(long mjDay) {
-        return 1;  // always leap
-    }
-
-    @Override
-    public int getTaiOffset(long mjDay) {
-        return (int) mjDay;
-    }
-
-    @Override
-    public long[] getLeapSecondDates() {
-        return new long[0];
-    }
-
-    @Override
-    public TaiInstant convertToTai(UtcInstant utcInstant) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public UtcInstant convertToUtc(TaiInstant taiInstant) {
-        throw new UnsupportedOperationException();
-    }
-
-}

--- a/src/test/java/org/threeten/extra/package-info.java
+++ b/src/test/java/org/threeten/extra/package-info.java
@@ -29,41 +29,8 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.threeten.extra.scale;
+@NullMarked
+package org.threeten.extra;
 
-/**
- * Mock rules that always returns a leap second.
- */
-public class MockUtcRulesAlwaysLeap extends UtcRules {
+import org.jspecify.annotations.NullMarked;
 
-    @Override
-    public String getName() {
-        return "Mock";
-    }
-
-    @Override
-    public int getLeapSecondAdjustment(long mjDay) {
-        return 1;  // always leap
-    }
-
-    @Override
-    public int getTaiOffset(long mjDay) {
-        return (int) mjDay;
-    }
-
-    @Override
-    public long[] getLeapSecondDates() {
-        return new long[0];
-    }
-
-    @Override
-    public TaiInstant convertToTai(UtcInstant utcInstant) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public UtcInstant convertToUtc(TaiInstant taiInstant) {
-        throw new UnsupportedOperationException();
-    }
-
-}

--- a/src/test/java/org/threeten/extra/scale/MockUtcRulesLeapOn1000.java
+++ b/src/test/java/org/threeten/extra/scale/MockUtcRulesLeapOn1000.java
@@ -58,12 +58,12 @@ public class MockUtcRulesLeapOn1000 extends UtcRules {
 
     @Override
     public TaiInstant convertToTai(UtcInstant utcInstant) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public UtcInstant convertToUtc(TaiInstant taiInstant) {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestTaiInstant.java
@@ -45,6 +45,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -126,6 +127,7 @@ public class TestTaiInstant {
 
     @Test
     public void factory_of_Instant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TaiInstant.of((Instant) null));
     }
 
@@ -145,6 +147,7 @@ public class TestTaiInstant {
 
     @Test
     public void factory_of_UtcInstant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> TaiInstant.of((UtcInstant) null));
     }
 
@@ -182,7 +185,8 @@ public class TestTaiInstant {
 
     @Test
     public void factory_parse_CharSequence_null() {
-        assertThrows(NullPointerException.class, () -> TaiInstant.parse((String) null));
+        //noinspection DataFlowIssue - testing nulls
+        assertThrows(NullPointerException.class, () -> TaiInstant.parse(null));
     }
 
     //-----------------------------------------------------------------------
@@ -210,25 +214,25 @@ public class TestTaiInstant {
     //-----------------------------------------------------------------------
     // withNano()
     //-----------------------------------------------------------------------
-    public static Object[][] data_withNano() {
-        return new Object[][] {
+    public static @Nullable Object[][] data_withNano() {
+        return new @Nullable Object[][] {
             {0L, 12345L, 1, 0L, 1L},
             {7L, 12345L, 2, 7L, 2L},
             {-99L, 12345L, 3, -99L, 3L},
             {-99L, 12345L, 999999999, -99L, 999999999L},
-            {-99L, 12345L, -1, null, null},
-            {-99L, 12345L, 1000000000, null, null},
+            {-99L, 12345L, -1, null, 0L},
+            {-99L, 12345L, 1000000000, null, 0L},
         };
     }
 
     @ParameterizedTest
     @MethodSource("data_withNano")
-    public void test_withNano(long tai, long nanos, int newNano, Long expectedTai, Long expectedNanos) {
+    public void test_withNano(long tai, long nanos, int newNano, @Nullable Long expectedTai, long expectedNanos) {
         TaiInstant i = TaiInstant.ofTaiSeconds(tai, nanos);
         if (expectedTai != null) {
             TaiInstant withNano = i.withNano(newNano);
             assertEquals(expectedTai.longValue(), withNano.getTaiSeconds());
-            assertEquals(expectedNanos.longValue(), withNano.getNano());
+            assertEquals(expectedNanos, withNano.getNano());
         } else {
             assertThrows(IllegalArgumentException.class, () -> i.withNano(newNano));
         }
@@ -756,6 +760,7 @@ public class TestTaiInstant {
     @Test
     public void test_compareTo_ObjectNull() {
         TaiInstant a = TaiInstant.ofTaiSeconds(0L, 0);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> a.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcInstant.java
@@ -33,6 +33,7 @@ package org.threeten.extra.scale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -45,6 +46,7 @@ import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -97,7 +99,7 @@ public class TestUtcInstant {
                 UtcInstant t = UtcInstant.ofModifiedJulianDay(i, j);
                 assertEquals(i, t.getModifiedJulianDay());
                 assertEquals(j, t.getNanoOfDay());
-                assertEquals(false, t.isLeapSecond());
+                assertFalse(t.isLeapSecond());
             }
         }
     }
@@ -156,6 +158,7 @@ public class TestUtcInstant {
 
     @Test
     public void factory_of_Instant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> UtcInstant.of((Instant) null));
     }
 
@@ -175,6 +178,7 @@ public class TestUtcInstant {
 
     @Test
     public void factory_of_TaiInstant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> UtcInstant.of((TaiInstant) null));
     }
 
@@ -208,35 +212,36 @@ public class TestUtcInstant {
 
     @Test
     public void factory_parse_CharSequence_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> UtcInstant.parse((String) null));
     }
 
     //-----------------------------------------------------------------------
     // withModifiedJulianDay()
     //-----------------------------------------------------------------------
-    public static Object[][] data_withModifiedJulianDay() {
-        return new Object[][] {
+    public static @Nullable Object[][] data_withModifiedJulianDay() {
+        return new @Nullable Object[][] {
             {0L, 12345L, 1L, 1L, 12345L},
             {0L, 12345L, -1L, -1L, 12345L},
             {7L, 12345L, 2L, 2L, 12345L},
             {7L, 12345L, -2L, -2L, 12345L},
             {-99L, 12345L, 3L, 3L, 12345L},
             {-99L, 12345L, -3L, -3L, 12345L},
-            {MJD_1972_12_31_LEAP, NANOS_PER_DAY, MJD_1972_12_30, null, null},
+            {MJD_1972_12_31_LEAP, NANOS_PER_DAY, MJD_1972_12_30, null, 0L},
             {MJD_1972_12_31_LEAP, NANOS_PER_DAY, MJD_1972_12_31_LEAP, MJD_1972_12_31_LEAP, NANOS_PER_DAY},
-            {MJD_1972_12_31_LEAP, NANOS_PER_DAY, MJD_1973_01_01, null, null},
+            {MJD_1972_12_31_LEAP, NANOS_PER_DAY, MJD_1973_01_01, null, 0L},
             {MJD_1972_12_31_LEAP, NANOS_PER_DAY, MJD_1973_12_31_LEAP, MJD_1973_12_31_LEAP, NANOS_PER_DAY},
         };
     }
 
     @ParameterizedTest
     @MethodSource("data_withModifiedJulianDay")
-    public void test_withModifiedJulianDay(long mjd, long nanos, long newMjd, Long expectedMjd, Long expectedNanos) {
+    public void test_withModifiedJulianDay(long mjd, long nanos, long newMjd, @Nullable Long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
             UtcInstant withModifiedJulianDay = i.withModifiedJulianDay(newMjd);
             assertEquals(expectedMjd.longValue(), withModifiedJulianDay.getModifiedJulianDay());
-            assertEquals(expectedNanos.longValue(), withModifiedJulianDay.getNanoOfDay());
+            assertEquals(expectedNanos, withModifiedJulianDay.getNanoOfDay());
         } else {
             assertThrows(DateTimeException.class, () -> i.withModifiedJulianDay(newMjd));
         }
@@ -245,35 +250,35 @@ public class TestUtcInstant {
     //-----------------------------------------------------------------------
     // withNanoOfDay()
     //-----------------------------------------------------------------------
-    public static Object[][] data_withNanoOfDay() {
-        return new Object[][] {
+    public static @Nullable Object[][] data_withNanoOfDay() {
+        return new @Nullable Object[][] {
             {0L, 12345L, 1L, 0L, 1L},
-            {0L, 12345L, -1L, null, null},
+            {0L, 12345L, -1L, null, 0L},
             {7L, 12345L, 2L, 7L, 2L},
             {-99L, 12345L, 3L, -99L, 3L},
             {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_DAY - 1, MJD_1972_12_30, NANOS_PER_DAY - 1},
             {MJD_1972_12_31_LEAP, NANOS_PER_DAY - 1, NANOS_PER_DAY - 1, MJD_1972_12_31_LEAP, NANOS_PER_DAY - 1},
             {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_DAY - 1, MJD_1973_01_01, NANOS_PER_DAY - 1},
-            {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_DAY, null, null},
+            {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_DAY, null, 0L},
             {MJD_1972_12_31_LEAP, NANOS_PER_DAY - 1, NANOS_PER_DAY, MJD_1972_12_31_LEAP, NANOS_PER_DAY},
-            {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_DAY, null, null},
-            {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY - 1, null, null},
+            {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_DAY, null, 0L},
+            {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY - 1, null, 0L},
             {MJD_1972_12_31_LEAP, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY - 1, MJD_1972_12_31_LEAP, NANOS_PER_LEAP_DAY - 1},
-            {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY - 1, null, null},
-            {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY, null, null},
-            {MJD_1972_12_31_LEAP, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY, null, null},
-            {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY, null, null},
+            {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY - 1, null, 0L},
+            {MJD_1972_12_30, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY, null, 0L},
+            {MJD_1972_12_31_LEAP, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY, null, 0L},
+            {MJD_1973_01_01, NANOS_PER_DAY - 1, NANOS_PER_LEAP_DAY, null, 0L},
         };
     }
 
     @ParameterizedTest
     @MethodSource("data_withNanoOfDay")
-    public void test_withNanoOfDay(long mjd, long nanos, long newNanoOfDay, Long expectedMjd, Long expectedNanos) {
+    public void test_withNanoOfDay(long mjd, long nanos, long newNanoOfDay, @Nullable Long expectedMjd, long expectedNanos) {
         UtcInstant i = UtcInstant.ofModifiedJulianDay(mjd, nanos);
         if (expectedMjd != null) {
             UtcInstant withNanoOfDay = i.withNanoOfDay(newNanoOfDay);
             assertEquals(expectedMjd.longValue(), withNanoOfDay.getModifiedJulianDay());
-            assertEquals(expectedNanos.longValue(), withNanoOfDay.getNanoOfDay());
+            assertEquals(expectedNanos, withNanoOfDay.getNanoOfDay());
         } else {
             assertThrows(DateTimeException.class, () -> i.withNanoOfDay(newNanoOfDay));
         }
@@ -487,17 +492,17 @@ public class TestUtcInstant {
                 UtcInstant b = instants[j];
                 if (i < j) {
                     assertEquals(-1, a.compareTo(b));
-                    assertEquals(false, a.equals(b));
+                    assertNotEquals(a, b);
                     assertTrue(a.isBefore(b));
                     assertFalse(a.isAfter(b));
                 } else if (i > j) {
                     assertEquals(1, a.compareTo(b));
-                    assertEquals(false, a.equals(b));
+                    assertNotEquals(a, b);
                     assertFalse(a.isBefore(b));
                     assertTrue(a.isAfter(b));
                 } else {
                     assertEquals(0, a.compareTo(b));
-                    assertEquals(true, a.equals(b));
+                    assertEquals(a, b);
                     assertFalse(a.isBefore(b));
                     assertFalse(a.isAfter(b));
                 }
@@ -508,6 +513,7 @@ public class TestUtcInstant {
     @Test
     public void test_compareTo_ObjectNull() {
         UtcInstant a = UtcInstant.ofModifiedJulianDay(0L, 0);
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> a.compareTo(null));
     }
 

--- a/src/test/java/org/threeten/extra/scale/TestUtcRules.java
+++ b/src/test/java/org/threeten/extra/scale/TestUtcRules.java
@@ -243,7 +243,7 @@ public class TestUtcRules {
         if (adjust != 0) {
             long[] leaps = rules.getLeapSecondDates();
             Arrays.sort(leaps);
-            assertEquals(true, Arrays.binarySearch(leaps, mjd) >= 0);
+            assertTrue(Arrays.binarySearch(leaps, mjd) >= 0);
         }
     }
 
@@ -347,11 +347,13 @@ public class TestUtcRules {
 
     @Test
     public void test_convertToUtc_TaiInstant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> rules.convertToUtc((TaiInstant) null));
     }
 
     @Test
     public void test_convertToTai_UtcInstant_null() {
+        //noinspection DataFlowIssue - testing nulls
         assertThrows(NullPointerException.class, () -> rules.convertToTai((UtcInstant) null));
     }
 
@@ -499,7 +501,7 @@ public class TestUtcRules {
         int adj = rules.getLeapSecondAdjustment(mjd);
         rules.register(mjd, adj);
         long[] test = rules.getLeapSecondDates();
-        assertEquals(true, Arrays.equals(test, dates));
+        assertTrue(Arrays.equals(test, dates));
         assertEquals(adj, rules.getLeapSecondAdjustment(mjd));
     }
 
@@ -510,7 +512,7 @@ public class TestUtcRules {
         int adj = rules.getLeapSecondAdjustment(mjd);
         rules.register(mjd, adj);
         long[] test = rules.getLeapSecondDates();
-        assertEquals(true, Arrays.equals(test, dates));
+        assertTrue(Arrays.equals(test, dates));
         assertEquals(adj, rules.getLeapSecondAdjustment(mjd));
     }
 

--- a/src/test/java/org/threeten/extra/scale/package-info.java
+++ b/src/test/java/org/threeten/extra/scale/package-info.java
@@ -29,41 +29,8 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+@NullMarked
 package org.threeten.extra.scale;
 
-/**
- * Mock rules that always returns a leap second.
- */
-public class MockUtcRulesAlwaysLeap extends UtcRules {
+import org.jspecify.annotations.NullMarked;
 
-    @Override
-    public String getName() {
-        return "Mock";
-    }
-
-    @Override
-    public int getLeapSecondAdjustment(long mjDay) {
-        return 1;  // always leap
-    }
-
-    @Override
-    public int getTaiOffset(long mjDay) {
-        return (int) mjDay;
-    }
-
-    @Override
-    public long[] getLeapSecondDates() {
-        return new long[0];
-    }
-
-    @Override
-    public TaiInstant convertToTai(UtcInstant utcInstant) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public UtcInstant convertToUtc(TaiInstant taiInstant) {
-        throw new UnsupportedOperationException();
-    }
-
-}


### PR DESCRIPTION
Follow #379 by updating the tests, which mostly involves eliminating warnings.

Also fix a few other older testing styles.

Fixes #170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened null-parameter test coverage by adding clarity for intentionally null inputs while keeping the same expected exceptions and outcomes.
  * Improved test assertion style by using boolean-specific assertions and more consistent equality checks.
  * Enhanced null-safety in parameterized test data by marking nullable values and using primitives where applicable.
  * Updated test-time mock UTC rules to fail fast with explicit unsupported operations.
  * Added package-level nullness annotations for test packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->