### PR TITLE
Add LocalDateRange.from(Temporal)

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -7,6 +7,13 @@
 
   <body>
     <!-- types are add, fix, remove, update -->
+    <release version="1.11.0" date="2026-06-16" description="v1.11.0">
+      <action dev="jodastephen" type="add" issue="371">
+        Add `LocalDateRange.from(Temporal)`.
+        Can be used to obtain the equivalent date range of most Temporal objects.
+        For example, `LocalDateRange.from(YearMonth.of(2024, 6))` will return the range 2024-06-01 to 2024-06-30 (inclusive).
+      </action>
+    </release>
     <release version="1.10.0" date="2026-06-16" description="v1.10.0">
       <action dev="jodastephen" type="add" issue="379">
         Add JSpecify nullness annotations.

--- a/src/main/java/org/threeten/extra/LocalDateRange.java
+++ b/src/main/java/org/threeten/extra/LocalDateRange.java
@@ -33,10 +33,15 @@ package org.threeten.extra;
 
 import java.io.Serializable;
 import java.time.DateTimeException;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalQueries;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -44,7 +49,6 @@ import java.util.Spliterators;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import org.joda.convert.FromString;
 import org.joda.convert.ToString;
 import org.jspecify.annotations.Nullable;
@@ -204,6 +208,50 @@ public final class LocalDateRange
     public static LocalDateRange ofEmpty(LocalDate date) {
         Objects.requireNonNull(date, "date");
         return new LocalDateRange(date, date);
+    }
+
+    /**
+     * Obtains a range of dates from a temporal object.
+     * <p>
+     * The temporal object must provide sufficient information to create a range, otherwise an exception will be thrown.
+     * <p>
+     * Most temporal objects are handled, including {@code LocalDate}, {@code YearMonth}, {@code Year},
+     * {@code YearHalf}, {@code YearQuarter} and {@code YearWeek}. Complete objects with a time amount will
+     * be converted to a date, ignoring the time component. For example, a {@code LocalDateTime}
+     * will be converted to a {@code LocalDate} and then used to create a one-day range.
+     * <p>
+     * Classes such as {@code MonthDay} and {@code Month} are not supported as they do not provide sufficient information.
+     *
+     * @param temporal  the temporal object to convert, not null
+     * @return the range, not null
+     * @throws DateTimeException if the temporal cannot be converted to a range
+     * @since 1.11.0
+     */
+    public static LocalDateRange from(Temporal temporal) {
+        Objects.requireNonNull(temporal, "temporal");
+        LocalDate date = temporal.query(TemporalQueries.localDate());
+        if (date != null) {
+            return ofClosed(date, date);
+        }
+        if (temporal instanceof Year) {
+            LocalDate start = ((Year) temporal).atDay(1);
+            return ofClosed(start, start.withMonth(12).withDayOfMonth(31));
+        } else if (temporal instanceof YearMonth) {
+            YearMonth ym = (YearMonth) temporal;
+            return ofClosed(ym.atDay(1), ym.atEndOfMonth());
+        } else if (temporal instanceof YearHalf) {
+            YearHalf yh = (YearHalf) temporal;
+            return ofClosed(yh.atDay(1), yh.atEndOfHalf());
+        } else if (temporal instanceof YearQuarter) {
+            YearQuarter yq = (YearQuarter) temporal;
+            return ofClosed(yq.atDay(1), yq.atEndOfQuarter());
+        } else if (temporal instanceof YearWeek) {
+            YearWeek yw = (YearWeek) temporal;
+            return ofClosed(yw.atDay(DayOfWeek.MONDAY), yw.atDay(DayOfWeek.SUNDAY));
+        } else {
+            // we could examine precision and try to extract based on fields, but it is pretty complex
+            throw new DateTimeException("Unknown Temporal type: " + temporal.getClass().getName());
+        }
     }
 
     /**

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -35,7 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.google.common.collect.Range;
+import com.google.common.testing.EqualsTester;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -43,21 +46,23 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.time.DateTimeException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import com.google.common.collect.Range;
-import com.google.common.testing.EqualsTester;
 
 /**
  * Test date range.
@@ -405,6 +410,36 @@ public class TestLocalDateRange {
     @Test
     public void test_ofEmpty_MAXM1() {
         assertThrows(DateTimeException.class, () -> LocalDateRange.ofEmpty(MAXM1));
+    }
+
+    //-----------------------------------------------------------------------
+    @ParameterizedTest
+    @MethodSource("data_from")
+    public void test_from(Temporal temporal, LocalDate startDate, LocalDate endDate) {
+        LocalDateRange test = LocalDateRange.from(temporal);
+        assertEquals(startDate, test.getStart());
+        assertEquals(endDate, test.getEndInclusive());
+    }
+
+    static Object[][] data_from() {
+        return new Object[][]{
+                {Year.of(2012), LocalDate.of(2012, 1, 1), LocalDate.of(2012, 12, 31)},
+                {Year.of(Year.MIN_VALUE), LocalDate.of(Year.MIN_VALUE, 1, 1), LocalDate.of(Year.MIN_VALUE, 12, 31)},
+                {Year.of(Year.MAX_VALUE), LocalDate.of(Year.MAX_VALUE, 1, 1), LocalDate.of(Year.MAX_VALUE, 12, 31)},
+                {YearMonth.of(2012, 2), LocalDate.of(2012, 2, 1), LocalDate.of(2012, 2, 29)},
+                {YearHalf.of(2012, Half.H1), LocalDate.of(2012, 1, 1), LocalDate.of(2012, 6, 30)},
+                {YearQuarter.of(2012, Quarter.Q1), LocalDate.of(2012, 1, 1), LocalDate.of(2012, 3, 31)},
+                {YearWeek.of(2012, 3), LocalDate.of(2012, 1, 16), LocalDate.of(2012, 1, 22)},
+                {LocalDateTime.of(2012, 7, 30, 12, 30), LocalDate.of(2012, 7, 30), LocalDate.of(2012, 7, 30)},
+                {OffsetDate.of(2012, 7, 30, ZoneOffset.UTC), LocalDate.of(2012, 7, 30), LocalDate.of(2012, 7, 30)},
+                {OffsetDateTime.of(2012, 7, 30, 12, 30, 0, 0, ZoneOffset.UTC), LocalDate.of(2012, 7, 30), LocalDate.of(2012, 7, 30)}
+        };
+    }
+
+    @Test
+    public void test_from_unknownType() {
+        assertThrows(DateTimeException.class, () -> LocalDateRange.from(LocalTime.NOON));
+        assertThrows(DateTimeException.class, () -> LocalDateRange.from(HourMinute.of(12, 30)));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
A new LocalDateRange method, allowing callers to obtain the equivalent date range of most Temporal objects

Fixes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `LocalDateRange.from(Temporal)` to build inclusive date ranges from `Temporal` inputs (including direct `LocalDate`-backed temporals, `Year`, `YearMonth`, `YearHalf`, `YearQuarter`, and `YearWeek`).
  * Unsupported `Temporal` types now throw a clear `DateTimeException` (e.g., `LocalTime`).
* **Documentation**
  * Updated release notes with a new entry for version 1.11.0 and examples (including `YearMonth` to start/end dates).
* **Tests**
  * Added parameterized tests validating computed boundaries and verifying errors for unsupported inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->