### PR TITLE
Add LocalDateRange.withEndInclusive(TemporalAdjuster)

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -13,6 +13,10 @@
         Can be used to obtain the equivalent date range of most Temporal objects.
         For example, `LocalDateRange.from(YearMonth.of(2024, 6))` will return the range 2024-06-01 to 2024-06-30 (inclusive).
       </action>
+      <action dev="jodastephen" type="add" issue="371">
+        Add `LocalDateRange.withEndInclusive(TemporalAdjuster)`.
+        Allows a range to be adjusted based on the inclusive end date.
+      </action>
     </release>
     <release version="1.10.0" date="2026-06-16" description="v1.10.0">
       <action dev="jodastephen" type="add" issue="379">

--- a/src/main/java/org/threeten/extra/LocalDateRange.java
+++ b/src/main/java/org/threeten/extra/LocalDateRange.java
@@ -142,6 +142,7 @@ public final class LocalDateRange
      * <p>
      * The range includes the start date and the end date.
      * The end date must be equal to or after the start date.
+     * Note that an empty range cannot be created with this method.
      * <p>
      * The constants {@code LocalDate.MIN} and {@code LocalDate.MAX} can be used
      * to indicate an unbounded far-past or far-future. In addition, an end date of
@@ -171,7 +172,7 @@ public final class LocalDateRange
      * Obtains an instance of {@code LocalDateRange} from the start and a period.
      * <p>
      * The end date is calculated as the start plus the duration.
-     * The period must not be negative.
+     * The period must not be negative, but may be zero.
      * <p>
      * The constant {@code LocalDate.MIN} can be used to indicate an unbounded far-past.
      * <p>
@@ -188,7 +189,7 @@ public final class LocalDateRange
         Objects.requireNonNull(startInclusive, "startInclusive");
         Objects.requireNonNull(period, "period");
         if (period.isNegative()) {
-            throw new DateTimeException("Period must not be zero or negative");
+            throw new DateTimeException("Period must not be negative");
         }
         return new LocalDateRange(startInclusive, startInclusive.plus(period));
     }
@@ -469,7 +470,7 @@ public final class LocalDateRange
     }
 
     /**
-     * Returns a copy of this range with the end date adjusted.
+     * Returns a copy of this range with the exclusive end date adjusted.
      * <p>
      * This returns a new instance with the exclusive end date altered.
      * Since {@code LocalDate} implements {@code TemporalAdjuster} any
@@ -481,11 +482,35 @@ public final class LocalDateRange
      * </pre>
      * 
      * @param adjuster  the adjuster to use, not null
-     * @return a copy of this range with the end date adjusted
+     * @return a copy of this range with the exclusive end date adjusted
      * @throws DateTimeException if the new end date is before the current start date
      */
     public LocalDateRange withEnd(TemporalAdjuster adjuster) {
         return LocalDateRange.of(start, end.with(adjuster));
+    }
+
+    /**
+     * Returns a copy of this range with the inclusive end date adjusted.
+     * <p>
+     * This returns a new instance with the inclusive end date altered.
+     * Since {@code LocalDate} implements {@code TemporalAdjuster} any
+     * local date can simply be passed in.
+     * <p>
+     * For example, to adjust the end to one week later:
+     * <pre>
+     *  range = range.withEndInclusive(date -&gt; date.plus(1, ChronoUnit.WEEKS));
+     * </pre>
+     * <p>
+     * It is not possible to create an empty range with this method,
+     * as the inclusive end date must always be on or after the start date.
+     *
+     * @param adjuster  the adjuster to use, not null
+     * @return a copy of this range with the inclusive end date adjusted
+     * @throws DateTimeException if the new inclusive end date is before the start date
+     * @since 1.11.0
+     */
+    public LocalDateRange withEndInclusive(TemporalAdjuster adjuster) {
+        return LocalDateRange.ofClosed(start, getEndInclusive().with(adjuster));
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/extra/TestLocalDateRange.java
+++ b/src/test/java/org/threeten/extra/TestLocalDateRange.java
@@ -251,6 +251,11 @@ public class TestLocalDateRange {
     }
 
     @Test
+    public void test_ofClosed_empty() {
+        assertThrows(DateTimeException.class, () -> LocalDateRange.ofClosed(DATE_2012_07_30, DATE_2012_07_29));
+    }
+
+    @Test
     public void test_ofClosed_MIN() {
         LocalDateRange test = LocalDateRange.ofClosed(LocalDate.MIN, DATE_2012_07_30);
         assertEquals(LocalDate.MIN, test.getStart());
@@ -699,6 +704,49 @@ public class TestLocalDateRange {
     public void test_withEnd_invalid() {
         LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
         assertThrows(DateTimeException.class, () -> base.withEnd(DATE_2012_07_27));
+    }
+
+    //-----------------------------------------------------------------------
+    @Test
+    public void test_withEndInclusive() {
+        LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
+        LocalDateRange test = base.withEndInclusive(DATE_2012_07_31);
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_31, test.getEndInclusive());
+        assertEquals(DATE_2012_08_01, test.getEnd());
+    }
+
+    @Test
+    public void test_withEndInclusive_adjuster() {
+        LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
+        LocalDateRange test = base.withEndInclusive(date -> {
+            assertEquals(DATE_2012_07_30, date);
+            return date.plus(1, ChronoUnit.WEEKS);
+        });
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(DATE_2012_07_30.plusWeeks(1), test.getEndInclusive());
+        assertEquals(DATE_2012_07_31.plusWeeks(1), test.getEnd());
+    }
+
+    @Test
+    public void test_withEndInclusive_max() {
+        LocalDateRange base = LocalDateRange.of(DATE_2012_07_28, DATE_2012_07_31);
+        LocalDateRange test = base.withEndInclusive(LocalDate.MAX);
+        assertEquals(DATE_2012_07_28, test.getStart());
+        assertEquals(LocalDate.MAX, test.getEndInclusive());
+        assertEquals(LocalDate.MAX, test.getEnd());
+    }
+
+    @Test
+    public void test_withEndInclusive_empty() {
+        LocalDateRange base = LocalDateRange.of(DATE_2012_07_30, DATE_2012_07_31);
+        assertThrows(DateTimeException.class, () -> base.withEndInclusive(DATE_2012_07_29));
+    }
+
+    @Test
+    public void test_withEndInclusive_invalid() {
+        LocalDateRange base = LocalDateRange.of(DATE_2012_07_29, DATE_2012_07_31);
+        assertThrows(DateTimeException.class, () -> base.withEndInclusive(DATE_2012_07_27));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Allows a range to be adjusted based on the inclusive end date.

Fixes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for adjusting a date range’s inclusive end date with a temporal adjuster.
- **Documentation**
  - Clarified date range behavior for empty ranges, zero-length periods, and exclusive versus inclusive end dates.
  - Updated validation messaging for invalid periods.
- **Bug Fixes**
  - Improved handling and validation of empty or invalid closed date ranges.
- **Tests**
  - Added coverage for inclusive-end adjustments, boundary dates, and invalid range scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->